### PR TITLE
Update tuikit to include lotabout/tuikit#51

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2755,8 +2755,7 @@ dependencies = [
 [[package]]
 name = "tuikit"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e19c6ab038babee3d50c8c12ff8b910bdb2196f62278776422f50390d8e53d8"
+source = "git+https://github.com/ClickHouse/tuikit.git?rev=e1994c0e03ff02c49cf1471f0cc3cbf185ce0104#e1994c0e03ff02c49cf1471f0cc3cbf185ce0104"
 dependencies = [
  "bitflags 1.3.2",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,8 @@ cursive = { version = "*", default-features = false, features = ["crossterm-back
 [patch.crates-io]
 cursive = { git = "https://github.com/azat-rust/cursive", branch = "next" }
 cursive_core = { git = "https://github.com/azat-rust/cursive", branch = "next" }
+# Ref: https://github.com/lotabout/tuikit/pull/51
+tuikit = { git = "https://github.com/ClickHouse/tuikit.git", rev = "e1994c0e03ff02c49cf1471f0cc3cbf185ce0104" }
 
 [dependencies]
 # Basic


### PR DESCRIPTION
And this is also required for bundling chdig as part of ClickHouse [1]

  [1]: https://github.com/ClickHouse/ClickHouse/pull/79666