### PR TITLE
Support password with special chars and CLICKHOUSE_HOST env support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,6 +284,7 @@ dependencies = [
  "futures-util",
  "humantime",
  "log",
+ "percent-encoding",
  "pretty_assertions",
  "quick-xml 0.38.0",
  "ratatui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ serde = { version = "*", features = ["derive"] }
 serde_yaml = { version = "*", default-features = false }
 quick-xml = { version = "*", features = ["serialize"] }
 urlencoding = { version = "*", default-features = false }
+percent-encoding = { version = "*", default-features = false }
 warp = { version = "*", default-features = false }
 # CLI
 clap = { version = "*", default-features = false, features = ["derive", "env", "help", "usage", "std", "color", "error-context", "suggestions"] }


### PR DESCRIPTION
The password was not being URL-encoded before being added to the connection string. This caused issues when the password contained special characters that have a reserved meaning in URLs. This change uses the `percent_encoding` crate to encode the password, ensuring that all special characters are correctly handled."