### PR TITLE
ci: use fresh MacOS images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,7 +115,7 @@ jobs:
 
   build-macos-x86_64:
     name: Build MacOS (x86_64)
-    runs-on: macos-13
+    runs-on: macos-15-intel
 
     steps:
     - uses: actions/checkout@v3
@@ -161,7 +161,7 @@ jobs:
 
   build-macos-arm64:
     name: Build MacOS (arm64)
-    runs-on: macos-14
+    runs-on: macos-26
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Since macos-13 is deprecated and does not work anymore [1]:

    This is a scheduled macos-13 brownout. The macOS-13 based runner images are being deprecated. For more details, see https://github.com/actions/runner-images/issues/13046.

  [1]: https://github.com/azat/chdig/actions/runs/19278314863/job/55123418234

List of available images: https://docs.github.com/en/actions/reference/runners/github-hosted-runners