### PR TITLE
Add show query action (shortcut - 'S')

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ mod utils;
 pub use utils::edit_query;
 #[cfg(not(target_family = "windows"))]
 pub use utils::fuzzy_actions;
+pub use utils::get_query;
 pub use utils::highlight_sql;
 pub use utils::open_graph_in_browser;
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -75,7 +75,7 @@ pub fn get_query(query: &String, settings: &HashMap<String, String>) -> String {
         .map(|kv| format!("\t{}='{}'\n", kv.0, kv.1.replace('\'', "\\\'")))
         .collect::<Vec<String>>()
         .join(",");
-    if query.contains("SETTINGS") {
+    if !query.contains("SETTINGS") {
         ret.push_str("\nSETTINGS\n");
     } else {
         ret.push_str(",\n");

--- a/src/view/processes_view.rs
+++ b/src/view/processes_view.rs
@@ -448,7 +448,7 @@ impl ProcessesView {
 
         let is_system_processes = matches!(processes_type, Type::ProcessList);
         let filter = Arc::new(Mutex::new(String::new()));
-        let limit = Arc::new(Mutex::new(if matches!(processes_type, Type::ProcessList) {
+        let limit = Arc::new(Mutex::new(if is_system_processes {
             10000
         } else {
             100_u64

--- a/src/view/processes_view.rs
+++ b/src/view/processes_view.rs
@@ -22,7 +22,7 @@ use crate::interpreter::{
 };
 use crate::view::{ExtTableView, ProcessView, QueryResultView, TableViewItem, TextLogView};
 use crate::wrap_impl_no_move;
-use chdig::edit_query;
+use chdig::{edit_query, get_query};
 
 // Analog of mapFromArrays() in ClickHouse
 fn map_from_arrays<K, V>(keys: Vec<K>, values: Vec<V>) -> HashMap<K, V>
@@ -837,6 +837,32 @@ impl ProcessesView {
                 )))));
             },
         );
+        context.add_view_action(&mut event_view, "Show query", 'S', |v| {
+            let v = v.downcast_mut::<ProcessesView>().unwrap();
+            let selected_query = v.get_selected_query()?;
+            let query = selected_query.original_query.clone();
+            let database = selected_query.current_database.clone();
+            let settings = selected_query.settings.clone();
+
+            let query = get_query(&query, &settings);
+            let query = format!("USE {};\n{}", database, query);
+
+            v.context
+                .lock()
+                .unwrap()
+                .cb_sink
+                .send(Box::new(move |siv: &mut cursive::Cursive| {
+                    siv.add_layer(views::Dialog::around(
+                        views::LinearLayout::vertical()
+                            .child(views::TextView::new("Query:").center())
+                            .child(views::DummyView.fixed_height(1))
+                            .child(views::TextView::new(query)),
+                    ));
+                }))
+                .unwrap();
+
+            return Ok(Some(EventResult::consumed()));
+        });
         context.add_view_action(&mut event_view, "EXPLAIN SYNTAX", 's', |v| {
             let v = v.downcast_mut::<ProcessesView>().unwrap();
             let selected_query = v.get_selected_query()?;


### PR DESCRIPTION
Useful when you don't have editor installed, since EXPLAIN SYNTAX expand
some part of the queries, and sometimes the different is significant,
i.e. (see [1] for expanded result, it is too big to post it here, since
it expand all the columns lists at least):

    explain syntax select * from system.parts p left join system.tables t on (p.database = t.database and p.table = t.name) left join system.databases d on (t.database = d.name);

  [1]: https://fiddle.clickhouse.com/bcfa3c50-051e-4c7c-abc3-f4a022418b24

Fixes: https://github.com/azat/chdig/issues/56