### PR TITLE
Store binaries uncompressed in artifacts (more convenient)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -142,7 +142,6 @@ jobs:
         set -x
         make deploy-binary
         cp target/chdig chdig-macos-x86_64
-        gzip --keep chdig-macos-x86_64
 
     - name: Check package
       run: |
@@ -154,7 +153,7 @@ jobs:
       with:
         name: macos-packages-x86_64
         path: |
-          chdig-macos-x86_64.gz
+          chdig-macos-x86_64
 
   build-macos-arm64:
     name: Build MacOS (arm64)
@@ -190,7 +189,6 @@ jobs:
         set -x
         make deploy-binary
         cp target/chdig chdig-macos-arm64
-        gzip --keep chdig-macos-arm64
 
     - name: Check package
       run: |
@@ -202,7 +200,7 @@ jobs:
       with:
         name: macos-packages-arm64
         path: |
-          chdig-macos-arm64.gz
+          chdig-macos-arm64
 
   build-windows:
     name: Build Windows
@@ -231,15 +229,14 @@ jobs:
     - name: Build
       run: |
         make deploy-binary
-        cp target/chdig.exe chdig-windows.exe
-        Compress-Archive -Path chdig-windows.exe -DestinationPath chdig-windows-x86_64.exe.zip
+        cp target/chdig.exe chdig-windows-x86_64.exe
 
     - name: Archive Packages
       uses: actions/upload-artifact@v4
       with:
         name: windows-packages-x86_64
         path: |
-          chdig-windows-x86_64.exe.zip
+          chdig-windows-x86_64.exe
 
   build-linux-aarch64:
     name: Build Linux (aarch64)

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ There are pre-built packages for the latest available version:
 - [fedora](https://github.com/azat/chdig/releases/download/latest/chdig-latest.x86_64.rpm)
 - [archlinux](https://github.com/azat/chdig/releases/download/latest/chdig-latest-x86_64.pkg.tar.zst)
 - [tar.gz](https://github.com/azat/chdig/releases/download/latest/chdig-latest-x86_64.tar.gz)
-- [macos x86_64](https://github.com/azat/chdig/releases/download/latest/chdig-macos-x86_64.gz)
-- [macos arm64](https://github.com/azat/chdig/releases/download/latest/chdig-macos-arm64.gz)
-- [windows](https://github.com/azat/chdig/releases/download/latest/chdig-windows.exe.zip)
+- [macos x86_64](https://github.com/azat/chdig/releases/download/latest/chdig-macos-x86_64)
+- [macos arm64](https://github.com/azat/chdig/releases/download/latest/chdig-macos-arm64)
+- [windows](https://github.com/azat/chdig/releases/download/latest/chdig-windows.exe)
 
 <details>
 

--- a/README.md
+++ b/README.md
@@ -6,11 +6,15 @@ Dig into [ClickHouse](https://github.com/ClickHouse/ClickHouse/) with TUI interf
 
 There are pre-built packages for the latest available version:
 
-- [chdig standalone binary](https://github.com/azat/chdig/releases/download/latest/chdig)
 - [debian](https://github.com/azat/chdig/releases/download/latest/chdig-latest_amd64.deb)
 - [fedora](https://github.com/azat/chdig/releases/download/latest/chdig-latest.x86_64.rpm)
 - [archlinux](https://github.com/azat/chdig/releases/download/latest/chdig-latest-x86_64.pkg.tar.zst)
 - [tar.gz](https://github.com/azat/chdig/releases/download/latest/chdig-latest-x86_64.tar.gz)
+
+### Standalone binaries
+
+- [linux amd64](https://github.com/azat/chdig/releases/download/latest/chdig-amd64)
+- [linux aarch64](https://github.com/azat/chdig/releases/download/latest/chdig-aarch64)
 - [macos x86_64](https://github.com/azat/chdig/releases/download/latest/chdig-macos-x86_64)
 - [macos arm64](https://github.com/azat/chdig/releases/download/latest/chdig-macos-arm64)
 - [windows](https://github.com/azat/chdig/releases/download/latest/chdig-windows.exe)


### PR DESCRIPTION
And after PyOxidizer (#75) has been removed, it is only ~20MiB instead of ~105MiB, so this should be OK.