### PR TITLE
Add pre-build packages for aarch64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
     - name: Install dependencies
       run: |
         # nfpm
-        curl -sS -Lo /tmp/nfpm.deb "https://github.com/goreleaser/nfpm/releases/download/v2.25.0/nfpm_amd64.deb"
+        curl -sS -Lo /tmp/nfpm.deb "https://github.com/goreleaser/nfpm/releases/download/v2.43.4/nfpm_2.43.4_amd64.deb"
         sudo dpkg -i /tmp/nfpm.deb
         # for building cityhash for clickhouse-rs
         sudo apt-get install -y musl-tools
@@ -68,6 +68,7 @@ jobs:
       run: |
         set -x
         make packages target=x86_64-unknown-linux-musl
+        ls -l
         declare -A mapping
         mapping[chdig*.x86_64.rpm]=chdig-latest.x86_64.rpm
         mapping[chdig*-x86_64.pkg.tar.zst]=chdig-latest-x86_64.pkg.tar.zst
@@ -243,7 +244,7 @@ jobs:
 
   build-linux-aarch64:
     name: Build Linux (aarch64)
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-22.04-arm
 
     steps:
     - uses: actions/checkout@v3
@@ -267,21 +268,40 @@ jobs:
 
     - name: Install dependencies
       run: |
-        curl -sS -Lo /tmp/nfpm.deb "https://github.com/goreleaser/nfpm/releases/download/v2.25.0/nfpm_amd64.deb" && sudo dpkg -i /tmp/nfpm.deb
-        cc --version
-        gcc_version=$(readlink -f $(which cc) | awk -F- '{print $NF}')
-        sudo apt-get install -y libc6-dev-arm64-cross libstdc++-$gcc_version-dev-arm64-cross
+        # nfpm
+        curl -sS -Lo /tmp/nfpm.deb "https://github.com/goreleaser/nfpm/releases/download/v2.43.4/nfpm_2.43.4_arm64.deb"
+        sudo dpkg -i /tmp/nfpm.deb
+        # for building cityhash for clickhouse-rs
+        sudo apt-get install -y musl-tools
+        # gcc cannot do cross compile, and there is no musl-g++ in musl-tools
+        sudo ln -srf /usr/bin/clang /usr/bin/musl-g++
+        # "Compiler family detection failed due to error: ToolNotFound: failed to find tool "aarch64-linux-musl-g++": No such file or directory"
+        sudo ln -srf /usr/bin/clang /usr/bin/aarch64-linux-musl-g++
+        # musl for static binaries
         rustup target add aarch64-unknown-linux-musl
+
+    - name: Run tests
+      run: make test
 
     - name: Build
       run: |
         set -x
-        # NOTE: for non-native target we cannot build packages, since they
-        # requires bash_completion, which requires chdig execution
-        #
-        # But we can try cross (that uses qemu for this).
-        make deploy-binary target=aarch64-unknown-linux-musl
-        cp target/chdig chdig-aarch64
+        make packages target=aarch64-unknown-linux-musl
+        ls -l
+        declare -A mapping
+        mapping[chdig*.aarch64.rpm]=chdig-latest.aarch64.rpm
+        mapping[chdig*-aarch64.pkg.tar.zst]=chdig-latest-aarch64.pkg.tar.zst
+        mapping[chdig*-aarch64.tar.gz]=chdig-latest-aarch64.tar.gz
+        mapping[chdig*_arm64.deb]=chdig-latest_arm64.deb
+        mapping[target/chdig]=chdig-aarch64
+        for pattern in "${!mapping[@]}"; do
+            cp $pattern ${mapping[$pattern]}
+        done
+
+    - name: Check package
+      run: |
+        sudo dpkg -i chdig-latest_arm64.deb
+        chdig --help
 
     - name: Archive Packages
       uses: actions/upload-artifact@v4
@@ -289,3 +309,6 @@ jobs:
         name: linux-packages-aarch64
         path: |
           chdig-aarch64
+          *.deb
+          *.rpm
+          *.tar.*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,8 @@ jobs:
 
         VERSION="${GITHUB_REF##*/}"
         VERSION="${VERSION#v}"
-        SHA256=$(sha256sum linux-packages-amd64/chdig-$VERSION-1-x86_64.pkg.tar.zst | cut -d' ' -f1)
+        SHA256_x86_64=$(sha256sum linux-packages-amd64/chdig-$VERSION-1-x86_64.pkg.tar.zst | cut -d' ' -f1)
+        SHA256_aarch64=$(sha256sum linux-packages-aarch64/chdig-$VERSION-1-aarch64.pkg.tar.zst | cut -d' ' -f1)
 
         cat > PKGBUILD <<EOL
         # shellcheck disable=SC2034,SC2154
@@ -54,20 +55,18 @@ jobs:
         pkgver=$VERSION
         pkgrel=1
         pkgdesc="Dig into ClickHouse with TUI interface (binaries for latest stable version)"
-        arch=('x86_64')
+        arch=('x86_64' 'aarch64')
         conflicts=("chdig")
         provides=("chdig")
         url="https://github.com/azat/chdig"
         license=('MIT')
-        source=(
-            "https://github.com/azat/chdig/releases/download/v\$pkgver/chdig-\$pkgver-1-x86_64.pkg.tar.zst"
-        )
-        sha256sums=(
-            '$SHA256'
-        )
+        source_x86_64=("https://github.com/azat/chdig/releases/download/v\$pkgver/chdig-\$pkgver-1-x86_64.pkg.tar.zst")
+        source_aarch64=("https://github.com/azat/chdig/releases/download/v\$pkgver/chdig-\$pkgver-1-aarch64.pkg.tar.zst")
+        sha256sums_x86_64=('$SHA256_x86_64')
+        sha256sums_aarch64=('$SHA256_aarch64')
 
         package() {
-            tar -C "\$pkgdir" -xvf chdig-\$pkgver-1-x86_64.pkg.tar.zst
+            tar -C "\$pkgdir" -xvf chdig-\$pkgver-1-\$(uname -m).pkg.tar.zst
             rm -f "\$pkgdir/.PKGINFO"
             rm -f "\$pkgdir/.MTREE"
         }

--- a/Makefile
+++ b/Makefile
@@ -121,17 +121,17 @@ deploy-binary: chdig
 packages: build build_completion deb rpm archlinux tar
 
 deb: build
-	CHDIG_VERSION=${CHDIG_VERSION} nfpm package --config chdig-nfpm.yaml --packager deb
+	CHDIG_VERSION=${CHDIG_VERSION} CHDIG_ARCH=${norm_target_arch} nfpm package --config chdig-nfpm.yaml --packager deb
 rpm: build
-	CHDIG_VERSION=${CHDIG_VERSION} nfpm package --config chdig-nfpm.yaml --packager rpm
+	CHDIG_VERSION=${CHDIG_VERSION} CHDIG_ARCH=${target_arch} nfpm package --config chdig-nfpm.yaml --packager rpm
 archlinux: build
-	CHDIG_VERSION=${CHDIG_VERSION_ARCH} nfpm package --config chdig-nfpm.yaml --packager archlinux
+	CHDIG_VERSION=${CHDIG_VERSION_ARCH} CHDIG_ARCH=${target_arch} nfpm package --config chdig-nfpm.yaml --packager archlinux
 .ONESHELL:
 tar: archlinux
-	CHDIG_VERSION=${CHDIG_VERSION_ARCH} nfpm package --config chdig-nfpm.yaml --packager archlinux
+	CHDIG_VERSION=${CHDIG_VERSION_ARCH} CHDIG_ARCH=${target_arch} nfpm package --config chdig-nfpm.yaml --packager archlinux
 	tmp_dir=$(shell mktemp -d /tmp/chdig-${CHDIG_VERSION}.XXXXXX)
 	echo "Temporary directory for tar package: $$tmp_dir"
-	tar -C $$tmp_dir -vxf chdig-${CHDIG_VERSION_ARCH}-1-x86_64.pkg.tar.zst usr
+	tar -C $$tmp_dir -vxf chdig-${CHDIG_VERSION_ARCH}-1-${target_arch}.pkg.tar.zst usr
 	# Strip /tmp/chdig-${CHDIG_VERSION}.XXXXXX and replace it with chdig-${CHDIG_VERSION}
 	# (and we need to remove leading slash)
 	tar --show-transformed-names --transform "s#^$${tmp_dir#/}#chdig-${CHDIG_VERSION}-${target_arch}#" -vczf chdig-${CHDIG_VERSION}-${target_arch}.tar.gz $$tmp_dir

--- a/README.md
+++ b/README.md
@@ -4,20 +4,10 @@ Dig into [ClickHouse](https://github.com/ClickHouse/ClickHouse/) with TUI interf
 
 ### Installation
 
-There are pre-built packages for the latest available version:
+Pre-built packages (`.deb`, `.rpm`, `archlinux`, `.tar.gz`) and standalone binaries for `Linux` and `macOS` are available for both `x86_64` and `aarch64` architectures.
+The latest [unstable release can be found on GitHub](https://github.com/azat/chdig/releases/tag/latest).
 
-- [debian](https://github.com/azat/chdig/releases/download/latest/chdig-latest_amd64.deb)
-- [fedora](https://github.com/azat/chdig/releases/download/latest/chdig-latest.x86_64.rpm)
-- [archlinux](https://github.com/azat/chdig/releases/download/latest/chdig-latest-x86_64.pkg.tar.zst)
-- [tar.gz](https://github.com/azat/chdig/releases/download/latest/chdig-latest-x86_64.tar.gz)
-
-### Standalone binaries
-
-- [linux amd64](https://github.com/azat/chdig/releases/download/latest/chdig-amd64)
-- [linux aarch64](https://github.com/azat/chdig/releases/download/latest/chdig-aarch64)
-- [macos x86_64](https://github.com/azat/chdig/releases/download/latest/chdig-macos-x86_64)
-- [macos arm64](https://github.com/azat/chdig/releases/download/latest/chdig-macos-arm64)
-- [windows](https://github.com/azat/chdig/releases/download/latest/chdig-windows-x86_64.exe)
+*See also the full list of [releases](https://github.com/azat/chdig/releases).*
 
 <details>
 
@@ -46,8 +36,6 @@ brew install chdig
 ```
 
 </details>
-
-*And also see [releases](https://github.com/azat/chdig/releases).*
 
 ### Demo
 

--- a/chdig-nfpm.yaml
+++ b/chdig-nfpm.yaml
@@ -1,6 +1,6 @@
 ---
 name: "chdig"
-arch: "amd64"
+arch: "${CHDIG_ARCH}"
 platform: "linux"
 version: "${CHDIG_VERSION}"
 homepage: "https://github.com/azat/chdig"


### PR DESCRIPTION
Now there is an arm64 public runner in github actions, so it is very
easy to do.

Also update PKGBUILD to support aarch64 as well.

And polish README, remove all links to the latest release and keep only
one to github release itself.

Fixes: https://github.com/azat/chdig/issues/81