### PR TITLE
Add ability to disable any flag

### DIFF
--- a/src/interpreter/options.rs
+++ b/src/interpreter/options.rs
@@ -168,9 +168,13 @@ pub struct ClickHouseOptions {
     /// Aggregate system.*_log historical data, using merge()
     #[arg(long, action = ArgAction::SetTrue)]
     pub history: bool,
+    #[arg(long, action = ArgAction::SetTrue, overrides_with = "history")]
+    pub no_history: bool,
     /// Do not hide internal (spawned by chdig) queries
     #[arg(long, action = ArgAction::SetTrue)]
     pub internal_queries: bool,
+    #[arg(long, action = ArgAction::SetTrue, overrides_with = "internal_queries")]
+    pub no_internal_queries: bool,
 }
 
 pub fn parse_datetime_or_date(value: &str) -> Result<DateTime<Local>, String> {


### PR DESCRIPTION
This will allow to override options in case of chdig has been called from some other binary with some predefined options.

And yes, the following will work:

    cargo run -- -d 30000 --history                        last-queries # history
    cargo run -- -d 30000 --history --no-history           last-queries # no history
    cargo run -- -d 30000 --history --no-history --history last-queries # history