### PR TITLE
Persist query filter and limit across view switches

### DIFF
--- a/src/interpreter/context.rs
+++ b/src/interpreter/context.rs
@@ -49,6 +49,9 @@ pub struct Context {
     pub current_view: Option<ChDigViews>,
 
     pub perfetto_server: Option<Arc<PerfettoServer>>,
+
+    pub queries_filter: Arc<Mutex<String>>,
+    pub queries_limit: Arc<Mutex<u64>>,
 }
 
 impl Context {
@@ -64,6 +67,9 @@ impl Context {
         let background_runner_summary_force = Arc::new(atomic::AtomicBool::new(false));
 
         let view_registry = crate::view::ViewRegistry::new();
+
+        let queries_filter = Arc::new(Mutex::new(String::new()));
+        let queries_limit = Arc::new(Mutex::new(options.view.queries_limit));
 
         let context = Arc::new(Mutex::new(Context {
             options,
@@ -83,6 +89,8 @@ impl Context {
             selected_host: None,
             current_view: None,
             perfetto_server: None,
+            queries_filter,
+            queries_limit,
         }));
 
         context.lock().unwrap().worker.start(context.clone());

--- a/src/interpreter/options.rs
+++ b/src/interpreter/options.rs
@@ -262,6 +262,10 @@ pub struct ViewOptions {
     /// Disable stripping common hostname prefix and suffix in queries and logs views
     #[arg(long, action = ArgAction::SetTrue)]
     pub no_strip_hostname_suffix: bool,
+
+    /// Limit for number of queries to render in queries views
+    #[arg(long, default_value_t = 10000)]
+    pub queries_limit: u64,
     // TODO: --mouse/--no-mouse (see EXIT_MOUSE_SEQUENCE in termion)
 }
 
@@ -371,6 +375,7 @@ struct ChDigViewConfig {
     end: Option<String>,
     wrap: Option<bool>,
     no_strip_hostname_suffix: Option<bool>,
+    queries_limit: Option<u64>,
 }
 
 #[derive(Deserialize, Default)]
@@ -592,6 +597,9 @@ fn apply_chdig_config(options: &mut ChDigOptions, config: &ChDigConfig) {
         && let Some(no_strip) = view.no_strip_hostname_suffix
     {
         options.view.no_strip_hostname_suffix = no_strip;
+    }
+    if let Some(queries_limit) = view.queries_limit {
+        options.view.queries_limit = queries_limit;
     }
 
     // service section
@@ -1252,6 +1260,7 @@ mod tests {
         assert_eq!(config.view.end.as_deref(), Some("30min"));
         assert_eq!(config.view.wrap, Some(true));
         assert_eq!(config.view.no_strip_hostname_suffix, Some(true));
+        assert_eq!(config.view.queries_limit, Some(500));
 
         assert_eq!(config.service.log.as_deref(), Some("/tmp/chdig.log"));
         assert_eq!(
@@ -1313,6 +1322,7 @@ mod tests {
         assert_eq!(options.view.no_subqueries, true);
         assert_eq!(options.view.wrap, true);
         assert_eq!(options.view.no_strip_hostname_suffix, true);
+        assert_eq!(options.view.queries_limit, 500);
         assert_eq!(options.service.log.as_deref(), Some("/tmp/chdig.log"));
         assert_eq!(
             options.service.pastila_clickhouse_host,

--- a/src/view/navigation.rs
+++ b/src/view/navigation.rs
@@ -391,13 +391,14 @@ impl Navigation for Cursive {
         }
 
         let context = self.user_data::<ContextArc>().unwrap().clone();
-        let (opts, server_version, selected_host, current_view) = {
+        let (opts, server_version, selected_host, current_view, queries_filter) = {
             let ctx = context.lock().unwrap();
             (
                 ctx.options.clone(),
                 ctx.server_version.clone(),
                 ctx.selected_host.clone(),
                 ctx.current_view,
+                ctx.queries_filter.lock().unwrap().clone(),
             )
         };
 
@@ -476,6 +477,18 @@ impl Navigation for Cursive {
             "no_strip_hostname_suffix",
             "set_no_strip_hostname_suffix",
             opts.view.no_strip_hostname_suffix,
+        ));
+        layout.add_child(edit_row(
+            "queries_filter",
+            "set_queries_filter",
+            &queries_filter,
+            30,
+        ));
+        layout.add_child(edit_row(
+            "queries_limit",
+            "set_queries_limit",
+            &opts.view.queries_limit.to_string(),
+            12,
         ));
         layout.add_child(edit_row(
             "start",
@@ -649,6 +662,14 @@ impl Navigation for Cursive {
                         v.is_checked()
                     })
                     .unwrap();
+                let queries_filter = siv
+                    .call_on_name("set_queries_filter", |v: &mut EditView| {
+                        (*v.get_content()).clone()
+                    })
+                    .unwrap();
+                let queries_limit_str = siv
+                    .call_on_name("set_queries_limit", |v: &mut EditView| v.get_content())
+                    .unwrap();
                 let start_str = siv
                     .call_on_name("set_start", |v: &mut EditView| v.get_content())
                     .unwrap();
@@ -726,6 +747,13 @@ impl Navigation for Cursive {
                         return;
                     }
                 };
+                let queries_limit: u64 = match queries_limit_str.parse() {
+                    Ok(v) => v,
+                    Err(_) => {
+                        siv.add_layer(Dialog::info("Invalid queries_limit value"));
+                        return;
+                    }
+                };
                 let new_start = match start_str.parse::<crate::common::RelativeDateTime>() {
                     Ok(v) => v,
                     Err(err) => {
@@ -753,6 +781,9 @@ impl Navigation for Cursive {
                     ctx.options.view.no_subqueries = no_subqueries;
                     ctx.options.view.wrap = wrap;
                     ctx.options.view.no_strip_hostname_suffix = no_strip;
+                    *ctx.queries_filter.lock().unwrap() = queries_filter;
+                    ctx.options.view.queries_limit = queries_limit;
+                    *ctx.queries_limit.lock().unwrap() = queries_limit;
                     ctx.options.view.start = new_start;
                     ctx.options.view.end = new_end;
 

--- a/src/view/queries_view.rs
+++ b/src/view/queries_view.rs
@@ -947,8 +947,8 @@ impl QueriesView {
         let delay = context.lock().unwrap().options.view.delay_interval;
 
         let is_system_processes = matches!(processes_type, Type::ProcessList);
-        let filter = Arc::new(Mutex::new(String::new()));
-        let limit = Arc::new(Mutex::new(10000));
+        let filter = context.lock().unwrap().queries_filter.clone();
+        let limit = context.lock().unwrap().queries_limit.clone();
 
         let update_callback_context = context.clone();
         let update_callback_filter = filter.clone();

--- a/tests/configs/chdig_basic.yaml
+++ b/tests/configs/chdig_basic.yaml
@@ -21,6 +21,7 @@ view:
   end: "30min"
   wrap: true
   no_strip_hostname_suffix: true
+  queries_limit: 500
 
 service:
   log: "/tmp/chdig.log"


### PR DESCRIPTION
Move filter/limit state from QueriesView locals into Context so they survive view recreation. Add --queries-limit CLI arg and config file option, and expose tme in the Settings dialog (F3).