### PR TITLE
Use system.trace_log.symbols if it is not empty

### DIFF
--- a/src/interpreter/clickhouse.rs
+++ b/src/interpreter/clickhouse.rs
@@ -840,10 +840,13 @@ impl ClickHouse {
                 {} AS start_time_,
                 {} AS end_time_
             SELECT
-              arrayStringConcat(arrayMap(
-                addr -> demangle(addressToSymbol(addr)),
-                arrayReverse(trace)
-              ), ';') AS human_trace,
+              if(empty(symbols),
+                 arrayStringConcat(arrayMap(
+                   addr -> demangle(addressToSymbol(addr)),
+                   arrayReverse(trace)
+                 ), ';'),
+                 arrayStringConcat(symbols, ';')
+              ) AS human_trace,
               {} weight
             FROM {}
             WHERE


### PR DESCRIPTION
Fixes: https://github.com/azat/chdig/issues/105