### PR TITLE
Compatibility with older ClickHouse servers (tested on 21.2)

### DIFF
--- a/src/interpreter/clickhouse_quirks.rs
+++ b/src/interpreter/clickhouse_quirks.rs
@@ -3,9 +3,10 @@ use semver::{Version, VersionReq};
 #[derive(Debug, Clone, Copy)]
 pub enum ClickHouseAvailableQuirks {
     ProcessesElapsed = 1,
+    ProcessesCurrentDatabase = 2,
 }
 
-const QUIRKS: [(&str, ClickHouseAvailableQuirks); 1] = [
+const QUIRKS: [(&str, ClickHouseAvailableQuirks); 2] = [
     // https://github.com/ClickHouse/ClickHouse/pull/46047
     //
     // NOTE: I use here 22.13 because I have such version in production, which is more or less the
@@ -14,6 +15,8 @@ const QUIRKS: [(&str, ClickHouseAvailableQuirks); 1] = [
         ">=22.13, <23.2",
         ClickHouseAvailableQuirks::ProcessesElapsed,
     ),
+    // https://github.com/ClickHouse/ClickHouse/pull/22365
+    ("<21.4", ClickHouseAvailableQuirks::ProcessesCurrentDatabase),
 ];
 
 pub struct ClickHouseQuirks {

--- a/src/interpreter/worker.rs
+++ b/src/interpreter/worker.rs
@@ -227,14 +227,10 @@ async fn render_flamegraph(tui: bool, cb_sink: cursive::CbSink, block: Columns) 
 async fn process_event(context: ContextArc, event: Event, need_clear: &mut bool) -> Result<()> {
     let cb_sink = context.lock().unwrap().cb_sink.clone();
     let clickhouse = context.lock().unwrap().clickhouse.clone();
-    let options = context.lock().unwrap().options.clone();
-    let no_subqueries = options.view.no_subqueries;
 
     match event {
         Event::UpdateProcessList(filter, limit) => {
-            let block = clickhouse
-                .get_processlist(!no_subqueries, filter, limit)
-                .await?;
+            let block = clickhouse.get_processlist(filter, limit).await?;
             cb_sink
                 .send(Box::new(move |siv: &mut cursive::Cursive| {
                     siv.call_on_name_or_render_error(
@@ -248,7 +244,7 @@ async fn process_event(context: ContextArc, event: Event, need_clear: &mut bool)
         }
         Event::UpdateSlowQueryLog(filter, start, end, limit) => {
             let block = clickhouse
-                .get_slow_query_log(!no_subqueries, &filter, start, end, limit)
+                .get_slow_query_log(&filter, start, end, limit)
                 .await?;
             cb_sink
                 .send(Box::new(move |siv: &mut cursive::Cursive| {
@@ -263,7 +259,7 @@ async fn process_event(context: ContextArc, event: Event, need_clear: &mut bool)
         }
         Event::UpdateLastQueryLog(filter, start, end, limit) => {
             let block = clickhouse
-                .get_last_query_log(!no_subqueries, &filter, start, end, limit)
+                .get_last_query_log(&filter, start, end, limit)
                 .await?;
             cb_sink
                 .send(Box::new(move |siv: &mut cursive::Cursive| {


### PR DESCRIPTION
### Changes
- Avoid using WINDOW functions for backward compatibilty with older ClickHouse
- Use {Settings,ProfileEvents}.{Names,Values} and mapFromArrays() in Rust
- Do not use PSQL CAST operator (::) for backward compatibility
- Add workaround for <21.4 (lack of current_database in system.processlist)

Fixes: #33 