### PR TITLE
ci: cleanup --no-default-features build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,22 +75,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        with:
-          # To fetch tags, but can this be improved using blobless checkout?
-          # [1]. But anyway right it is not important, and unlikely will be,
-          # since the repository is small.
-          #
-          #   [1]: https://github.blog/2020-12-21-get-up-to-speed-with-partial-clone-and-shallow-clone/
-          fetch-depth: 0
-
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
-
       - name: Build
         run: |
-          cargo build --no-default-features # should be the same as 'make'
-
+          cargo build --no-default-features
       - name: Check package
         run: |
           cargo run --no-default-features -- --help


### PR DESCRIPTION
- it does not requires tags (since we don't care about version there)
- and cargo build is not the same as make