### PR TITLE
Improve introspection for background_schedule_pool{,_log}

### DIFF
--- a/src/interpreter/clickhouse_quirks.rs
+++ b/src/interpreter/clickhouse_quirks.rs
@@ -9,10 +9,11 @@ pub enum ClickHouseAvailableQuirks {
     SystemReplicasUUID = 8,
     QueryLogPeakThreadsUsage = 16,
     ProcessesPeakThreadsUsage = 32,
+    SystemBackgroundSchedulePool = 64,
 }
 
 // List of quirks (that requires workaround) or new features.
-const QUIRKS: [(&str, ClickHouseAvailableQuirks); 7] = [
+const QUIRKS: [(&str, ClickHouseAvailableQuirks); 8] = [
     // https://github.com/ClickHouse/ClickHouse/pull/46047
     //
     // NOTE: I use here 22.13 because I have such version in production, which is more or less the
@@ -39,6 +40,11 @@ const QUIRKS: [(&str, ClickHouseAvailableQuirks); 7] = [
     (
         ">=25.11",
         ClickHouseAvailableQuirks::ProcessesPeakThreadsUsage,
+    ),
+    // peak_threads_usage is available in system.processes since 25.11
+    (
+        ">=25.12",
+        ClickHouseAvailableQuirks::SystemBackgroundSchedulePool,
     ),
 ];
 

--- a/src/interpreter/options.rs
+++ b/src/interpreter/options.rs
@@ -128,6 +128,8 @@ pub enum ChDigViews {
     Loggers,
     /// Show background schedule pool tasks (system.background_schedule_pool)
     BackgroundSchedulePool,
+    /// Show background schedule pool logs (system.background_schedule_pool_log)
+    BackgroundSchedulePoolLog,
     /// Spawn client inside chdig
     Client,
 }

--- a/src/view/navigation.rs
+++ b/src/view/navigation.rs
@@ -303,6 +303,7 @@ impl Navigation for Cursive {
         c.register_provider(Arc::new(ReplicasViewProvider));
         c.register_provider(Arc::new(TablesViewProvider));
         c.register_provider(Arc::new(BackgroundSchedulePoolViewProvider));
+        c.register_provider(Arc::new(BackgroundSchedulePoolLogViewProvider));
         c.register_provider(Arc::new(BackupsViewProvider));
         c.register_provider(Arc::new(DictionariesViewProvider));
         c.register_provider(Arc::new(ServerLogsViewProvider));

--- a/src/view/providers/background_schedule_pool_log.rs
+++ b/src/view/providers/background_schedule_pool_log.rs
@@ -1,0 +1,279 @@
+use crate::{
+    interpreter::{ContextArc, clickhouse::TextLogArguments, options::ChDigViews},
+    view::{self, Navigation, TextLogView, ViewProvider},
+};
+use cursive::{
+    Cursive,
+    view::{Nameable, Resizable},
+    views::{Dialog, DummyView, LinearLayout, NamedView, TextView},
+};
+use std::collections::HashMap;
+
+pub struct BackgroundSchedulePoolLogViewProvider;
+
+impl ViewProvider for BackgroundSchedulePoolLogViewProvider {
+    fn name(&self) -> &'static str {
+        "Background Tasks History"
+    }
+
+    fn view_type(&self) -> ChDigViews {
+        ChDigViews::BackgroundSchedulePoolLog
+    }
+
+    fn show(&self, siv: &mut Cursive, context: ContextArc) {
+        show_background_schedule_pool_log(siv, context, None, None, None);
+    }
+}
+
+struct FilterParams {
+    log_name: Option<String>,
+    database: Option<String>,
+    table: Option<String>,
+}
+
+impl FilterParams {
+    fn build_where_clauses(&self) -> Vec<String> {
+        let mut clauses = vec![
+            "event_date BETWEEN toDate(start_) AND toDate(end_)".to_string(),
+            "event_time BETWEEN toDateTime(start_) AND toDateTime(end_)".to_string(),
+        ];
+
+        if let Some(ref log_name) = self.log_name {
+            clauses.push(format!("log_name = '{}'", log_name.replace('\'', "''")));
+        }
+        if let Some(ref database) = self.database {
+            clauses.push(format!("database = '{}'", database.replace('\'', "''")));
+        }
+        if let Some(ref table) = self.table {
+            clauses.push(format!("table = '{}'", table.replace('\'', "''")));
+        }
+
+        clauses
+    }
+
+    fn build_title(&self, for_dialog: bool) -> String {
+        match (&self.log_name, &self.database, &self.table) {
+            (Some(ln), _, _) => {
+                if for_dialog {
+                    format!("Task summary: {}", ln)
+                } else {
+                    format!("Background Tasks Logs: {}", ln)
+                }
+            }
+            (None, Some(db), Some(tbl)) => {
+                if for_dialog {
+                    format!("Tasks for: {}.{}", db, tbl)
+                } else {
+                    format!("Background Tasks Logs: {}.{}", db, tbl)
+                }
+            }
+            (None, Some(db), None) => {
+                if for_dialog {
+                    format!("Tasks for: {}", db)
+                } else {
+                    format!("Background Tasks Logs: {}", db)
+                }
+            }
+            (None, None, Some(tbl)) => {
+                if for_dialog {
+                    format!("Tasks for table: {}", tbl)
+                } else {
+                    format!("Background Tasks Logs: table {}", tbl)
+                }
+            }
+            (None, None, None) => "Background Tasks Logs".to_string(),
+        }
+    }
+
+    fn generate_view_name(&self) -> String {
+        format!(
+            "background_schedule_pool_log_{}_{}_{}",
+            self.log_name.as_deref().unwrap_or("any"),
+            self.database.as_deref().unwrap_or("any"),
+            self.table.as_deref().unwrap_or("any")
+        )
+    }
+}
+
+fn build_query(context: &ContextArc, filters: &FilterParams) -> String {
+    let view_options = context.lock().unwrap().options.view.clone();
+    let limit = context.lock().unwrap().options.clickhouse.limit;
+
+    let dbtable = context
+        .lock()
+        .unwrap()
+        .clickhouse
+        .get_table_name("system", "background_schedule_pool_log");
+
+    let start_sql = view_options
+        .start
+        .to_sql_datetime_64()
+        .unwrap_or_else(|| "now() - INTERVAL 1 HOUR".to_string());
+    let end_sql = view_options
+        .end
+        .to_sql_datetime_64()
+        .unwrap_or_else(|| "now()".to_string());
+
+    let where_clauses = filters.build_where_clauses();
+
+    format!(
+        r#"
+        WITH {start} AS start_, {end} AS end_
+        SELECT event_time, log_name, database, table, query_id, duration_ms, error, exception
+        FROM {dbtable}
+        WHERE
+            {where_clause}
+        ORDER BY event_time DESC
+        LIMIT {limit}
+        "#,
+        start = start_sql,
+        end = end_sql,
+        dbtable = dbtable,
+        where_clause = where_clauses.join(" AND "),
+        limit = limit,
+    )
+}
+
+fn get_columns() -> (Vec<&'static str>, Vec<&'static str>) {
+    let columns = vec![
+        "event_time",
+        "log_name",
+        "database",
+        "table",
+        "query_id",
+        "duration_ms",
+        "error",
+        "exception",
+    ];
+    let columns_to_compare = vec!["event_time", "log_name", "database", "table"];
+    (columns, columns_to_compare)
+}
+
+fn show_task_logs(siv: &mut Cursive, columns: Vec<&'static str>, row: view::QueryResultRow) {
+    let row_data = row.0;
+    let mut map = HashMap::<String, String>::new();
+    columns.iter().zip(row_data.iter()).for_each(|(c, r)| {
+        let value = r.to_string();
+        map.insert(c.to_string(), value);
+    });
+
+    let log_name = map
+        .get("log_name")
+        .map(|s| s.to_owned())
+        .unwrap_or_default();
+    let query_id = map
+        .get("query_id")
+        .map(|s| s.to_owned())
+        .unwrap_or_default();
+
+    if query_id.is_empty() {
+        return;
+    }
+
+    let context = siv.user_data::<ContextArc>().unwrap().clone();
+    let view_options = context.clone().lock().unwrap().options.view.clone();
+
+    siv.add_layer(Dialog::around(
+        LinearLayout::vertical()
+            .child(TextView::new(format!("Logs for {} ({})", log_name, query_id)).center())
+            .child(DummyView.fixed_height(1))
+            .child(NamedView::new(
+                "background_task_logs",
+                TextLogView::new(
+                    "background_task_logs",
+                    context,
+                    TextLogArguments {
+                        query_ids: Some(vec![query_id]),
+                        logger_names: None,
+                        message_filter: None,
+                        max_level: None,
+                        start: view_options.start.into(),
+                        end: view_options.end,
+                    },
+                ),
+            )),
+    ));
+    siv.focus_name("background_task_logs").ok();
+}
+
+pub fn show_background_schedule_pool_log(
+    siv: &mut Cursive,
+    context: ContextArc,
+    log_name: Option<String>,
+    database: Option<String>,
+    table: Option<String>,
+) {
+    let view_name = "background_schedule_pool_log";
+
+    if siv.has_view(view_name) {
+        return;
+    }
+
+    let filters = FilterParams {
+        log_name,
+        database,
+        table,
+    };
+
+    let query = build_query(&context, &filters);
+    let (columns, columns_to_compare) = get_columns();
+
+    let mut view = view::SQLQueryView::new(
+        context.clone(),
+        view_name,
+        "event_time",
+        columns,
+        columns_to_compare,
+        query,
+    )
+    .unwrap_or_else(|_| panic!("Cannot create {}", view_name));
+
+    view.get_inner_mut().set_on_submit(show_task_logs);
+
+    let title = filters.build_title(false);
+
+    siv.drop_main_view();
+    siv.set_main_view(Dialog::around(view.with_name(view_name).full_screen()).title(title));
+}
+
+pub fn show_background_schedule_pool_log_dialog(
+    siv: &mut Cursive,
+    context: ContextArc,
+    log_name: Option<String>,
+    database: Option<String>,
+    table: Option<String>,
+) {
+    let filters = FilterParams {
+        log_name,
+        database,
+        table,
+    };
+
+    let view_name: &'static str = Box::leak(filters.generate_view_name().into_boxed_str());
+    let query = build_query(&context, &filters);
+    let (columns, columns_to_compare) = get_columns();
+
+    let mut sql_view = view::SQLQueryView::new(
+        context.clone(),
+        view_name,
+        "event_time",
+        columns,
+        columns_to_compare,
+        query,
+    )
+    .unwrap_or_else(|_| panic!("Cannot create {}", view_name));
+
+    sql_view.get_inner_mut().set_on_submit(show_task_logs);
+
+    let title = filters.build_title(true);
+
+    siv.add_layer(
+        Dialog::around(
+            LinearLayout::vertical()
+                .child(TextView::new(title).center())
+                .child(DummyView.fixed_height(1))
+                .child(sql_view.with_name(view_name).min_size((140, 30))),
+        )
+        .title("Background Schedule Pool Logs"),
+    );
+}

--- a/src/view/providers/mod.rs
+++ b/src/view/providers/mod.rs
@@ -1,4 +1,5 @@
 mod background_schedule_pool;
+mod background_schedule_pool_log;
 mod backups;
 mod client;
 mod dictionaries;
@@ -15,6 +16,7 @@ mod server_logs;
 mod tables;
 
 pub use background_schedule_pool::BackgroundSchedulePoolViewProvider;
+pub use background_schedule_pool_log::BackgroundSchedulePoolLogViewProvider;
 pub use backups::BackupsViewProvider;
 pub use client::ClientViewProvider;
 pub use dictionaries::DictionariesViewProvider;

--- a/src/view/sql_query_view.rs
+++ b/src/view/sql_query_view.rs
@@ -21,9 +21,11 @@ pub enum Field {
     Float32(f32),
     UInt64(u64),
     UInt32(u32),
+    UInt16(u16),
     UInt8(u8),
     Int64(i64),
     Int32(i32),
+    Int16(i16),
     Int8(i8),
     DateTime(DateTime<Local>),
     // TODO: support more types
@@ -60,6 +62,7 @@ impl std::fmt::Display for Field {
                 }
             }
             Self::UInt32(ref value) => write!(f, "{}", value),
+            Self::UInt16(ref value) => write!(f, "{}", value),
             Self::UInt8(ref value) => write!(f, "{}", value),
             Self::Int64(ref value) => {
                 if *value < 1_000 {
@@ -69,6 +72,7 @@ impl std::fmt::Display for Field {
                 }
             }
             Self::Int32(ref value) => write!(f, "{}", value),
+            Self::Int16(ref value) => write!(f, "{}", value),
             Self::Int8(ref value) => write!(f, "{}", value),
             Self::DateTime(ref value) => write!(f, "{}", value),
         }
@@ -144,9 +148,11 @@ impl SQLQueryView {
                     SqlType::Float32 => Field::Float32(block.get::<_, _>(i, column)?),
                     SqlType::UInt64 => Field::UInt64(block.get::<_, _>(i, column)?),
                     SqlType::UInt32 => Field::UInt32(block.get::<_, _>(i, column)?),
+                    SqlType::UInt16 => Field::UInt16(block.get::<_, _>(i, column)?),
                     SqlType::UInt8 => Field::UInt8(block.get::<_, _>(i, column)?),
                     SqlType::Int64 => Field::Int64(block.get::<_, _>(i, column)?),
                     SqlType::Int32 => Field::Int32(block.get::<_, _>(i, column)?),
+                    SqlType::Int16 => Field::Int16(block.get::<_, _>(i, column)?),
                     SqlType::Int8 => Field::Int8(block.get::<_, _>(i, column)?),
                     SqlType::DateTime(_) => Field::DateTime(
                         block


### PR DESCRIPTION
- Add missing event_date/event_time filters
- Per table tasks
- Tasks view
- Per-task logs
- Show number of tasks per table

Refs: https://github.com/ClickHouse/ClickHouse/pull/91157