### PR TITLE
Fix chrono::Utc for windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ humantime = { version = "*", default-features = false }
 backtrace = { version = "*", default-features = false, features = ["std"] }
 futures = { version = "*", default-features = false, features = ["std"] }
 # chrono/chrono-tz should match clickhouse-rs
-chrono = { version = "0.4", default-features = false }
+chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
 chrono-tz = { version = "0.8", default-features = false }
 flexi_logger = { version = "0.22", default-features = false }
 log = { version = "0.4", default-features = false }


### PR DESCRIPTION
Now it fails [1]:

    error[E0599]: no function or associated item named `now` found for struct `Utc` in the current scope
       --> src\view\processes_view.rs:341:37
        |
    341 |             .unwrap_or_else(|| Utc::now().with_timezone(&UTC));
        |                                     ^^^ function or associated item not found in `Utc`

  [1]: https://github.com/azat/chdig/actions/runs/7333205128/job/19968365371

P.S. I guess now I have to do everything via pull requests...