### PR TITLE
Add --database to read system tables from a custom database

### DIFF
--- a/src/interpreter/clickhouse.rs
+++ b/src/interpreter/clickhouse.rs
@@ -275,7 +275,7 @@ impl ClickHouse {
         limit: u64,
         selected_host: Option<&String>,
     ) -> Result<Columns> {
-        let dbtable = self.get_log_table_name("system", "query_log");
+        let dbtable = self.get_log_table_name("query_log");
         let host_filter = self.get_log_host_filter_clause(selected_host);
         return self
             .execute(
@@ -361,7 +361,7 @@ impl ClickHouse {
         // TODO:
         // - propagate sort order from the table
         // - distributed_group_by_no_merge=2 is broken for this query with WINDOW function
-        let dbtable = self.get_log_table_name("system", "query_log");
+        let dbtable = self.get_log_table_name("query_log");
         let host_filter = self.get_log_host_filter_clause(selected_host);
         return self
             .execute(
@@ -440,7 +440,7 @@ impl ClickHouse {
         limit: u64,
         selected_host: Option<&String>,
     ) -> Result<Columns> {
-        let dbtable = self.get_table_name_no_history("system", "processes");
+        let dbtable = self.get_table_name_no_history("processes");
         let host_filter = self.get_host_filter_clause(selected_host);
         return self
             .execute(
@@ -521,7 +521,7 @@ impl ClickHouse {
         };
 
         let memory_index_granularity_trait = if self.quirks.has(ClickHouseAvailableQuirks::AsynchronousMetricsTotalIndexGranularityBytesInMemoryAllocated) {
-            format!("(SELECT sum(index_granularity_bytes_in_memory_allocated) FROM {}{}) AS memory_index_granularity_", self.get_table_name_no_history("system", "parts"), host_where)
+            format!("(SELECT sum(index_granularity_bytes_in_memory_allocated) FROM {}{}) AS memory_index_granularity_", self.get_table_name_no_history("parts"), host_where)
         } else {
             "0::UInt64 AS memory_index_granularity_".to_string()
         };
@@ -697,16 +697,16 @@ impl ClickHouse {
                     ) as metrics
                     SETTINGS enable_global_with_statement=0
                 "#,
-                    metrics=self.get_table_name_no_history("system", "metrics"),
-                    events=self.get_table_name_no_history("system", "events"),
-                    tables=self.get_table_name_no_history("system", "tables"),
-                    processes=self.get_table_name_no_history("system", "processes"),
-                    merges=self.get_table_name_no_history("system", "merges"),
-                    async_inserts=self.get_table_name_no_history("system", "asynchronous_inserts"),
-                    replication_queue=self.get_table_name_no_history("system", "replication_queue"),
-                    dictionaries=self.get_table_name_no_history("system", "dictionaries"),
-                    asynchronous_metrics=self.get_table_name_no_history("system", "asynchronous_metrics"),
-                    one=self.get_table_name_no_history("system", "one"),
+                    metrics=self.get_table_name_no_history("metrics"),
+                    events=self.get_table_name_no_history("events"),
+                    tables=self.get_table_name_no_history("tables"),
+                    processes=self.get_table_name_no_history("processes"),
+                    merges=self.get_table_name_no_history("merges"),
+                    async_inserts=self.get_table_name_no_history("asynchronous_inserts"),
+                    replication_queue=self.get_table_name_no_history("replication_queue"),
+                    dictionaries=self.get_table_name_no_history("dictionaries"),
+                    asynchronous_metrics=self.get_table_name_no_history("asynchronous_metrics"),
+                    one=self.get_table_name_no_history("one"),
 
                     memory_index_granularity_trait=memory_index_granularity_trait,
                     host_filter_where=host_where,
@@ -931,7 +931,7 @@ impl ClickHouse {
         //   a) they are pretty complex
         //   b) it does not work in case we monitor the whole cluster
 
-        let dbtable = self.get_log_table_name("system", "text_log");
+        let dbtable = self.get_log_table_name("text_log");
         let order = if self.options.logs_order == LogsOrder::Desc {
             "DESC"
         } else {
@@ -1012,7 +1012,7 @@ impl ClickHouse {
         end_microseconds: Option<DateTime<Local>>,
         selected_host: Option<&String>,
     ) -> Result<Columns> {
-        let dbtable = self.get_log_table_name("system", "trace_log");
+        let dbtable = self.get_log_table_name("trace_log");
         let host_filter = self.get_log_host_filter_clause(selected_host);
         return self
             .execute(&format!(
@@ -1089,7 +1089,7 @@ impl ClickHouse {
     /// Return jemalloc flamegraph in pyspy format.
     /// It is the same format as TSV, but with ' ' delimiter between symbols and weight.
     pub async fn get_jemalloc_flamegraph(&self, selected_host: Option<&String>) -> Result<Columns> {
-        let dbtable = self.get_table_name("system", "jemalloc_profile_text");
+        let dbtable = self.get_table_name("jemalloc_profile_text");
         let host_filter = if let Some(host) = selected_host {
             if !host.is_empty() && self.options.cluster.is_some() {
                 format!("AND hostName() = '{}'", host.replace('\'', "''"))
@@ -1120,7 +1120,7 @@ impl ClickHouse {
         query_ids: &Option<Vec<String>>,
         selected_host: Option<&String>,
     ) -> Result<Columns> {
-        let dbtable = self.get_table_name_no_history("system", "stack_trace");
+        let dbtable = self.get_table_name_no_history("stack_trace");
         let host_filter = self.get_host_filter_clause(selected_host);
         let where_clause = match (query_ids.as_ref(), host_filter.is_empty()) {
             (Some(v), true) => format!("query_id IN ('{}')", v.join("','")),
@@ -1156,7 +1156,7 @@ impl ClickHouse {
         end: RelativeDateTime,
         selected_host: Option<&String>,
     ) -> Result<Vec<String>> {
-        let dbtable = self.get_log_table_name("system", "background_schedule_pool_log");
+        let dbtable = self.get_log_table_name("background_schedule_pool_log");
 
         let start_sql = start
             .to_sql_datetime_64()
@@ -1230,7 +1230,7 @@ impl ClickHouse {
         start: DateTime<Local>,
         end: DateTime<Local>,
     ) -> Result<Columns> {
-        let dbtable = self.get_log_table_name("system", "opentelemetry_span_log");
+        let dbtable = self.get_log_table_name("opentelemetry_span_log");
         let start_us = start.timestamp_micros();
         let end_us = end.timestamp_micros();
         let query_id_filter = if let Some(ids) = query_ids {
@@ -1270,7 +1270,7 @@ impl ClickHouse {
         start: DateTime<Local>,
         end: DateTime<Local>,
     ) -> Result<Columns> {
-        let dbtable = self.get_log_table_name("system", "trace_log");
+        let dbtable = self.get_log_table_name("trace_log");
         let query_id_filter = if let Some(ids) = query_ids {
             format!("AND query_id IN ('{}')", ids.join("','"))
         } else {
@@ -1312,7 +1312,7 @@ impl ClickHouse {
         start: DateTime<Local>,
         end: DateTime<Local>,
     ) -> Result<Vec<QueryMetricRow>> {
-        let dbtable = self.get_log_table_name("system", "query_metric_log");
+        let dbtable = self.get_log_table_name("query_metric_log");
         let query_id_filter = if let Some(ids) = query_ids {
             format!("AND query_id IN ('{}')", ids.join("','"))
         } else {
@@ -1393,7 +1393,7 @@ impl ClickHouse {
         start: DateTime<Local>,
         end: DateTime<Local>,
     ) -> Result<Columns> {
-        let dbtable = self.get_log_table_name("system", "part_log");
+        let dbtable = self.get_log_table_name("part_log");
         let query_id_filter = if let Some(ids) = query_ids {
             format!("AND query_id IN ('{}')", ids.join("','"))
         } else {
@@ -1440,7 +1440,7 @@ impl ClickHouse {
         start: DateTime<Local>,
         end: DateTime<Local>,
     ) -> Result<Columns> {
-        let dbtable = self.get_log_table_name("system", "trace_log");
+        let dbtable = self.get_log_table_name("trace_log");
         let symbol_expr = if self
             .quirks
             .has(ClickHouseAvailableQuirks::TraceLogHasSymbols)
@@ -1496,7 +1496,7 @@ impl ClickHouse {
         start: DateTime<Local>,
         end: DateTime<Local>,
     ) -> Result<Columns> {
-        let dbtable = self.get_log_table_name("system", "text_log");
+        let dbtable = self.get_log_table_name("text_log");
         let query_id_filter = if let Some(ids) = query_ids {
             format!("AND query_id IN ('{}')", ids.join("','"))
         } else {
@@ -1539,7 +1539,7 @@ impl ClickHouse {
         start: DateTime<Local>,
         end: DateTime<Local>,
     ) -> Result<Columns> {
-        let dbtable = self.get_log_table_name("system", "query_thread_log");
+        let dbtable = self.get_log_table_name("query_thread_log");
         let query_id_filter = if let Some(ids) = query_ids {
             format!("AND query_id IN ('{}')", ids.join("','"))
         } else {
@@ -1584,7 +1584,7 @@ impl ClickHouse {
         end: DateTime<Local>,
         query_ids: &Option<Vec<String>>,
     ) -> Result<Columns> {
-        let dbtable = self.get_log_table_name("system", "query_log");
+        let dbtable = self.get_log_table_name("query_log");
         return self
             .execute(
                 format!(
@@ -1646,7 +1646,7 @@ impl ClickHouse {
         start: DateTime<Local>,
         end: DateTime<Local>,
     ) -> Result<PerfettoQueryScope> {
-        let query_log = self.get_log_table_name("system", "query_log");
+        let query_log = self.get_log_table_name("query_log");
         let query_id_escaped = query_id.replace('\'', "''");
         let block = self
             .execute(
@@ -1694,7 +1694,7 @@ impl ClickHouse {
         start: DateTime<Local>,
         end: DateTime<Local>,
     ) -> Result<Vec<MetricLogRow>> {
-        let dbtable = self.get_log_table_name("system", "metric_log");
+        let dbtable = self.get_log_table_name("metric_log");
         let block = self
             .execute(&format!(
                 r#"
@@ -1775,7 +1775,7 @@ impl ClickHouse {
         start: DateTime<Local>,
         end: DateTime<Local>,
     ) -> Result<Columns> {
-        let dbtable = self.get_log_table_name("system", "asynchronous_metric_log");
+        let dbtable = self.get_log_table_name("asynchronous_metric_log");
         return self
             .execute(&format!(
                 r#"
@@ -1807,7 +1807,7 @@ impl ClickHouse {
         start: DateTime<Local>,
         end: DateTime<Local>,
     ) -> Result<Columns> {
-        let dbtable = self.get_log_table_name("system", "asynchronous_insert_log");
+        let dbtable = self.get_log_table_name("asynchronous_insert_log");
         return self
             .execute(&format!(
                 r#"
@@ -1844,7 +1844,7 @@ impl ClickHouse {
         start: DateTime<Local>,
         end: DateTime<Local>,
     ) -> Result<Columns> {
-        let dbtable = self.get_log_table_name("system", "error_log");
+        let dbtable = self.get_log_table_name("error_log");
         return self
             .execute(&format!(
                 r#"
@@ -1878,7 +1878,7 @@ impl ClickHouse {
         start: DateTime<Local>,
         end: DateTime<Local>,
     ) -> Result<Columns> {
-        let dbtable = self.get_log_table_name("system", "s3queue_log");
+        let dbtable = self.get_log_table_name("s3queue_log");
         return self
             .execute(&format!(
                 r#"
@@ -1908,7 +1908,7 @@ impl ClickHouse {
         start: DateTime<Local>,
         end: DateTime<Local>,
     ) -> Result<Columns> {
-        let dbtable = self.get_log_table_name("system", "azure_queue_log");
+        let dbtable = self.get_log_table_name("azure_queue_log");
         return self
             .execute(&format!(
                 r#"
@@ -1940,7 +1940,7 @@ impl ClickHouse {
         start: DateTime<Local>,
         end: DateTime<Local>,
     ) -> Result<Columns> {
-        let dbtable = self.get_log_table_name("system", "blob_storage_log");
+        let dbtable = self.get_log_table_name("blob_storage_log");
         return self
             .execute(&format!(
                 r#"
@@ -1976,7 +1976,7 @@ impl ClickHouse {
         start: DateTime<Local>,
         end: DateTime<Local>,
     ) -> Result<Columns> {
-        let dbtable = self.get_log_table_name("system", "background_schedule_pool_log");
+        let dbtable = self.get_log_table_name("background_schedule_pool_log");
         return self
             .execute(&format!(
                 r#"
@@ -2012,7 +2012,7 @@ impl ClickHouse {
         start: DateTime<Local>,
         end: DateTime<Local>,
     ) -> Result<Columns> {
-        let dbtable = self.get_log_table_name("system", "session_log");
+        let dbtable = self.get_log_table_name("session_log");
         return self
             .execute(&format!(
                 r#"
@@ -2049,7 +2049,7 @@ impl ClickHouse {
         start: DateTime<Local>,
         end: DateTime<Local>,
     ) -> Result<Columns> {
-        let dbtable = self.get_log_table_name("system", "aggregated_zookeeper_log");
+        let dbtable = self.get_log_table_name("aggregated_zookeeper_log");
         return self
             .execute(&format!(
                 r#"
@@ -2186,7 +2186,13 @@ impl ClickHouse {
         }
     }
 
-    pub fn get_table_name(&self, database: &str, table: &str) -> String {
+    /// Database with the system tables ("system" unless overridden with --database).
+    pub fn system_database(&self) -> &str {
+        self.options.database.as_deref().unwrap_or("system")
+    }
+
+    pub fn get_table_name(&self, table: &str) -> String {
+        let database = self.system_database();
         let cluster = self.options.cluster.clone().unwrap_or_default();
         let history = self.options.history;
 
@@ -2206,8 +2212,9 @@ impl ClickHouse {
 
     // Variant for system.*_log tables. With use_shared_merge_tree_log_pipeline we can skip
     // clusterAllReplicas() entirely — a single replica observes the whole cluster's rows.
-    pub fn get_log_table_name(&self, database: &str, table: &str) -> String {
+    pub fn get_log_table_name(&self, table: &str) -> String {
         if self.shared_log_pipeline {
+            let database = self.system_database();
             let history = self.options.history;
             return if history {
                 format!("merge('{}', '^{}')", database, table)
@@ -2215,10 +2222,11 @@ impl ClickHouse {
                 format!("{}.{}", database, table)
             };
         }
-        self.get_table_name(database, table)
+        self.get_table_name(table)
     }
 
-    pub fn get_table_name_no_history(&self, database: &str, table: &str) -> String {
+    pub fn get_table_name_no_history(&self, table: &str) -> String {
+        let database = self.system_database();
         let cluster = self.options.cluster.clone().unwrap_or_default();
         return match cluster.is_empty() {
             true => format!("{}.{}", database, table),

--- a/src/interpreter/options.rs
+++ b/src/interpreter/options.rs
@@ -303,6 +303,10 @@ pub struct ClickHouseOptions {
     pub url_safe: String,
     #[arg(short('c'), long)]
     pub cluster: Option<String>,
+    /// Database with the system tables, e.g. a preserved copy; overrides database in --url
+    /// (for clickhouse-client compatibility; default: system)
+    #[arg(long, env = "CLICKHOUSE_DATABASE")]
+    pub database: Option<String>,
     /// Aggregate system.*_log historical data, using merge()
     #[arg(long, action = ArgAction::SetTrue)]
     pub history: bool,
@@ -508,6 +512,7 @@ struct ChDigClickHouseConfig {
     config: Option<String>,
     connection: Option<String>,
     cluster: Option<String>,
+    database: Option<String>,
     history: Option<bool>,
     internal_queries: Option<bool>,
     limit: Option<u64>,
@@ -696,6 +701,9 @@ fn apply_chdig_config(options: &mut ChDigOptions, config: &ChDigConfig) {
     if options.clickhouse.cluster.is_none() {
         options.clickhouse.cluster = ch.cluster.clone();
     }
+    if options.clickhouse.database.is_none() {
+        options.clickhouse.database = ch.database.clone();
+    }
     if !options.clickhouse.history
         && let Some(history) = ch.history
     {
@@ -874,6 +882,12 @@ fn clickhouse_url_defaults(
             .map_err(|_| anyhow!("username is invalid"))?;
     }
     set_password_from_opt(&mut url, options.password.clone(), true)?;
+    if let Some(database) = &options.database {
+        url.set_path(&format!("/{}", database));
+    } else if url.path().len() > 1 {
+        // Database in the URL is also the database with the system tables
+        options.database = Some(url.path().trim_start_matches('/').to_string());
+    }
     if options.secure {
         secure = Some(true);
     }
@@ -1023,7 +1037,8 @@ fn clickhouse_url_defaults(
     }
     options.url_safe = url_safe.to_string();
 
-    // Switch database to "system", since "default" may not be present.
+    // Switch database to "system", since "default" may not be present
+    // (--database/URL database was already applied above).
     if url_safe.path().is_empty() || url_safe.path() == "/" {
         url.set_path("/system");
     }
@@ -1217,6 +1232,37 @@ mod tests {
         assert_eq!(
             parse_url(&options).unwrap(),
             url::Url::parse("tcp://127.1:9440/system?connection_timeout=5s&query_timeout=600s")
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn test_url_parse_database_from_url() {
+        let mut options = ClickHouseOptions {
+            url: Some("tcp://127.1/mydb".into()),
+            ..Default::default()
+        };
+        clickhouse_url_defaults(&mut options, None).unwrap();
+        assert_eq!(options.database.as_deref(), Some("mydb"));
+        assert_eq!(
+            parse_url(&options).unwrap(),
+            url::Url::parse("tcp://127.1:9000/mydb?connection_timeout=5s&query_timeout=600s")
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn test_url_parse_database_option_overrides_url() {
+        let mut options = ClickHouseOptions {
+            url: Some("tcp://127.1/mydb".into()),
+            database: Some("other".into()),
+            ..Default::default()
+        };
+        clickhouse_url_defaults(&mut options, None).unwrap();
+        assert_eq!(options.database.as_deref(), Some("other"));
+        assert_eq!(
+            parse_url(&options).unwrap(),
+            url::Url::parse("tcp://127.1:9000/other?connection_timeout=5s&query_timeout=600s")
                 .unwrap()
         );
     }

--- a/src/view/providers/asynchronous_inserts.rs
+++ b/src/view/providers/asynchronous_inserts.rs
@@ -34,8 +34,7 @@ fn build_query(
         let ctx = context.lock().unwrap();
         (
             ctx.options.clickhouse.limit,
-            ctx.clickhouse
-                .get_table_name("system", "asynchronous_inserts"),
+            ctx.clickhouse.get_table_name("asynchronous_inserts"),
             ctx.clickhouse.clone(),
             ctx.selected_host.clone(),
         )

--- a/src/view/providers/asynchronous_metric_log.rs
+++ b/src/view/providers/asynchronous_metric_log.rs
@@ -30,8 +30,7 @@ fn build_query(context: &ContextArc) -> String {
         let ctx = context.lock().unwrap();
         (
             ctx.options.view.clone(),
-            ctx.clickhouse
-                .get_log_table_name("system", "asynchronous_metric_log"),
+            ctx.clickhouse.get_log_table_name("asynchronous_metric_log"),
             ctx.clickhouse.clone(),
             ctx.selected_host.clone(),
         )

--- a/src/view/providers/background_schedule_pool.rs
+++ b/src/view/providers/background_schedule_pool.rs
@@ -45,7 +45,7 @@ impl ViewProvider for BackgroundSchedulePoolViewProvider {
             (
                 ctx.options.clickhouse.cluster.is_some(),
                 ctx.clickhouse
-                    .get_table_name_no_history("system", "background_schedule_pool"),
+                    .get_table_name_no_history("background_schedule_pool"),
                 ctx.clickhouse.clone(),
                 ctx.selected_host.clone(),
             )
@@ -203,7 +203,7 @@ pub fn show_background_schedule_pool_dialog(
         let ctx = context.lock().unwrap();
         (
             ctx.clickhouse
-                .get_table_name_no_history("system", "background_schedule_pool"),
+                .get_table_name_no_history("background_schedule_pool"),
             ctx.clickhouse.clone(),
             ctx.selected_host.clone(),
         )

--- a/src/view/providers/background_schedule_pool_log.rs
+++ b/src/view/providers/background_schedule_pool_log.rs
@@ -102,7 +102,7 @@ fn build_query(context: &ContextArc, filters: &FilterParams) -> String {
             ctx.options.view.clone(),
             ctx.options.clickhouse.limit,
             ctx.clickhouse
-                .get_log_table_name("system", "background_schedule_pool_log"),
+                .get_log_table_name("background_schedule_pool_log"),
             ctx.clickhouse.clone(),
             ctx.selected_host.clone(),
         )

--- a/src/view/providers/error_log.rs
+++ b/src/view/providers/error_log.rs
@@ -38,7 +38,7 @@ impl ViewProvider for ErrorLogViewProvider {
             let ctx = context.lock().unwrap();
             (
                 ctx.options.view.clone(),
-                ctx.clickhouse.get_log_table_name("system", "error_log"),
+                ctx.clickhouse.get_log_table_name("error_log"),
                 ctx.clickhouse.clone(),
                 ctx.selected_host.clone(),
             )

--- a/src/view/providers/errors.rs
+++ b/src/view/providers/errors.rs
@@ -92,7 +92,7 @@ impl ViewProvider for ErrorsViewProvider {
         let (dbtable, clickhouse, selected_host) = {
             let ctx = context.lock().unwrap();
             (
-                ctx.clickhouse.get_table_name("system", "errors"),
+                ctx.clickhouse.get_table_name("errors"),
                 ctx.clickhouse.clone(),
                 ctx.selected_host.clone(),
             )

--- a/src/view/providers/logger_names.rs
+++ b/src/view/providers/logger_names.rs
@@ -98,7 +98,7 @@ impl ViewProvider for LoggerNamesViewProvider {
         let (dbtable, clickhouse, selected_host, limit) = {
             let ctx = context.lock().unwrap();
             (
-                ctx.clickhouse.get_log_table_name("system", "text_log"),
+                ctx.clickhouse.get_log_table_name("text_log"),
                 ctx.clickhouse.clone(),
                 ctx.selected_host.clone(),
                 ctx.options.clickhouse.limit,

--- a/src/view/providers/merges.rs
+++ b/src/view/providers/merges.rs
@@ -70,8 +70,8 @@ fn build_query(
     let (tables_dbtable, merges_dbtable, clickhouse, selected_host) = {
         let ctx = context.lock().unwrap();
         (
-            ctx.clickhouse.get_table_name("system", "tables"),
-            ctx.clickhouse.get_table_name("system", "merges"),
+            ctx.clickhouse.get_table_name("tables"),
+            ctx.clickhouse.get_table_name("merges"),
             ctx.clickhouse.clone(),
             ctx.selected_host.clone(),
         )

--- a/src/view/providers/metric_log.rs
+++ b/src/view/providers/metric_log.rs
@@ -30,7 +30,7 @@ fn build_query(context: &ContextArc) -> String {
         let ctx = context.lock().unwrap();
         (
             ctx.options.view.clone(),
-            ctx.clickhouse.get_log_table_name("system", "metric_log"),
+            ctx.clickhouse.get_log_table_name("metric_log"),
             ctx.clickhouse.clone(),
             ctx.selected_host.clone(),
         )

--- a/src/view/providers/mod.rs
+++ b/src/view/providers/mod.rs
@@ -337,7 +337,7 @@ pub fn render_from_clickhouse_query<F, T>(
             .lock()
             .unwrap()
             .clickhouse
-            .get_table_name("system", table_alias)
+            .get_table_name(table_alias)
     } else {
         let pattern = params.table.join("|");
         format!("merge('system', '^({pattern})$')")
@@ -413,7 +413,7 @@ pub fn show_metric_chart(
         let ctx = context.lock().unwrap();
         (
             ctx.options.view.clone(),
-            ctx.clickhouse.get_log_table_name("system", table),
+            ctx.clickhouse.get_log_table_name(table),
             ctx.clickhouse.clone(),
             ctx.selected_host.clone(),
         )

--- a/src/view/providers/mutations.rs
+++ b/src/view/providers/mutations.rs
@@ -62,7 +62,7 @@ fn build_query(
     let (mutations_dbtable, clickhouse, selected_host) = {
         let ctx = context.lock().unwrap();
         (
-            ctx.clickhouse.get_table_name("system", "mutations"),
+            ctx.clickhouse.get_table_name("mutations"),
             ctx.clickhouse.clone(),
             ctx.selected_host.clone(),
         )

--- a/src/view/providers/part_log.rs
+++ b/src/view/providers/part_log.rs
@@ -100,7 +100,7 @@ fn build_query(context: &ContextArc, filters: &FilterParams, is_dialog: bool) ->
         (
             ctx.options.view.clone(),
             ctx.options.clickhouse.limit,
-            ctx.clickhouse.get_log_table_name("system", "part_log"),
+            ctx.clickhouse.get_log_table_name("part_log"),
             ctx.clickhouse.clone(),
             ctx.selected_host.clone(),
         )

--- a/src/view/providers/query_patterns.rs
+++ b/src/view/providers/query_patterns.rs
@@ -31,7 +31,7 @@ fn build_query(context: &ContextArc) -> String {
         (
             ctx.options.view.clone(),
             ctx.options.clickhouse.limit,
-            ctx.clickhouse.get_log_table_name("system", "query_log"),
+            ctx.clickhouse.get_log_table_name("query_log"),
             ctx.clickhouse.clone(),
             ctx.selected_host.clone(),
         )

--- a/src/view/providers/replicas.rs
+++ b/src/view/providers/replicas.rs
@@ -48,7 +48,7 @@ impl ViewProvider for ReplicasViewProvider {
             let ctx = context.lock().unwrap();
             (
                 ctx.options.clickhouse.cluster.is_some(),
-                ctx.clickhouse.get_table_name("system", "replicas"),
+                ctx.clickhouse.get_table_name("replicas"),
                 ctx.clickhouse.clone(),
                 ctx.selected_host.clone(),
             )

--- a/src/view/providers/table_parts.rs
+++ b/src/view/providers/table_parts.rs
@@ -38,8 +38,8 @@ fn build_query(
         let ctx = context.lock().unwrap();
         (
             ctx.options.clickhouse.limit,
-            ctx.clickhouse.get_table_name("system", "parts"),
-            ctx.clickhouse.get_table_name("system", "tables"),
+            ctx.clickhouse.get_table_name("parts"),
+            ctx.clickhouse.get_table_name("tables"),
             ctx.clickhouse.clone(),
             ctx.selected_host.clone(),
         )

--- a/src/view/providers/tables.rs
+++ b/src/view/providers/tables.rs
@@ -43,7 +43,7 @@ impl ViewProvider for TablesViewProvider {
                 ctx.clickhouse
                     .quirks
                     .has(ClickHouseAvailableQuirks::SystemBackgroundSchedulePool),
-                ctx.clickhouse.get_table_name_no_history("system", "tables"),
+                ctx.clickhouse.get_table_name_no_history("tables"),
                 ctx.clickhouse.clone(),
                 ctx.selected_host.clone(),
             )
@@ -73,7 +73,7 @@ impl ViewProvider for TablesViewProvider {
                 r#"
                 SELECT DISTINCT ON (tables.database, tables.table, tables.uuid) {}
                 FROM {} tables
-                JOIN (SELECT table_uuid, count() tasks FROM system.background_schedule_pool GROUP BY table_uuid) bg ON tables.uuid = bg.table_uuid
+                JOIN (SELECT table_uuid, count() tasks FROM {} GROUP BY table_uuid) bg ON tables.uuid = bg.table_uuid
                 WHERE
                     engine NOT LIKE 'System%'
                     AND tables.database NOT IN ('INFORMATION_SCHEMA', 'information_schema')
@@ -82,6 +82,7 @@ impl ViewProvider for TablesViewProvider {
                 "#,
                 columns.join(", "),
                 dbtable,
+                clickhouse.get_table_name_no_history("background_schedule_pool"),
                 host_where,
             )
         } else {

--- a/src/view/queries_view.rs
+++ b/src/view/queries_view.rs
@@ -1041,7 +1041,7 @@ impl QueriesView {
             .lock()
             .unwrap()
             .clickhouse
-            .get_log_table_name("system", table);
+            .get_log_table_name(table);
 
         let max_query_end_with_buffer = max_query_end_microseconds.unwrap_or(Local::now())
             + TimeDelta::seconds(QUERY_TIME_DRIFT_BUFFER_SECONDS);
@@ -1112,7 +1112,7 @@ impl QueriesView {
             .lock()
             .unwrap()
             .clickhouse
-            .get_log_table_name("system", table);
+            .get_log_table_name(table);
 
         let max_query_end_with_buffer = max_query_end_microseconds.unwrap_or(Local::now())
             + TimeDelta::seconds(QUERY_TIME_DRIFT_BUFFER_SECONDS);

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -5,6 +5,11 @@
 //    schema for this server version (via SYSTEM FLUSH LOGS).
 // 2. With all of them disabled (config.d override with "@remove"), so that the server never
 //    writes to them again. The tables are then truncated and tests insert deterministic rows.
+//
+// NOTE: tests share the system database, hence the unique per-test fixture prefixes. With
+// --database every test could instead get its own database (with cloned *_log tables and views
+// to the live system tables) on the one shared server, removing the shared state and allowing
+// to run them in parallel even under process-per-test runners (cargo-nextest). Not implemented.
 
 use std::env;
 use std::net::TcpListener;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1048,6 +1048,76 @@ async fn test_history_with_cluster() {
     );
 }
 
+async fn test_custom_database() {
+    let Some(server) = common::server() else {
+        return;
+    };
+    server.query("CREATE DATABASE IF NOT EXISTS it_db");
+    server.query("CREATE TABLE IF NOT EXISTS it_db.query_log AS system.query_log");
+    server.insert_query_log_into(
+        "it_db.query_log",
+        "it-db-0",
+        "it_user_db",
+        100,
+        "SELECT 0 FROM it_db",
+    );
+    server.insert_query_log("it-db-1", "it_user_db", 100, "SELECT 1 FROM it_db");
+
+    // With --database only the custom database is visible, not system
+    let chdig = ClickHouse::new(ClickHouseOptions {
+        database: Some("it_db".to_string()),
+        ..server.chdig_options()
+    })
+    .await
+    .unwrap();
+    let (start, end) = window();
+    let block = chdig
+        .get_last_query_log(&"it-db-%".to_string(), start, end, 100, None)
+        .await
+        .unwrap();
+    assert_eq!(block.row_count(), 1);
+    assert_eq!(block.get::<String, _>(0, "query_id").unwrap(), "it-db-0");
+}
+
+async fn test_database_from_url() {
+    let Some(server) = common::server() else {
+        return;
+    };
+    server.query("CREATE DATABASE IF NOT EXISTS it_db_url");
+    server.query("CREATE TABLE IF NOT EXISTS it_db_url.query_log AS system.query_log");
+    server.insert_query_log_into(
+        "it_db_url.query_log",
+        "it-urldb-0",
+        "it_user_urldb",
+        100,
+        "SELECT 0 FROM it_urldb",
+    );
+    server.insert_query_log("it-urldb-1", "it_user_urldb", 100, "SELECT 1 FROM it_urldb");
+
+    // Full options parsing: the database from the URL must end up as the system tables database.
+    // The empty config files keep it hermetic (no user configs from default paths).
+    let options = chdig::interpreter::options::parse_from([
+        "chdig",
+        "--url",
+        &format!("tcp://default@127.0.0.1:{}/it_db_url", server.tcp_port),
+        "--chdig-config",
+        "tests/configs/chdig_empty.yaml",
+        "--config",
+        "tests/configs/empty.xml",
+    ])
+    .unwrap();
+    assert_eq!(options.clickhouse.database.as_deref(), Some("it_db_url"));
+
+    let chdig = ClickHouse::new(options.clickhouse).await.unwrap();
+    let (start, end) = window();
+    let block = chdig
+        .get_last_query_log(&"it-urldb-%".to_string(), start, end, 100, None)
+        .await
+        .unwrap();
+    assert_eq!(block.row_count(), 1);
+    assert_eq!(block.get::<String, _>(0, "query_id").unwrap(), "it-urldb-0");
+}
+
 // Under cargo test every scenario is a separate #[test] (parallel threads against the shared
 // server), for per-test reporting. cargo-nextest runs every test in a separate process, which
 // would bootstrap one server per test - there (the NEXTEST env variable is set) the per-scenario
@@ -1135,4 +1205,6 @@ integration_tests!(
     test_history,
     test_cluster,
     test_history_with_cluster,
+    test_custom_database,
+    test_database_from_url,
 );


### PR DESCRIPTION
Useful for analyzing a preserved copy of system tables (or fixtures in tests).

Can be set via --database, CLICKHOUSE_DATABASE or the database directive in the clickhouse section of the chdig config. It also becomes the connection default database (unless the URL already names one).
