### PR TITLE
Add CLI export for perfetto traces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dist
 *.rpm
 # intellij
 .idea/
+*.pftrace

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -49,15 +49,13 @@ fn write_perfetto_trace(path: &str, data: Vec<u8>) -> Result<()> {
     Ok(())
 }
 
-async fn maybe_run_cli_perfetto_export(
+async fn run_cli_perfetto_export(
     options: &options::ChDigOptions,
     clickhouse: &Arc<ClickHouse>,
 ) -> Result<bool> {
-    let Some(cmd) = options.perfetto_command() else {
-        return Ok(false);
-    };
-
-    let output = cmd
+    
+    let output = options
+        .view
         .output
         .clone()
         .unwrap_or_else(|| "/tmp/chdig_perfetto.pftrace".to_string());
@@ -68,20 +66,18 @@ async fn maybe_run_cli_perfetto_export(
     perfetto_options.query_metric_log = true;
     perfetto_options.asynchronous_metric_log = true;
 
-    if let Some(query_id) = cmd.query_id.as_deref() {
+    if let Some(query_id) = options.view.query_id.as_deref() {
         let scope = clickhouse.get_perfetto_query_scope(query_id).await?;
-        let end_time = scope.end + chrono::TimeDelta::seconds(1);
-        let query_block = clickhouse
-            .get_queries_for_perfetto(scope.start, end_time)
-            .await?;
-        let query_ids = scope.query_ids;
-        let query_ids_set = std::collections::HashSet::<&String>::from_iter(query_ids.iter());
+        let start = scope.start;
+        let end = scope.end;
+
+        let end_time = end + chrono::TimeDelta::seconds(1);
+        let query_block = clickhouse.get_queries_for_perfetto(start, end_time, &Some(scope.query_ids.clone())).await?;
         let mut queries = Vec::new();
 
         for i in 0..query_block.row_count() {
             match Query::from_clickhouse_block(&query_block, i, false) {
-                Ok(q) if query_ids_set.contains(&q.query_id) => queries.push(q),
-                Ok(_) => {}
+                Ok(q) => queries.push(q),
                 Err(e) => log::warn!("Perfetto: failed to parse query row {}: {}", i, e),
             }
         }
@@ -95,7 +91,7 @@ async fn maybe_run_cli_perfetto_export(
             clickhouse,
             &mut builder,
             &perfetto_options,
-            Some(&query_ids),
+            Some(&scope.query_ids),
             scope.start,
             end_time,
         )
@@ -104,10 +100,12 @@ async fn maybe_run_cli_perfetto_export(
         return Ok(true);
     }
 
-    if cmd.server {
-        let start: DateTime<Local> = cmd.start.clone().into();
-        let end: DateTime<Local> = cmd.end.clone().into();
-        let query_block = clickhouse.get_queries_for_perfetto(start, end).await?;
+    if options.view.server {
+        let start: DateTime<Local> = options.view.start.clone().into();
+        let end: DateTime<Local> = options.view.end.clone().into();
+
+        let end_time = end + chrono::TimeDelta::seconds(1);
+        let query_block = clickhouse.get_queries_for_perfetto(start, end_time, &None).await?;
         let mut queries = Vec::new();
 
         for i in 0..query_block.row_count() {
@@ -117,7 +115,6 @@ async fn maybe_run_cli_perfetto_export(
             }
         }
 
-        let end_time = end + chrono::TimeDelta::seconds(1);
         let mut builder = PerfettoTraceBuilder::new(
             perfetto_options.per_server,
             perfetto_options.text_log_android,
@@ -163,7 +160,8 @@ where
     // panic hook will clear the screen).
     let clickhouse = Arc::new(ClickHouse::new(options.clickhouse.clone()).await?);
 
-    if maybe_run_cli_perfetto_export(&options, &clickhouse).await? {
+    if options.perfetto_command().is_some() {
+        run_cli_perfetto_export(&options, &clickhouse).await?;
         return Ok(());
     }
 

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -1,6 +1,5 @@
 use anyhow::{Result, anyhow};
 use backtrace::Backtrace;
-use chrono::{DateTime, Local};
 use flexi_logger::{FileSpec, LogSpecification, Logger};
 use std::ffi::OsString;
 use std::panic::{self, PanicHookInfo};
@@ -8,6 +7,7 @@ use std::sync::Arc;
 
 use cursive::view::Resizable;
 
+use crate::interpreter::clickhouse::PerfettoQueryScope;
 use crate::{
     interpreter::{
         ClickHouse, Context, ContextArc, Query, fetch_and_populate_perfetto_trace,
@@ -54,88 +54,81 @@ async fn run_cli_perfetto_export(
     clickhouse: &Arc<ClickHouse>,
 ) -> Result<bool> {
     
-    let output = options
+    let mut perfetto_options = options.perfetto.clone();
+
+    match options.perfetto_command() {
+        Some(cmd) => {
+            perfetto_options.aggregated_zookeeper_log = cmd.aggregated_zookeeper_log;
+            perfetto_options.query_metric_log = cmd.query_metric_log;
+            perfetto_options.asynchronous_metric_log = cmd.asynchronous_metric_log;
+            if cmd.all {
+                perfetto_options.aggregated_zookeeper_log = true;
+                perfetto_options.query_metric_log = true;
+                perfetto_options.asynchronous_metric_log = true;
+            }
+        },
+        None => {},
+    };
+
+    let mut scope: PerfettoQueryScope = PerfettoQueryScope {start: options.view.start.clone().into(), end: options.view.end.clone().into(), query_ids: None};
+    let mut is_server_scope = false; 
+
+    match &options.view.query_id {
+        Some(query_id) => {
+            scope = clickhouse.get_perfetto_query_scope(&query_id).await?;
+        }
+        None => {
+            is_server_scope = true;
+        }
+    }
+
+    scope.end = scope.end + chrono::TimeDelta::seconds(1);
+
+    let query_block: clickhouse_rs::Block<clickhouse_rs::types::Complex> = clickhouse.get_queries_for_perfetto(scope.start, scope.end, &scope.query_ids).await?;
+    let mut queries = Vec::new();
+    for i in 0..query_block.row_count() {
+        match Query::from_clickhouse_block(&query_block, i, false) {
+            Ok(q) => queries.push(q),
+            Err(e) => log::warn!("Perfetto: failed to parse query row {}: {}", i, e),
+        }
+    }
+
+    let mut builder = PerfettoTraceBuilder::new(
+        perfetto_options.per_server,
+        perfetto_options.text_log_android,
+    );
+    builder.add_queries(&queries);
+    fetch_and_populate_perfetto_trace(
+        clickhouse,
+        &mut builder,
+        &perfetto_options,
+        scope.query_ids.as_ref().map(|v| v.as_slice()),
+        scope.start,
+        scope.end,
+    )
+    .await;
+
+    if is_server_scope {
+        fetch_server_perfetto_sources(clickhouse, &mut builder, &perfetto_options, scope.start, scope.end)
+            .await;
+    }
+
+    let mut output = options
         .view
         .output
         .clone()
-        .unwrap_or_else(|| "/tmp/chdig_perfetto.pftrace".to_string());
-    
-    let mut perfetto_options = options.perfetto.clone();
+        .unwrap();
 
-    perfetto_options.aggregated_zookeeper_log = true;
-    perfetto_options.query_metric_log = true;
-    perfetto_options.asynchronous_metric_log = true;
-
-    if let Some(query_id) = options.view.query_id.as_deref() {
-        let scope = clickhouse.get_perfetto_query_scope(query_id).await?;
-        let start = scope.start;
-        let end = scope.end;
-
-        let end_time = end + chrono::TimeDelta::seconds(1);
-        let query_block = clickhouse.get_queries_for_perfetto(start, end_time, &Some(scope.query_ids.clone())).await?;
-        let mut queries = Vec::new();
-
-        for i in 0..query_block.row_count() {
-            match Query::from_clickhouse_block(&query_block, i, false) {
-                Ok(q) => queries.push(q),
-                Err(e) => log::warn!("Perfetto: failed to parse query row {}: {}", i, e),
-            }
+    if output == "./" {
+        if is_server_scope {
+            output += "server_perfetto_trace.pftrace"
+        } else {
+            output += &format!("{}.pftrace", options.view.query_id.as_ref().unwrap());
         }
-
-        let mut builder = PerfettoTraceBuilder::new(
-            perfetto_options.per_server,
-            perfetto_options.text_log_android,
-        );
-        builder.add_queries(&queries);
-        fetch_and_populate_perfetto_trace(
-            clickhouse,
-            &mut builder,
-            &perfetto_options,
-            Some(&scope.query_ids),
-            scope.start,
-            end_time,
-        )
-        .await;
-        write_perfetto_trace(&output, builder.build())?;
-        return Ok(true);
     }
+    write_perfetto_trace(&output, builder.build())?;
 
-    if options.view.server {
-        let start: DateTime<Local> = options.view.start.clone().into();
-        let end: DateTime<Local> = options.view.end.clone().into();
-
-        let end_time = end + chrono::TimeDelta::seconds(1);
-        let query_block = clickhouse.get_queries_for_perfetto(start, end_time, &None).await?;
-        let mut queries = Vec::new();
-
-        for i in 0..query_block.row_count() {
-            match Query::from_clickhouse_block(&query_block, i, false) {
-                Ok(q) => queries.push(q),
-                Err(e) => log::warn!("Perfetto: failed to parse query row {}: {}", i, e),
-            }
-        }
-
-        let mut builder = PerfettoTraceBuilder::new(
-            perfetto_options.per_server,
-            perfetto_options.text_log_android,
-        );
-        builder.add_queries(&queries);
-        fetch_and_populate_perfetto_trace(
-            clickhouse,
-            &mut builder,
-            &perfetto_options,
-            None,
-            start,
-            end_time,
-        )
-        .await;
-        fetch_server_perfetto_sources(clickhouse, &mut builder, &perfetto_options, start, end_time)
-            .await;
-        write_perfetto_trace(&output, builder.build())?;
-        return Ok(true);
-    }
-
-    Ok(false)
+    Ok(true)
 }
 
 pub async fn chdig_main_async<I, T>(itr: I) -> Result<()>

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -53,7 +53,6 @@ async fn run_cli_perfetto_export(
     options: &options::ChDigOptions,
     clickhouse: &Arc<ClickHouse>,
 ) -> Result<bool> {
-    
     let mut perfetto_options = options.perfetto.clone();
 
     match options.perfetto_command() {
@@ -61,17 +60,25 @@ async fn run_cli_perfetto_export(
             perfetto_options.aggregated_zookeeper_log = cmd.aggregated_zookeeper_log;
             perfetto_options.query_metric_log = cmd.query_metric_log;
             perfetto_options.asynchronous_metric_log = cmd.asynchronous_metric_log;
+            perfetto_options.text_log_android = cmd.text_log;
+            perfetto_options.text_log = cmd.text_log;
+            perfetto_options.per_server = cmd.track_per_server;
             if cmd.all {
                 perfetto_options.aggregated_zookeeper_log = true;
                 perfetto_options.query_metric_log = true;
                 perfetto_options.asynchronous_metric_log = true;
+                perfetto_options.text_log_android = true;
             }
-        },
-        None => {},
+        }
+        None => {}
     };
 
-    let mut scope: PerfettoQueryScope = PerfettoQueryScope {start: options.view.start.clone().into(), end: options.view.end.clone().into(), query_ids: None};
-    let mut is_server_scope = false; 
+    let mut scope: PerfettoQueryScope = PerfettoQueryScope {
+        start: options.view.start.clone().into(),
+        end: options.view.end.clone().into(),
+        query_ids: None,
+    };
+    let mut is_server_scope = false;
 
     match &options.view.query_id {
         Some(query_id) => {
@@ -84,7 +91,9 @@ async fn run_cli_perfetto_export(
 
     scope.end = scope.end + chrono::TimeDelta::seconds(1);
 
-    let query_block: clickhouse_rs::Block<clickhouse_rs::types::Complex> = clickhouse.get_queries_for_perfetto(scope.start, scope.end, &scope.query_ids).await?;
+    let query_block: clickhouse_rs::Block<clickhouse_rs::types::Complex> = clickhouse
+        .get_queries_for_perfetto(scope.start, scope.end, &scope.query_ids)
+        .await?;
     let mut queries = Vec::new();
     for i in 0..query_block.row_count() {
         match Query::from_clickhouse_block(&query_block, i, false) {
@@ -109,15 +118,17 @@ async fn run_cli_perfetto_export(
     .await;
 
     if is_server_scope {
-        fetch_server_perfetto_sources(clickhouse, &mut builder, &perfetto_options, scope.start, scope.end)
-            .await;
+        fetch_server_perfetto_sources(
+            clickhouse,
+            &mut builder,
+            &perfetto_options,
+            scope.start,
+            scope.end,
+        )
+        .await;
     }
 
-    let mut output = options
-        .view
-        .output
-        .clone()
-        .unwrap();
+    let mut output = options.view.output.clone().unwrap();
 
     if output == "./" {
         if is_server_scope {

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -1,5 +1,6 @@
 use anyhow::{Result, anyhow};
 use backtrace::Backtrace;
+use chrono::{DateTime, Local};
 use flexi_logger::{FileSpec, LogSpecification, Logger};
 use std::ffi::OsString;
 use std::panic::{self, PanicHookInfo};
@@ -8,7 +9,10 @@ use std::sync::Arc;
 use cursive::view::Resizable;
 
 use crate::{
-    interpreter::{ClickHouse, Context, ContextArc, options},
+    interpreter::{
+        ClickHouse, Context, ContextArc, Query, fetch_and_populate_perfetto_trace,
+        fetch_server_perfetto_sources, options, perfetto::PerfettoTraceBuilder,
+    },
     view::Navigation,
 };
 
@@ -39,6 +43,104 @@ fn panic_hook(info: &PanicHookInfo<'_>) {
     );
 }
 
+fn write_perfetto_trace(path: &str, data: Vec<u8>) -> Result<()> {
+    std::fs::write(path, &data)?;
+    println!("Perfetto trace exported to {}", path);
+    Ok(())
+}
+
+async fn maybe_run_cli_perfetto_export(
+    options: &options::ChDigOptions,
+    clickhouse: &Arc<ClickHouse>,
+) -> Result<bool> {
+    let Some(cmd) = options.perfetto_command() else {
+        return Ok(false);
+    };
+
+    let output = cmd
+        .output
+        .clone()
+        .unwrap_or_else(|| "/tmp/chdig_perfetto.pftrace".to_string());
+    
+    let mut perfetto_options = options.perfetto.clone();
+
+    perfetto_options.aggregated_zookeeper_log = true;
+    perfetto_options.query_metric_log = true;
+    perfetto_options.asynchronous_metric_log = true;
+
+    if let Some(query_id) = cmd.query_id.as_deref() {
+        let scope = clickhouse.get_perfetto_query_scope(query_id).await?;
+        let end_time = scope.end + chrono::TimeDelta::seconds(1);
+        let query_block = clickhouse
+            .get_queries_for_perfetto(scope.start, end_time)
+            .await?;
+        let query_ids = scope.query_ids;
+        let query_ids_set = std::collections::HashSet::<&String>::from_iter(query_ids.iter());
+        let mut queries = Vec::new();
+
+        for i in 0..query_block.row_count() {
+            match Query::from_clickhouse_block(&query_block, i, false) {
+                Ok(q) if query_ids_set.contains(&q.query_id) => queries.push(q),
+                Ok(_) => {}
+                Err(e) => log::warn!("Perfetto: failed to parse query row {}: {}", i, e),
+            }
+        }
+
+        let mut builder = PerfettoTraceBuilder::new(
+            perfetto_options.per_server,
+            perfetto_options.text_log_android,
+        );
+        builder.add_queries(&queries);
+        fetch_and_populate_perfetto_trace(
+            clickhouse,
+            &mut builder,
+            &perfetto_options,
+            Some(&query_ids),
+            scope.start,
+            end_time,
+        )
+        .await;
+        write_perfetto_trace(&output, builder.build())?;
+        return Ok(true);
+    }
+
+    if cmd.server {
+        let start: DateTime<Local> = cmd.start.clone().into();
+        let end: DateTime<Local> = cmd.end.clone().into();
+        let query_block = clickhouse.get_queries_for_perfetto(start, end).await?;
+        let mut queries = Vec::new();
+
+        for i in 0..query_block.row_count() {
+            match Query::from_clickhouse_block(&query_block, i, false) {
+                Ok(q) => queries.push(q),
+                Err(e) => log::warn!("Perfetto: failed to parse query row {}: {}", i, e),
+            }
+        }
+
+        let end_time = end + chrono::TimeDelta::seconds(1);
+        let mut builder = PerfettoTraceBuilder::new(
+            perfetto_options.per_server,
+            perfetto_options.text_log_android,
+        );
+        builder.add_queries(&queries);
+        fetch_and_populate_perfetto_trace(
+            clickhouse,
+            &mut builder,
+            &perfetto_options,
+            None,
+            start,
+            end_time,
+        )
+        .await;
+        fetch_server_perfetto_sources(clickhouse, &mut builder, &perfetto_options, start, end_time)
+            .await;
+        write_perfetto_trace(&output, builder.build())?;
+        return Ok(true);
+    }
+
+    Ok(false)
+}
+
 pub async fn chdig_main_async<I, T>(itr: I) -> Result<()>
 where
     I: IntoIterator<Item = T>,
@@ -60,6 +162,10 @@ where
     // Initialize it before any backends (otherwise backend will prepare terminal for TUI app, and
     // panic hook will clear the screen).
     let clickhouse = Arc::new(ClickHouse::new(options.clickhouse.clone()).await?);
+
+    if maybe_run_cli_perfetto_export(&options, &clickhouse).await? {
+        return Ok(());
+    }
 
     let server_warnings = match clickhouse.get_warnings().await {
         Ok(w) => w,

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -1,14 +1,19 @@
 use anyhow::{Result, anyhow};
 use backtrace::Backtrace;
+use chrono::TimeDelta;
 use flexi_logger::{FileSpec, LogSpecification, Logger};
 use std::ffi::OsString;
 use std::panic::{self, PanicHookInfo};
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use cursive::view::Resizable;
 
 use crate::{
-    interpreter::{ClickHouse, Context, ContextArc, options},
+    interpreter::{
+        ClickHouse, Context, ContextArc, Query, fetch_and_populate_perfetto_trace,
+        fetch_server_perfetto_sources, options, perfetto::PerfettoTraceBuilder,
+    },
     view::Navigation,
 };
 
@@ -39,6 +44,98 @@ fn panic_hook(info: &PanicHookInfo<'_>) {
     );
 }
 
+fn derive_output_path(
+    user_path: Option<&Path>,
+    is_server_scope: bool,
+    query_id: Option<&str>,
+) -> PathBuf {
+    if let Some(p) = user_path {
+        return p.to_path_buf();
+    }
+    if is_server_scope {
+        PathBuf::from("server_perfetto_trace.pftrace")
+    } else {
+        // query_id presence is guaranteed by the !is_server_scope branch in the caller
+        PathBuf::from(format!("{}.pftrace", query_id.unwrap()))
+    }
+}
+
+async fn run_cli_perfetto_export(
+    options: &options::ChDigOptions,
+    clickhouse: &Arc<ClickHouse>,
+) -> Result<()> {
+    let cmd = options
+        .perfetto_command()
+        .expect("run_cli_perfetto_export requires the perfetto export subcommand");
+
+    let perfetto_options = cmd.apply(options.perfetto.clone());
+
+    let is_server_scope = options.view.query_id.is_none();
+    let view_start = options.view.start.clone().into();
+    let view_end = options.view.end.clone().into();
+    let mut scope = match &options.view.query_id {
+        Some(query_id) => {
+            clickhouse
+                .get_perfetto_query_scope(query_id, view_start, view_end)
+                .await?
+        }
+        None => crate::interpreter::clickhouse::PerfettoQueryScope {
+            start: view_start,
+            end: view_end,
+            query_ids: None,
+        },
+    };
+    // Match TUI behavior: include events that arrived in the same second as the query end.
+    scope.end += TimeDelta::seconds(1);
+
+    let query_block = clickhouse
+        .get_queries_for_perfetto(scope.start, scope.end, &scope.query_ids)
+        .await?;
+    let mut queries = Vec::new();
+    for i in 0..query_block.row_count() {
+        match Query::from_clickhouse_block(&query_block, i, false) {
+            Ok(q) => queries.push(q),
+            Err(e) => log::warn!("Perfetto: failed to parse query row {}: {}", i, e),
+        }
+    }
+
+    let mut builder = PerfettoTraceBuilder::new(
+        perfetto_options.per_server,
+        perfetto_options.text_log_android,
+    );
+    builder.add_queries(&queries);
+    fetch_and_populate_perfetto_trace(
+        clickhouse,
+        &mut builder,
+        &perfetto_options,
+        scope.query_ids.as_deref(),
+        scope.start,
+        scope.end,
+    )
+    .await;
+
+    if is_server_scope {
+        fetch_server_perfetto_sources(
+            clickhouse,
+            &mut builder,
+            &perfetto_options,
+            scope.start,
+            scope.end,
+        )
+        .await;
+    }
+
+    let output = derive_output_path(
+        options.view.output.as_deref(),
+        is_server_scope,
+        options.view.query_id.as_deref(),
+    );
+
+    std::fs::write(&output, builder.build())?;
+    println!("Perfetto trace exported to {}", output.display());
+    Ok(())
+}
+
 pub async fn chdig_main_async<I, T>(itr: I) -> Result<()>
 where
     I: IntoIterator<Item = T>,
@@ -60,6 +157,11 @@ where
     // Initialize it before any backends (otherwise backend will prepare terminal for TUI app, and
     // panic hook will clear the screen).
     let clickhouse = Arc::new(ClickHouse::new(options.clickhouse.clone()).await?);
+
+    if options.perfetto_command().is_some() {
+        run_cli_perfetto_export(&options, &clickhouse).await?;
+        return Ok(());
+    }
 
     let server_warnings = match clickhouse.get_warnings().await {
         Ok(w) => w,

--- a/src/interpreter/clickhouse.rs
+++ b/src/interpreter/clickhouse.rs
@@ -49,6 +49,13 @@ pub struct TextLogArguments {
     pub end: RelativeDateTime,
 }
 
+#[derive(Debug, Clone)]
+pub struct PerfettoQueryScope {
+    pub query_ids: Vec<String>,
+    pub start: DateTime<Local>,
+    pub end: DateTime<Local>,
+}
+
 #[derive(Default)]
 pub struct ClickHouseServerCPU {
     pub count: u64,
@@ -1601,6 +1608,48 @@ impl ClickHouse {
                 .as_str(),
             )
             .await;
+    }
+
+    pub async fn get_perfetto_query_scope(&self, query_id: &str) -> Result<PerfettoQueryScope> {
+        let query_log = self.get_table_name("system", "query_log");
+        let query_id_escaped = query_id.replace('\'', "''");
+        let block = self
+            .execute(
+                format!(
+                    r#"
+                    WITH '{query_id}' AS root_query_id
+                    SELECT
+                        groupUniqArray(query_id) AS query_ids,
+                        min(query_start_time_microseconds) AS query_start_time_microseconds,
+                        max(event_time_microseconds) AS query_end_time_microseconds
+                    FROM {query_log}
+                    WHERE
+                        type != 'QueryStart'
+                        AND (query_id = root_query_id OR initial_query_id = root_query_id)
+                    "#,
+                    query_id = query_id_escaped,
+                    query_log = query_log,
+                )
+                .as_str(),
+            )
+            .await?;
+
+        if block.row_count() == 0 {
+            return Err(Error::msg(format!(
+                "Query '{}' was not found in system.query_log",
+                query_id
+            )));
+        }
+
+        return Ok(PerfettoQueryScope {
+            query_ids: block.get(0, "query_ids")?,
+            start: block
+                .get::<DateTime<Tz>, _>(0, "query_start_time_microseconds")?
+                .with_timezone(&Local),
+            end: block
+                .get::<DateTime<Tz>, _>(0, "query_end_time_microseconds")?
+                .with_timezone(&Local),
+        });
     }
 
     pub async fn get_metric_log_for_perfetto(

--- a/src/interpreter/clickhouse.rs
+++ b/src/interpreter/clickhouse.rs
@@ -1578,6 +1578,7 @@ impl ClickHouse {
         &self,
         start: DateTime<Local>,
         end: DateTime<Local>,
+        query_ids: &Option<Vec<String>>
     ) -> Result<Columns> {
         let dbtable = self.get_log_table_name("system", "query_log");
         return self
@@ -1609,6 +1610,7 @@ impl ClickHouse {
                     WHERE type != 'QueryStart'
                       AND event_date >= toDate(start_) AND event_time >= toDateTime(start_)
                       AND event_date <= toDate(end_)   AND event_time <= toDateTime(end_)
+                      {query_ids}
                     "#,
                     start = start
                         .timestamp_nanos_opt()
@@ -1622,6 +1624,11 @@ impl ClickHouse {
                         "peak_threads_usage"
                     } else {
                         "length(thread_ids)"
+                    },
+                    query_ids = if let Some(query_id) = query_ids {
+                        format!("AND query_id IN ('{}')", query_id.join("','"))
+                    } else {
+                        String::new()
                     },
                 )
                 .as_str(),

--- a/src/interpreter/clickhouse.rs
+++ b/src/interpreter/clickhouse.rs
@@ -57,7 +57,7 @@ pub struct TextLogArguments {
 
 #[derive(Debug, Clone)]
 pub struct PerfettoQueryScope {
-    pub query_ids: Vec<String>,
+    pub query_ids: Option<Vec<String>>,
     pub start: DateTime<Local>,
     pub end: DateTime<Local>,
 }
@@ -1660,15 +1660,8 @@ impl ClickHouse {
             )
             .await?;
 
-        if block.row_count() == 0 {
-            return Err(Error::msg(format!(
-                "Query '{}' was not found in system.query_log",
-                query_id
-            )));
-        }
-
         return Ok(PerfettoQueryScope {
-            query_ids: block.get(0, "query_ids")?,
+            query_ids: Some(block.get::<Vec<String>, _>(0, "query_ids")?),
             start: block
                 .get::<DateTime<Tz>, _>(0, "query_start_time_microseconds")?
                 .with_timezone(&Local),

--- a/src/interpreter/clickhouse.rs
+++ b/src/interpreter/clickhouse.rs
@@ -55,6 +55,13 @@ pub struct TextLogArguments {
     pub end: RelativeDateTime,
 }
 
+#[derive(Debug, Clone)]
+pub struct PerfettoQueryScope {
+    pub query_ids: Option<Vec<String>>,
+    pub start: DateTime<Local>,
+    pub end: DateTime<Local>,
+}
+
 #[derive(Default)]
 pub struct ClickHouseServerCPU {
     pub count: u64,
@@ -1589,6 +1596,7 @@ impl ClickHouse {
         &self,
         start: DateTime<Local>,
         end: DateTime<Local>,
+        query_ids: &Option<Vec<String>>,
     ) -> Result<Columns> {
         let dbtable = self.get_log_table_name("system", "query_log");
         return self
@@ -1620,6 +1628,7 @@ impl ClickHouse {
                     WHERE type != 'QueryStart'
                       AND event_date >= toDate(start_) AND event_time >= toDateTime(start_)
                       AND event_date <= toDate(end_)   AND event_time <= toDateTime(end_)
+                      {query_ids}
                     "#,
                     start = start
                         .timestamp_nanos_opt()
@@ -1634,10 +1643,64 @@ impl ClickHouse {
                     } else {
                         "length(thread_ids)"
                     },
+                    query_ids = if let Some(query_id) = query_ids {
+                        format!("AND query_id IN ('{}')", query_id.join("','"))
+                    } else {
+                        String::new()
+                    },
                 )
                 .as_str(),
             )
             .await;
+    }
+
+    pub async fn get_perfetto_query_scope(
+        &self,
+        query_id: &str,
+        start: DateTime<Local>,
+        end: DateTime<Local>,
+    ) -> Result<PerfettoQueryScope> {
+        let query_log = self.get_log_table_name("system", "query_log");
+        let query_id_escaped = query_id.replace('\'', "''");
+        let block = self
+            .execute(
+                format!(
+                    r#"
+                    WITH
+                        '{query_id}' AS root_query_id,
+                        fromUnixTimestamp64Nano({start}) AS start_,
+                        fromUnixTimestamp64Nano({end}) AS end_
+                    SELECT
+                        groupUniqArray(query_id) AS query_ids,
+                        min(query_start_time_microseconds) AS query_start_time_microseconds,
+                        max(event_time_microseconds) AS query_end_time_microseconds
+                    FROM {query_log}
+                    WHERE
+                        type != 'QueryStart'
+                        AND (query_id = root_query_id OR initial_query_id = root_query_id)
+                        AND event_date >= toDate(start_) AND event_time >= toDateTime(start_)
+                        AND event_date <= toDate(end_)   AND event_time <= toDateTime(end_)
+                    "#,
+                    query_id = query_id_escaped,
+                    query_log = query_log,
+                    start = start
+                        .timestamp_nanos_opt()
+                        .ok_or(Error::msg("Invalid start"))?,
+                    end = end.timestamp_nanos_opt().ok_or(Error::msg("Invalid end"))?,
+                )
+                .as_str(),
+            )
+            .await?;
+
+        return Ok(PerfettoQueryScope {
+            query_ids: Some(block.get::<Vec<String>, _>(0, "query_ids")?),
+            start: block
+                .get::<DateTime<Tz>, _>(0, "query_start_time_microseconds")?
+                .with_timezone(&Local),
+            end: block
+                .get::<DateTime<Tz>, _>(0, "query_end_time_microseconds")?
+                .with_timezone(&Local),
+        });
     }
 
     pub async fn get_metric_log_for_perfetto(

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -17,6 +17,7 @@ pub use clickhouse_quirks::ClickHouseQuirks;
 pub use context::Context;
 pub use context::ContextArc;
 pub use worker::Worker;
+pub(crate) use worker::{fetch_and_populate_perfetto_trace, fetch_server_perfetto_sources};
 
 pub type WorkerEvent = worker::Event;
 pub type Query = query::Query;

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -18,6 +18,7 @@ pub use clickhouse_quirks::ClickHouseQuirks;
 pub use context::Context;
 pub use context::ContextArc;
 pub use worker::Worker;
+pub(crate) use worker::{fetch_and_populate_perfetto_trace, fetch_server_perfetto_sources};
 
 pub type WorkerEvent = worker::Event;
 pub type Query = query::Query;

--- a/src/interpreter/options.rs
+++ b/src/interpreter/options.rs
@@ -1518,15 +1518,15 @@ mod tests {
     fn test_perfetto_query_cli_options() {
         let options = parse_from([
             "chdig",
-            "perfetto",
             "--query_id",
             "query-123",
             "--output",
             "/tmp/query.pftrace",
+            "perfetto",
         ])
         .unwrap();
 
-        let cmd = options.perfetto_command().unwrap();
+        let _cmd = options.perfetto_command().unwrap();
         assert_eq!(options.view.query_id.as_deref(), Some("query-123"));
         assert!(!options.view.server);
         assert_eq!(options.view.output.as_deref(), Some("/tmp/query.pftrace"));
@@ -1535,18 +1535,18 @@ mod tests {
     #[test]
     fn test_perfetto_server_cli_options() {
         let options = parse_from([
-            "chdig", "perfetto", "--server", "--start", "10minute", "--end", "5minute",
+            "chdig", "--server", "--start", "10minute", "--end", "5minute", "perfetto",
         ])
         .unwrap();
 
-        let cmd = options.perfetto_command().unwrap();
+        let _cmd = options.perfetto_command().unwrap();
         assert!(options.view.server);
         assert!(options.view.query_id.is_none());
     }
 
     #[test]
     fn test_perfetto_output_requires_export_mode() {
-        let err = match parse_from(["chdig", "perfetto", "--output", "/tmp/out.pftrace"]) {
+        let err = match parse_from(["chdig", "--output", "/tmp/out.pftrace", "perfetto"]) {
             Ok(_) => panic!("expected parse_from() to fail"),
             Err(err) => err,
         };

--- a/src/interpreter/options.rs
+++ b/src/interpreter/options.rs
@@ -154,9 +154,14 @@ pub struct PerfettoCommand {
     pub query_metric_log: bool,
     #[arg(long, action = ArgAction::SetTrue)]
     pub asynchronous_metric_log: bool,
+    #[arg(long, default_value = "true")]
+    pub text_log: bool,
 
     #[arg(long, action = ArgAction::SetTrue)]
     pub all: bool,
+
+    #[arg(long, default_value = "true")]
+    pub track_per_server: bool,
 }
 
 #[derive(Debug, Clone, Subcommand)]
@@ -362,17 +367,12 @@ pub struct ViewOptions {
     pub queries_limit: u64,
 
     /// Specified query_id for commands that support it
-    #[arg(
-        long = "query-id",
-        alias = "query_id",
-        value_name = "QUERY_ID"
-    )]
+    #[arg(long = "query-id", alias = "query_id", value_name = "QUERY_ID")]
     pub query_id: Option<String>,
 
     #[arg(long, short = 'o', value_name = "PATH", default_value = "./")]
     /// Output path for CLI export
     pub output: Option<String>,
-
     // TODO: --mouse/--no-mouse (see EXIT_MOUSE_SEQUENCE in termion)
 }
 
@@ -1537,5 +1537,4 @@ mod tests {
         let _cmd = options.perfetto_command().unwrap();
         assert!(options.view.query_id.is_none());
     }
-
 }

--- a/src/interpreter/options.rs
+++ b/src/interpreter/options.rs
@@ -370,7 +370,7 @@ pub struct ViewOptions {
     pub query_id: Option<String>,
 
     #[arg(long, short = 'o', value_name = "PATH", default_value = "./")]
-    /// Output path for CLI  export
+    /// Output path for CLI export
     pub output: Option<String>,
 
     // TODO: --mouse/--no-mouse (see EXIT_MOUSE_SEQUENCE in termion)

--- a/src/interpreter/options.rs
+++ b/src/interpreter/options.rs
@@ -148,6 +148,15 @@ pub enum ChDigViews {
 
 #[derive(Args, Debug, Clone)]
 pub struct PerfettoCommand {
+    #[arg(long, action = ArgAction::SetTrue)]
+    pub aggregated_zookeeper_log: bool,
+    #[arg(long, action = ArgAction::SetTrue)]
+    pub query_metric_log: bool,
+    #[arg(long, action = ArgAction::SetTrue)]
+    pub asynchronous_metric_log: bool,
+
+    #[arg(long, action = ArgAction::SetTrue)]
+    pub all: bool,
 }
 
 #[derive(Debug, Clone, Subcommand)]
@@ -360,12 +369,8 @@ pub struct ViewOptions {
     )]
     pub query_id: Option<String>,
 
-    #[arg(long, action = ArgAction::SetTrue)]
-    /// Export server-wide Perfetto trace for the specified time window
-    pub server: bool,
-
-    #[arg(long, value_name = "PATH")]
-    /// Output path for CLI Perfetto export
+    #[arg(long, short = 'o', value_name = "PATH", default_value = "./")]
+    /// Output path for CLI  export
     pub output: Option<String>,
 
     // TODO: --mouse/--no-mouse (see EXIT_MOUSE_SEQUENCE in termion)
@@ -1070,15 +1075,6 @@ where
 
     adjust_defaults(&mut options)?;
 
-    if let Some(_cmd) = options.perfetto_command()
-        && options.view.query_id.is_none()
-        && !options.view.server
-    {
-        return Err(anyhow!(
-            "perfetto command requires --query-id/--query_id or --server"
-        ));
-    }
-
     return Ok(options);
 }
 
@@ -1528,31 +1524,18 @@ mod tests {
 
         let _cmd = options.perfetto_command().unwrap();
         assert_eq!(options.view.query_id.as_deref(), Some("query-123"));
-        assert!(!options.view.server);
         assert_eq!(options.view.output.as_deref(), Some("/tmp/query.pftrace"));
     }
 
     #[test]
     fn test_perfetto_server_cli_options() {
         let options = parse_from([
-            "chdig", "--server", "--start", "10minute", "--end", "5minute", "perfetto",
+            "chdig", "--start", "10minute", "--end", "5minute", "perfetto",
         ])
         .unwrap();
 
         let _cmd = options.perfetto_command().unwrap();
-        assert!(options.view.server);
         assert!(options.view.query_id.is_none());
     }
 
-    #[test]
-    fn test_perfetto_output_requires_export_mode() {
-        let err = match parse_from(["chdig", "--output", "/tmp/out.pftrace", "perfetto"]) {
-            Ok(_) => panic!("expected parse_from() to fail"),
-            Err(err) => err,
-        };
-        assert_eq!(
-            err.to_string(),
-            "perfetto command requires --query-id/--query_id or --server"
-        );
-    }
 }

--- a/src/interpreter/options.rs
+++ b/src/interpreter/options.rs
@@ -146,6 +146,87 @@ pub enum ChDigViews {
     Client,
 }
 
+#[derive(Args, Debug, Clone)]
+pub struct PerfettoCommand {
+    #[arg(long, action = ArgAction::SetTrue, conflicts_with = "query_id")]
+    /// Export server-wide Perfetto trace for the specified time window
+    pub server: bool,
+    #[arg(
+        long = "query-id",
+        alias = "query_id",
+        value_name = "QUERY_ID",
+        conflicts_with = "server"
+    )]
+    /// Export query-scoped Perfetto trace for the specified query_id
+    pub query_id: Option<String>,
+    #[arg(long, value_name = "PATH")]
+    /// Output path for CLI Perfetto export
+    pub output: Option<String>,
+    #[arg(long, short('b'), default_value = "1hour")]
+    /// Begin of the time interval to look at (used with --server)
+    pub start: RelativeDateTime,
+    #[arg(long, short('e'), default_value = "")]
+    /// End of the time interval (used with --server)
+    pub end: RelativeDateTime,
+}
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum ChDigCommand {
+    Queries,
+    LastQueries,
+    SlowQueries,
+    Merges,
+    S3Queue,
+    AzureQueue,
+    Mutations,
+    ReplicationQueue,
+    ReplicatedFetches,
+    Replicas,
+    Tables,
+    Errors,
+    Backups,
+    Dictionaries,
+    ServerLogs,
+    Loggers,
+    BackgroundSchedulePool,
+    BackgroundSchedulePoolLog,
+    TableParts,
+    AsynchronousInserts,
+    PartLog,
+    Client,
+    Perfetto(PerfettoCommand),
+}
+
+impl ChDigCommand {
+    pub fn as_view(&self) -> Option<ChDigViews> {
+        match self {
+            ChDigCommand::Queries => Some(ChDigViews::Queries),
+            ChDigCommand::LastQueries => Some(ChDigViews::LastQueries),
+            ChDigCommand::SlowQueries => Some(ChDigViews::SlowQueries),
+            ChDigCommand::Merges => Some(ChDigViews::Merges),
+            ChDigCommand::S3Queue => Some(ChDigViews::S3Queue),
+            ChDigCommand::AzureQueue => Some(ChDigViews::AzureQueue),
+            ChDigCommand::Mutations => Some(ChDigViews::Mutations),
+            ChDigCommand::ReplicationQueue => Some(ChDigViews::ReplicationQueue),
+            ChDigCommand::ReplicatedFetches => Some(ChDigViews::ReplicatedFetches),
+            ChDigCommand::Replicas => Some(ChDigViews::Replicas),
+            ChDigCommand::Tables => Some(ChDigViews::Tables),
+            ChDigCommand::Errors => Some(ChDigViews::Errors),
+            ChDigCommand::Backups => Some(ChDigViews::Backups),
+            ChDigCommand::Dictionaries => Some(ChDigViews::Dictionaries),
+            ChDigCommand::ServerLogs => Some(ChDigViews::ServerLogs),
+            ChDigCommand::Loggers => Some(ChDigViews::Loggers),
+            ChDigCommand::BackgroundSchedulePool => Some(ChDigViews::BackgroundSchedulePool),
+            ChDigCommand::BackgroundSchedulePoolLog => Some(ChDigViews::BackgroundSchedulePoolLog),
+            ChDigCommand::TableParts => Some(ChDigViews::TableParts),
+            ChDigCommand::AsynchronousInserts => Some(ChDigViews::AsynchronousInserts),
+            ChDigCommand::PartLog => Some(ChDigViews::PartLog),
+            ChDigCommand::Client => Some(ChDigViews::Client),
+            ChDigCommand::Perfetto(_) => None,
+        }
+    }
+}
+
 #[derive(Parser, Clone)]
 #[command(name = "chdig")]
 #[command(author, version, about, long_about = None)]
@@ -155,11 +236,24 @@ pub struct ChDigOptions {
     #[command(flatten)]
     pub view: ViewOptions,
     #[command(subcommand)]
-    pub start_view: Option<ChDigViews>,
+    pub command: Option<ChDigCommand>,
     #[command(flatten)]
     pub service: ServiceOptions,
     #[clap(skip)]
     pub perfetto: ChDigPerfettoConfig,
+}
+
+impl ChDigOptions {
+    pub fn start_view(&self) -> Option<ChDigViews> {
+        self.command.as_ref().and_then(ChDigCommand::as_view)
+    }
+
+    pub fn perfetto_command(&self) -> Option<&PerfettoCommand> {
+        match &self.command {
+            Some(ChDigCommand::Perfetto(cmd)) => Some(cmd),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Args, Clone, Default)]
@@ -954,6 +1048,15 @@ where
 
     adjust_defaults(&mut options)?;
 
+    if let Some(cmd) = options.perfetto_command()
+        && cmd.query_id.is_none()
+        && !cmd.server
+    {
+        return Err(anyhow!(
+            "perfetto command requires --query-id/--query_id or --server"
+        ));
+    }
+
     return Ok(options);
 }
 
@@ -1384,6 +1487,48 @@ mod tests {
         assert_eq!(
             options.view.delay_interval,
             time::Duration::from_millis(5000)
+        );
+    }
+
+    #[test]
+    fn test_perfetto_query_cli_options() {
+        let options = parse_from([
+            "chdig",
+            "perfetto",
+            "--query_id",
+            "query-123",
+            "--output",
+            "/tmp/query.pftrace",
+        ])
+        .unwrap();
+
+        let cmd = options.perfetto_command().unwrap();
+        assert_eq!(cmd.query_id.as_deref(), Some("query-123"));
+        assert!(!cmd.server);
+        assert_eq!(cmd.output.as_deref(), Some("/tmp/query.pftrace"));
+    }
+
+    #[test]
+    fn test_perfetto_server_cli_options() {
+        let options = parse_from([
+            "chdig", "perfetto", "--server", "--start", "10minute", "--end", "5minute",
+        ])
+        .unwrap();
+
+        let cmd = options.perfetto_command().unwrap();
+        assert!(cmd.server);
+        assert!(cmd.query_id.is_none());
+    }
+
+    #[test]
+    fn test_perfetto_output_requires_export_mode() {
+        let err = match parse_from(["chdig", "perfetto", "--output", "/tmp/out.pftrace"]) {
+            Ok(_) => panic!("expected parse_from() to fail"),
+            Err(err) => err,
+        };
+        assert_eq!(
+            err.to_string(),
+            "perfetto command requires --query-id/--query_id or --server"
         );
     }
 }

--- a/src/interpreter/options.rs
+++ b/src/interpreter/options.rs
@@ -148,26 +148,6 @@ pub enum ChDigViews {
 
 #[derive(Args, Debug, Clone)]
 pub struct PerfettoCommand {
-    #[arg(long, action = ArgAction::SetTrue, conflicts_with = "query_id")]
-    /// Export server-wide Perfetto trace for the specified time window
-    pub server: bool,
-    #[arg(
-        long = "query-id",
-        alias = "query_id",
-        value_name = "QUERY_ID",
-        conflicts_with = "server"
-    )]
-    /// Export query-scoped Perfetto trace for the specified query_id
-    pub query_id: Option<String>,
-    #[arg(long, value_name = "PATH")]
-    /// Output path for CLI Perfetto export
-    pub output: Option<String>,
-    #[arg(long, short('b'), default_value = "1hour")]
-    /// Begin of the time interval to look at (used with --server)
-    pub start: RelativeDateTime,
-    #[arg(long, short('e'), default_value = "")]
-    /// End of the time interval (used with --server)
-    pub end: RelativeDateTime,
 }
 
 #[derive(Debug, Clone, Subcommand)]
@@ -254,6 +234,7 @@ impl ChDigOptions {
             _ => None,
         }
     }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, ValueEnum, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -370,6 +351,23 @@ pub struct ViewOptions {
     /// Limit for number of queries to render in queries views
     #[arg(long, default_value_t = 10000)]
     pub queries_limit: u64,
+
+    /// Specified query_id for commands that support it
+    #[arg(
+        long = "query-id",
+        alias = "query_id",
+        value_name = "QUERY_ID"
+    )]
+    pub query_id: Option<String>,
+
+    #[arg(long, action = ArgAction::SetTrue)]
+    /// Export server-wide Perfetto trace for the specified time window
+    pub server: bool,
+
+    #[arg(long, value_name = "PATH")]
+    /// Output path for CLI Perfetto export
+    pub output: Option<String>,
+
     // TODO: --mouse/--no-mouse (see EXIT_MOUSE_SEQUENCE in termion)
 }
 
@@ -1072,9 +1070,9 @@ where
 
     adjust_defaults(&mut options)?;
 
-    if let Some(cmd) = options.perfetto_command()
-        && cmd.query_id.is_none()
-        && !cmd.server
+    if let Some(_cmd) = options.perfetto_command()
+        && options.view.query_id.is_none()
+        && !options.view.server
     {
         return Err(anyhow!(
             "perfetto command requires --query-id/--query_id or --server"
@@ -1529,9 +1527,9 @@ mod tests {
         .unwrap();
 
         let cmd = options.perfetto_command().unwrap();
-        assert_eq!(cmd.query_id.as_deref(), Some("query-123"));
-        assert!(!cmd.server);
-        assert_eq!(cmd.output.as_deref(), Some("/tmp/query.pftrace"));
+        assert_eq!(options.view.query_id.as_deref(), Some("query-123"));
+        assert!(!options.view.server);
+        assert_eq!(options.view.output.as_deref(), Some("/tmp/query.pftrace"));
     }
 
     #[test]
@@ -1542,8 +1540,8 @@ mod tests {
         .unwrap();
 
         let cmd = options.perfetto_command().unwrap();
-        assert!(cmd.server);
-        assert!(cmd.query_id.is_none());
+        assert!(options.view.server);
+        assert!(options.view.query_id.is_none());
     }
 
     #[test]

--- a/src/interpreter/options.rs
+++ b/src/interpreter/options.rs
@@ -146,6 +146,89 @@ pub enum ChDigViews {
     Client,
 }
 
+/// Generate `PerfettoCommand` (clap `--<name>` / `--no-<name>` flag pairs) and its
+/// `apply()` method from a single list of `(field, no_field)` identifiers. Each pair
+/// maps 1:1 to a field on `ChDigPerfettoConfig`; if neither flag is given the default
+/// from `ChDigPerfettoConfig::default()` (or the YAML config) is kept.
+///
+/// Coverage is enforced at compile time: `apply()` builds `ChDigPerfettoConfig` with
+/// an exhaustive struct literal (no `..base`), so a field added to the config without
+/// a matching row here fails with E0063, and a misspelled row fails with E0560.
+macro_rules! perfetto_flags {
+    ( $( ($name:ident, $no_name:ident) ),+ $(,)? ) => {
+        #[derive(Args, Debug, Clone, Default)]
+        pub struct PerfettoCommand {
+            $(
+                #[arg(long, overrides_with = stringify!($no_name), action = ArgAction::SetTrue)]
+                pub $name: bool,
+                #[arg(long, overrides_with = stringify!($name), action = ArgAction::SetTrue)]
+                pub $no_name: bool,
+            )+
+        }
+
+        impl PerfettoCommand {
+            /// Resolve a `--foo`/`--no-foo` pair against a base value.
+            #[inline]
+            fn pick(on: bool, off: bool, base: bool) -> bool {
+                if on { true } else if off { false } else { base }
+            }
+
+            /// Merge CLI flags into `base` (config-file values or `Default`).
+            pub fn apply(&self, base: ChDigPerfettoConfig) -> ChDigPerfettoConfig {
+                ChDigPerfettoConfig {
+                    $( $name: Self::pick(self.$name, self.$no_name, base.$name), )+
+                }
+            }
+        }
+    };
+}
+
+perfetto_flags! {
+    (opentelemetry_span_log,       no_opentelemetry_span_log),
+    (trace_log,                    no_trace_log),
+    (query_metric_log,             no_query_metric_log),
+    (part_log,                     no_part_log),
+    (query_thread_log,             no_query_thread_log),
+    (text_log,                     no_text_log),
+    (text_log_android,             no_text_log_android),
+    (per_server,                   no_per_server),
+    (metric_log,                   no_metric_log),
+    (asynchronous_metric_log,      no_asynchronous_metric_log),
+    (asynchronous_insert_log,      no_asynchronous_insert_log),
+    (error_log,                    no_error_log),
+    (s3_queue_log,                 no_s3_queue_log),
+    (azure_queue_log,              no_azure_queue_log),
+    (blob_storage_log,             no_blob_storage_log),
+    (background_schedule_pool_log, no_background_schedule_pool_log),
+    (session_log,                  no_session_log),
+    (aggregated_zookeeper_log,     no_aggregated_zookeeper_log),
+}
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum ExportCommand {
+    /// Export Perfetto trace
+    Perfetto(PerfettoCommand),
+}
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum ChDigCommand {
+    /// Open a TUI view (default)
+    #[command(subcommand)]
+    View(ChDigViews),
+    /// Export data in various formats
+    #[command(subcommand)]
+    Export(ExportCommand),
+}
+
+impl ChDigCommand {
+    pub fn as_view(&self) -> Option<ChDigViews> {
+        match self {
+            ChDigCommand::View(v) => Some(*v),
+            ChDigCommand::Export(_) => None,
+        }
+    }
+}
+
 #[derive(Parser, Clone)]
 #[command(name = "chdig")]
 #[command(author, version, about, long_about = None)]
@@ -155,11 +238,24 @@ pub struct ChDigOptions {
     #[command(flatten)]
     pub view: ViewOptions,
     #[command(subcommand)]
-    pub start_view: Option<ChDigViews>,
+    pub command: Option<ChDigCommand>,
     #[command(flatten)]
     pub service: ServiceOptions,
     #[clap(skip)]
     pub perfetto: ChDigPerfettoConfig,
+}
+
+impl ChDigOptions {
+    pub fn start_view(&self) -> Option<ChDigViews> {
+        self.command.as_ref().and_then(ChDigCommand::as_view)
+    }
+
+    pub fn perfetto_command(&self) -> Option<&PerfettoCommand> {
+        match &self.command {
+            Some(ChDigCommand::Export(ExportCommand::Perfetto(cmd))) => Some(cmd),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, ValueEnum, Deserialize)]
@@ -292,6 +388,14 @@ pub struct ViewOptions {
     /// Limit for number of queries to render in queries views
     #[arg(long, default_value_t = 10000)]
     pub queries_limit: u64,
+
+    /// Specified query_id for commands that support it
+    #[arg(long = "query-id", alias = "query_id", value_name = "QUERY_ID")]
+    pub query_id: Option<String>,
+
+    /// Output path for CLI export (derived automatically when omitted)
+    #[arg(long, short = 'o', value_name = "PATH")]
+    pub output: Option<path::PathBuf>,
 
     /// Columns to show in queries views, in display order (labels match table headers,
     /// e.g. "io_wait", "net"). Defaults to all columns; "host" is still gated on
@@ -1438,5 +1542,74 @@ mod tests {
             options.view.delay_interval,
             time::Duration::from_millis(5000)
         );
+    }
+
+    #[test]
+    fn test_perfetto_query_cli_options() {
+        let options = parse_from([
+            "chdig",
+            "--query_id",
+            "query-123",
+            "--output",
+            "/tmp/query.pftrace",
+            "export",
+            "perfetto",
+        ])
+        .unwrap();
+
+        let _cmd = options.perfetto_command().unwrap();
+        assert_eq!(options.view.query_id.as_deref(), Some("query-123"));
+        assert_eq!(
+            options.view.output.as_deref(),
+            Some(path::Path::new("/tmp/query.pftrace")),
+        );
+    }
+
+    #[test]
+    fn test_perfetto_server_cli_options() {
+        let options = parse_from([
+            "chdig", "--start", "10minute", "--end", "5minute", "export", "perfetto",
+        ])
+        .unwrap();
+
+        let _cmd = options.perfetto_command().unwrap();
+        assert!(options.view.query_id.is_none());
+    }
+
+    #[test]
+    fn test_perfetto_flag_pairs() {
+        // No flag → inherit defaults.
+        let options = parse_from(["chdig", "export", "perfetto"]).unwrap();
+        let cfg = options
+            .perfetto_command()
+            .unwrap()
+            .apply(ChDigPerfettoConfig::default());
+        assert_eq!(cfg.text_log, true);
+        assert_eq!(cfg.query_metric_log, false);
+
+        // --no-text-log turns off a default-true field.
+        let options = parse_from(["chdig", "export", "perfetto", "--no-text-log"]).unwrap();
+        let cfg = options
+            .perfetto_command()
+            .unwrap()
+            .apply(ChDigPerfettoConfig::default());
+        assert_eq!(cfg.text_log, false);
+
+        // --query-metric-log turns on a default-false field.
+        let options = parse_from(["chdig", "export", "perfetto", "--query-metric-log"]).unwrap();
+        let cfg = options
+            .perfetto_command()
+            .unwrap()
+            .apply(ChDigPerfettoConfig::default());
+        assert_eq!(cfg.query_metric_log, true);
+
+        // Last of --foo/--no-foo wins (overrides_with).
+        let options =
+            parse_from(["chdig", "export", "perfetto", "--no-text-log", "--text-log"]).unwrap();
+        let cfg = options
+            .perfetto_command()
+            .unwrap()
+            .apply(ChDigPerfettoConfig::default());
+        assert_eq!(cfg.text_log, true);
     }
 }

--- a/src/interpreter/worker.rs
+++ b/src/interpreter/worker.rs
@@ -347,7 +347,7 @@ async fn render_or_share_flamegraph(
 
 use crate::interpreter::options::ChDigPerfettoConfig;
 
-async fn fetch_and_populate_perfetto_trace(
+pub(crate) async fn fetch_and_populate_perfetto_trace(
     clickhouse: &Arc<ClickHouse>,
     builder: &mut PerfettoTraceBuilder,
     cfg: &ChDigPerfettoConfig,
@@ -472,7 +472,7 @@ async fn fetch_and_populate_perfetto_trace(
     }
 }
 
-async fn fetch_server_perfetto_sources(
+pub(crate) async fn fetch_server_perfetto_sources(
     clickhouse: &Arc<ClickHouse>,
     builder: &mut PerfettoTraceBuilder,
     cfg: &ChDigPerfettoConfig,

--- a/src/interpreter/worker.rs
+++ b/src/interpreter/worker.rs
@@ -1209,7 +1209,7 @@ async fn process_event(context: ContextArc, event: Event, need_clear: &mut bool)
         }
         Event::ServerPerfettoExport(start, end) => {
             let perfetto_cfg = context.lock().unwrap().options.perfetto.clone();
-            let query_block = clickhouse.get_queries_for_perfetto(start, end).await?;
+            let query_block = clickhouse.get_queries_for_perfetto(start, end, &None).await?;
             let mut queries = Vec::new();
             for i in 0..query_block.row_count() {
                 match Query::from_clickhouse_block(&query_block, i, false) {

--- a/src/interpreter/worker.rs
+++ b/src/interpreter/worker.rs
@@ -365,7 +365,7 @@ async fn render_or_share_flamegraph(
 
 use crate::interpreter::options::ChDigPerfettoConfig;
 
-async fn fetch_and_populate_perfetto_trace(
+pub(crate) async fn fetch_and_populate_perfetto_trace(
     clickhouse: &Arc<ClickHouse>,
     builder: &mut PerfettoTraceBuilder,
     cfg: &ChDigPerfettoConfig,
@@ -490,7 +490,7 @@ async fn fetch_and_populate_perfetto_trace(
     }
 }
 
-async fn fetch_server_perfetto_sources(
+pub(crate) async fn fetch_server_perfetto_sources(
     clickhouse: &Arc<ClickHouse>,
     builder: &mut PerfettoTraceBuilder,
     cfg: &ChDigPerfettoConfig,
@@ -1209,7 +1209,9 @@ async fn process_event(context: ContextArc, event: Event, need_clear: &mut bool)
         }
         Event::ServerPerfettoExport(start, end) => {
             let perfetto_cfg = context.lock().unwrap().options.perfetto.clone();
-            let query_block = clickhouse.get_queries_for_perfetto(start, end).await?;
+            let query_block = clickhouse
+                .get_queries_for_perfetto(start, end, &None)
+                .await?;
             let mut queries = Vec::new();
             for i in 0..query_block.row_count() {
                 match Query::from_clickhouse_block(&query_block, i, false) {

--- a/src/view/navigation.rs
+++ b/src/view/navigation.rs
@@ -1204,7 +1204,7 @@ impl Navigation for Cursive {
 
                                     context
                                         .current_view
-                                        .or(context.options.start_view)
+                                        .or(context.options.start_view())
                                         .unwrap_or(ChDigViews::Queries)
                                 };
 

--- a/src/view/navigation.rs
+++ b/src/view/navigation.rs
@@ -258,7 +258,7 @@ impl Navigation for Cursive {
             .lock()
             .unwrap()
             .options
-            .start_view
+            .start_view()
             .unwrap_or(ChDigViews::Queries);
 
         let provider = context
@@ -760,7 +760,7 @@ impl Navigation for Cursive {
 
                                     context
                                         .current_view
-                                        .or(context.options.start_view)
+                                        .or(context.options.start_view())
                                         .unwrap_or(ChDigViews::Queries)
                                 };
 

--- a/src/view/navigation.rs
+++ b/src/view/navigation.rs
@@ -245,7 +245,7 @@ impl Navigation for Cursive {
             .lock()
             .unwrap()
             .options
-            .start_view
+            .start_view()
             .unwrap_or(ChDigViews::Queries);
 
         let provider = context
@@ -1142,7 +1142,7 @@ impl Navigation for Cursive {
                                 // Get current view name to re-open it
                                 context
                                     .current_view
-                                    .or(context.options.start_view)
+                                    .or(context.options.start_view())
                                     .unwrap_or(ChDigViews::Queries)
                             };
 

--- a/src/view/settings_view.rs
+++ b/src/view/settings_view.rs
@@ -221,7 +221,7 @@ fn apply_settings(siv: &mut Cursive, context: &ContextArc) {
         let ctx = context.lock().unwrap();
         let current_view = ctx
             .current_view
-            .or(ctx.options.start_view)
+            .or(ctx.options.start_view())
             .unwrap_or(ChDigViews::Queries);
         (
             ctx.view_registry.get_by_view_type(current_view),


### PR DESCRIPTION
Adds `chdig export perfetto` to generate trace files without the TUI - useful for testing different perfetto versions and for sharing traces for research/debugging.

_Also, idea is to make "chdig" as togo tool for making exports for research/debug purposes_