### PR TITLE
Get back Esc binding

### DIFF
--- a/Documentation/FAQ.md
+++ b/Documentation/FAQ.md
@@ -40,7 +40,7 @@ highly not recommended), you can use `chdig --connection prod`.
 
 ### What are the shortcuts supported?
 
-| Category        | Shortcut       | Description                                   |
+| Category        | Shortcut      | Description                                   |
 |-----------------|---------------|-----------------------------------------------|
 | Global Shortcuts| **F1**        | Show help                                     |
 |                 | **F2**        | Views                                         |

--- a/Documentation/FAQ.md
+++ b/Documentation/FAQ.md
@@ -50,6 +50,7 @@ highly not recommended), you can use `chdig --connection prod`.
 |                 |               | CPU Server Flamegraph in speedscope           |
 |                 | **~**         | chdig debug console                           |
 |                 | **q**         | Back/Quit                                     |
+|                 | **Esc**       | Back/Quit                                     |
 |                 | **Q**         | Quit forcefully                               |
 |                 | **Backspace** | Back                                          |
 |                 | **p**         | Toggle pause                                  |

--- a/src/view/navigation.rs
+++ b/src/view/navigation.rs
@@ -294,7 +294,7 @@ impl Navigation for Cursive {
             '~',
             toggle_flexi_logger_debug_console,
         );
-        // NOTE: Do not bind to Esc, since this breaks other bindings (Home/End/...)
+        context.add_global_action(self, "Back/Quit", Key::Esc, |siv| siv.pop_ui(true));
         context.add_global_action(self, "Back/Quit", 'q', |siv| siv.pop_ui(true));
         context.add_global_action(self, "Quit forcefully", 'Q', |siv| siv.quit());
         context.add_global_action(self, "Back", Key::Backspace, |siv| siv.pop_ui(false));


### PR DESCRIPTION
Apparently after switching to termion (from default ncurses) backend it
fully functional, or maybe that was a different terminal... For now I
checked alacritty and konsole and both are OK.

Refs: https://github.com/azat/chdig/issues/50