### PR TITLE
Fix slow/last queries view (disable analyzer as a workaround for now)

### DIFF
--- a/src/interpreter/clickhouse.rs
+++ b/src/interpreter/clickhouse.rs
@@ -140,6 +140,11 @@ impl ClickHouse {
                 1000,
                 /* is_important= */ false,
             )
+            // FIXME: ClickHouse's analyzer does not handle ProfileEvents.Names (and similar), it throws:
+            //
+            //   Invalid column type for ColumnUnique::insertRangeFrom. Expected String, got LowCardinality(String)
+            //
+            .with_setting("allow_experimental_analyzer", false, true)
             // TODO: add support of Map type for LowCardinality in the driver
             .with_setting("low_cardinality_allow_in_native_format", false, true);
         let pool = Pool::new(connect_options);


### PR DESCRIPTION
The problem:

    azat.local$ select ProfileEvents.Names from system.query_log

    SELECT ProfileEvents.Names
    FROM system.query_log

    Query id: 6036f039-3b9b-4cd3-a853-b6d5d24bf92b

    Elapsed: 0.006 sec.

    Received exception from server (version 24.10.1):
    Code: 44. DB::Exception: Received from localhost:9000. DB::Exception: Invalid column type for ColumnUnique::insertRangeFrom. Expected String, got LowCardinality(String). (ILLEGAL_COLUMN)

Will be fixed separately.