### PR TITLE
fix filter for query "last query log"

### DIFF
--- a/src/interpreter/clickhouse.rs
+++ b/src/interpreter/clickhouse.rs
@@ -262,6 +262,7 @@ impl ClickHouse {
                                 event_date BETWEEN toDate(start_) AND toDate(end_) AND
                                 event_time BETWEEN toDateTime(start_) AND toDateTime(end_) AND
                                 type != 'QueryStart'
+                                {filter}
                             ORDER BY event_date DESC, event_time DESC
                             LIMIT {limit}
                         )


### PR DESCRIPTION
Hello!

Because the last_queries_ids query does not use "filter" and has a limit (as far as I understand for "last query log" it will be 100), the conditions "initial_query_id GLOBAL IN last_queries_ids" and "filter" may not overlap in the main query.

Example:

`CREATE DATABASE test;`
`CREATE TABLE test.kek (
    `id` UInt8,
    `str` String
)
ENGINE = MergeTree
ORDER BY id
;`
`INSERT INTO test.kek VALUES (1, 'FOO');` - execute 99 times

After these operations it will be difficult to find by query_id the database creation in the "Last queries" view.

If I'm wrong, can you please correct me?

Thank you very much!