### PR TITLE
Do not query 'index_granularity_bytes_in_memory' on old versions

### DIFF
--- a/src/interpreter/clickhouse_quirks.rs
+++ b/src/interpreter/clickhouse_quirks.rs
@@ -20,7 +20,7 @@ const QUIRKS: [(&str, ClickHouseAvailableQuirks); 3] = [
     ("<21.4", ClickHouseAvailableQuirks::ProcessesCurrentDatabase),
     // https://github.com/ClickHouse/ClickHouse/pull/80861
     (
-        "<25.6",
+        ">=24.11, <25.6",
         ClickHouseAvailableQuirks::AsynchronousMetricsTotalIndexGranularityBytesInMemoryAllocated,
     ),
 ];


### PR DESCRIPTION
The recent version of chdig returns the following error on 24.10:
```
Code: 47. DB::Exception: Missing columns: 'index_granularity_bytes_in_memory_allocated' while processing query: 'SELECT sum(index_granularity_bytes_in_memory_allocated) FROM system.parts', required columns: 'index_granularity_bytes_in_memory_allocated', maybe you meant: 'primary_key_bytes_in_memory_allocated': While processing (SELECT sum(index_granularity_bytes_in_memory_allocated) FROM system.parts) AS memory_index_granularity_. (UNKNOWN_IDENTIFIER) (version 24.10.1.2812 (official build))
```
