### PR TITLE
Add support for authentication via mTLS (authentication with TLS certificates)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -385,7 +385,7 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 [[package]]
 name = "clickhouse-rs"
 version = "1.1.0-alpha.1"
-source = "git+https://github.com/azat-rust/clickhouse-rs?branch=next#437c4afa857ca80b0392e08376ea33de4a1bad0e"
+source = "git+https://github.com/azat-rust/clickhouse-rs?branch=mTLS#f88e93e0d0b16591298bffd623510290b1c0782b"
 dependencies = [
  "byteorder",
  "cfg-if",
@@ -417,7 +417,7 @@ dependencies = [
 [[package]]
 name = "clickhouse-rs-cityhash-sys"
 version = "0.1.2"
-source = "git+https://github.com/azat-rust/clickhouse-rs?branch=next#437c4afa857ca80b0392e08376ea33de4a1bad0e"
+source = "git+https://github.com/azat-rust/clickhouse-rs?branch=mTLS#f88e93e0d0b16591298bffd623510290b1c0782b"
 dependencies = [
  "cc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ syntect = { version = "*", default-features = false, features = ["default-syntax
 # Patches:
 # - rustls
 # - no panic on broken protocol
-clickhouse-rs = { git = "https://github.com/azat-rust/clickhouse-rs", branch = "next", default-features = false, features = ["tokio_io"] }
+clickhouse-rs = { git = "https://github.com/azat-rust/clickhouse-rs", branch = "mTLS", default-features = false, features = ["tokio_io"] }
 tokio = { version = "*", default-features = false, features = ["macros"] }
 # Flamegraphs
 flamelens = { version = "0.3.1", default-features = false }


### PR DESCRIPTION
mTLS (Mutual TLS, or mTLS for short, is a method for mutual authentication) allows you to authenticate on the server with client certificate.

Now `chdig` supports it, for this you need to pass the following arguments for connection url:
- `ca_certificate`
- `certificate_file`
- `private_key_file`

I.e. `tcp://azat-tls@localhost:9440?secure=true&ca_certificate=ca.pem&certificate_file=client.crt&private_key_file=client.key`

Note, that this is a **rought draft** for now, since mTLS support in clickhouse-rs should be stabilized for this, this should be done until next chdig release.

Refs: https://github.com/azat/chdig/issues/85 (since this is draft only `Refs` over `Fixes`)
Refs: **https://github.com/azat-rust/clickhouse-rs/pull/3** (all implementation is here)