### PR TITLE
Show 'source' instead of 'origin' for dictionaries

### DIFF
--- a/src/view/navigation.rs
+++ b/src/view/navigation.rs
@@ -1006,7 +1006,7 @@ impl Navigation for Cursive {
         let mut columns = vec![
             "name",
             "status::String status",
-            "origin",
+            "source",
             "bytes_allocated memory",
             "query_count queries",
             "found_rate",
@@ -1014,6 +1014,7 @@ impl Navigation for Cursive {
             "last_successful_update_time last_update",
             "loading_duration",
             "last_exception",
+            "origin",
         ];
 
         self.show_query_result_view(


### PR DESCRIPTION
- The 'origin' field shows dictionaries UUIDs where the 'source' field shows the actual sources used for loading

TBH the format of text in the 'source' field is quite random, we could try to parse it, and, for example, remove 'ClickHouse: ' because it takes too much space. 

[![asciicast](https://asciinema.org/a/ZNKYVYVShTyvFqvpIRgsUvoep.svg)](https://asciinema.org/a/ZNKYVYVShTyvFqvpIRgsUvoep)