### PR TITLE
Fix "flexi_logger has to work with UTC rather than with local time, caused by IndeterminateOffset"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -603,14 +603,13 @@ dependencies = [
 [[package]]
 name = "cursive-flexi-logger-view"
 version = "0.5.0"
-source = "git+https://github.com/azat-rust/cursive-flexi-logger-view?branch=next#422c186af1a407661728ce85cc19d64a93051d1f"
+source = "git+https://github.com/azat-rust/cursive-flexi-logger-view?branch=next#8fdfab688a471c3789bf619d7ab6e3d36ae54bea"
 dependencies = [
  "arraydeque",
  "cursive_core",
  "flexi_logger",
  "lazy_static",
  "log",
- "time 0.3.9",
  "unicode-width",
 ]
 
@@ -932,19 +931,18 @@ dependencies = [
 
 [[package]]
 name = "flexi_logger"
-version = "0.22.6"
+version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c76a80dd14a27fc3d8bc696502132cb52b3f227256fd8601166c3a35e45f409"
+checksum = "2ac35b454b60e1836602173e2eb7ef531173388c0212e02ec7f9fac086159ee5"
 dependencies = [
- "ansi_term",
- "atty",
+ "chrono",
  "glob",
+ "is-terminal",
  "lazy_static",
  "log",
+ "nu-ansi-term",
  "regex",
- "rustversion",
  "thiserror",
- "time 0.3.9",
 ]
 
 [[package]]
@@ -1288,6 +1286,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa799dd5ed20a7e349f3b4639aa80d74549c81716d9ec4f994c9b5815598306"
 
 [[package]]
+name = "is-terminal"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bad00257d07be169d870ab665980b06cdb366d792ad690bf2e76876dc503455"
+dependencies = [
+ "hermit-abi 0.3.3",
+ "rustix",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1490,6 +1499,15 @@ dependencies = [
  "cfg-if",
  "libc",
  "memoffset",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.49.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c073d3c1930d0751774acf49e66653acecb416c3a54c6ec095a9b11caddb5a68"
+dependencies = [
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2687,7 +2705,7 @@ dependencies = [
  "libc",
  "standback",
  "stdweb",
- "time-macros 0.1.1",
+ "time-macros",
  "version_check",
  "winapi",
 ]
@@ -2701,7 +2719,6 @@ dependencies = [
  "itoa",
  "libc",
  "num_threads",
- "time-macros 0.2.4",
 ]
 
 [[package]]
@@ -2713,12 +2730,6 @@ dependencies = [
  "proc-macro-hack",
  "time-macros-impl",
 ]
-
-[[package]]
-name = "time-macros"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42657b1a6f4d817cda8e7a0ace261fe0cc946cf3a80314390b22cc61ae080792"
 
 [[package]]
 name = "time-macros-impl"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ futures = { version = "*", default-features = false, features = ["std"] }
 # chrono/chrono-tz should match clickhouse-rs
 chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
 chrono-tz = { version = "0.8", default-features = false }
-flexi_logger = { version = "0.22", default-features = false }
+flexi_logger = { version = "0.27", default-features = false }
 log = { version = "0.4", default-features = false }
 futures-util = { version = "*", default-features = false }
 semver = { version = "*", default-features = false }

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,11 +54,9 @@ async fn main() -> Result<()> {
     //
     // NOTE: hyper also has trace_span() which will not be overwritten
     //
-    // FIXME: "flexi_logger has to work with UTC rather than with local time, caused by IndeterminateOffset"
-    //
     // FIXME: should be initialize before options, but options prints completion that should be
     // done before terminal switched to raw mode.
-    let mut logger = Logger::try_with_env_or_str(
+    let logger = Logger::try_with_env_or_str(
         "trace,cursive=info,clickhouse_rs=info,skim=info,tuikit=info,hyper=info",
     )?
     .log_to_writer(cursive_flexi_logger_view::cursive_flexi_logger(&siv))


### PR DESCRIPTION
Since 0.24 flexi_logger does not use time crate anymore (it uses chrono instead), and this warning will go away.

So let's simply update flexi_logger to 0.27

Fixes: https://github.com/azat/chdig/issues/38