### PR TITLE
More accurate threads column for queries

### DIFF
--- a/src/interpreter/clickhouse_quirks.rs
+++ b/src/interpreter/clickhouse_quirks.rs
@@ -7,10 +7,12 @@ pub enum ClickHouseAvailableQuirks {
     AsynchronousMetricsTotalIndexGranularityBytesInMemoryAllocated = 3,
     TraceLogHasSymbols = 4,
     SystemReplicasUUID = 8,
+    QueryLogPeakThreadsUsage = 16,
+    ProcessesPeakThreadsUsage = 32,
 }
 
 // List of quirks (that requires workaround) or new features.
-const QUIRKS: [(&str, ClickHouseAvailableQuirks); 5] = [
+const QUIRKS: [(&str, ClickHouseAvailableQuirks); 7] = [
     // https://github.com/ClickHouse/ClickHouse/pull/46047
     //
     // NOTE: I use here 22.13 because I have such version in production, which is more or less the
@@ -28,6 +30,16 @@ const QUIRKS: [(&str, ClickHouseAvailableQuirks); 5] = [
     ),
     (">=25.1", ClickHouseAvailableQuirks::TraceLogHasSymbols),
     (">=25.11", ClickHouseAvailableQuirks::SystemReplicasUUID),
+    // peak_threads_usage is available in system.query_log since 23.8
+    (
+        ">=23.8",
+        ClickHouseAvailableQuirks::QueryLogPeakThreadsUsage,
+    ),
+    // peak_threads_usage is available in system.processes since 25.11
+    (
+        ">=25.11",
+        ClickHouseAvailableQuirks::ProcessesPeakThreadsUsage,
+    ),
 ];
 
 pub struct ClickHouseQuirks {

--- a/src/view/processes_view.rs
+++ b/src/view/processes_view.rs
@@ -227,7 +227,7 @@ impl ProcessesView {
                 selection: false,
                 host_name: processes.get::<_, _>(i, "host_name")?,
                 user: processes.get::<_, _>(i, "user")?,
-                threads: processes.get::<Vec<u64>, _>(i, "thread_ids")?.len(),
+                threads: processes.get::<u64, _>(i, "peak_threads_usage")? as usize,
                 memory: processes.get::<_, _>(i, "peak_memory_usage")?,
                 elapsed: processes.get::<_, _>(i, "elapsed")?,
                 query_start_time_microseconds: processes


### PR DESCRIPTION
Use peak_threads_usage, which shows maximum count of simultaneous threads executing the query, instead of just raw number of all threads on which query has been scheduled (the later can be bigger).

Refs:
- https://github.com/ClickHouse/ClickHouse/pull/54335
- https://github.com/ClickHouse/ClickHouse/pull/90459