### PR TITLE
Support skip_verify in client config to skip strict TLS verification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ dist
 *.tar.*
 *.tar
 *.rpm
+# intellij
+.idea/

--- a/Documentation/FAQ.md
+++ b/Documentation/FAQ.md
@@ -13,6 +13,8 @@ Here is an example in `XML` format:
             <hostname>prod</hostname>
             <user>default</user>
             <password>secret</password>
+            <!-- <secure>false</secure> -->
+            <!-- <skip_verify>false</skip_verify> -->
         </connection>
     </connections_credentials>
 </clickhouse>


### PR DESCRIPTION
# Why

Many a times like in case of self-signed certificate and sometimes with letsencrypt certs, TLS verification fails with unknown issuer error. In those cases, it is useful to enable skip_verify.

Error message:

```
Error: Cannot connect to ClickHouse at tcp://default@<redacted>:9440 (Connections error: `Input/output error: `invalid peer certificate: UnknownIssuer``)
```