### PR TITLE
README: fix `cargo build` instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,15 +101,22 @@ cargo build
 ```
 
 > [!NOTE]
-If you see any error `failed to authenticate when downloading repository: git@github.com:azat-rust/cursive`
-high chance you may have some local git config `$HOME/.gitconfig` that is using `git` protocol instead of `http` to fetch that dependency.
-
-```
-[url "git@github.com:"]
-	insteadOf = https://github.com/
-```
-Try again without those configs.
-
+> If you see an error like `failed to authenticate when downloading repository: git@github.com:azat-rust/cursive`,
+> it is likely because your local Git config is rewriting `https://github.com/` to `git@github.com:`:
+>
+> ```
+> [url "git@github.com:"]
+>     insteadOf = https://github.com/
+> ```
+>
+> Cargo’s built-in Git library does not handle this case gracefully.
+> You can either remove that config entry or tell Cargo to use the system Git client instead:
+>
+> ```toml
+> # ~/.cargo/config.toml
+> [net]
+> git-fetch-with-cli = true
+> ```
 ### Third party libraries
 
 - [flamelens](https://github.com/ys-l/flamelens)


### PR DESCRIPTION
When I tried to build from source, it failed with following error.

```
Updating git repository https://github.com/azat-rust/cursive error: failed to load source for dependency cursive Caused by:
  Unable to update https://github.com/azat-rust/cursive?branch=chdig-25.7#2c18a81a
Caused by:
  failed to fetch into: /home/kavi/.cargo/git/db/cursive-6ea9b78501fad33c
Caused by:
  revision 2c18a81add64a3c4fa844ade56688905ac7361c7 not found
Caused by:
  failed to authenticate when downloading repository: git@github.com:azat-rust/cursive
  * attempted ssh-agent authentication, but no usernames succeeded: git if the git CLI succeeds then net.git-fetch-with-cli may help here https://doc.rust-lang.org/cargo/reference/config.html#netgit-fetch-with-cli Caused by:
  no authentication methods succeeded
```

Adding `net.git-fetch-with-cli` to $HOME/.cargo/config.toml fixed the issue.

Reference: https://doc.rust-lang.org/cargo/reference/config.html#netgit-fetch-with-cli

thought of adding it to README for anyone facing the same issue. Feel free to ignore if there are better way to handle this.