### PR TITLE
Fix ClickHouse install retry loop in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,8 +38,13 @@ jobs:
         cache-on-failure: true
     - name: Install ClickHouse
       run: |
+        # NOTE: no "curl | sh": without pipefail the pipeline exit code is sh's, which
+        # succeeds on empty/partial input from a failed curl
         for attempt in {1..5}; do
-            curl -fsSL https://clickhouse.com/ | sh && break
+            if curl -fsSL -o /tmp/clickhouse-install.sh https://clickhouse.com/ \
+                && sh /tmp/clickhouse-install.sh; then
+                break
+            fi
             echo "ClickHouse install failed (attempt $attempt), retrying..."
             sleep 5
         done


### PR DESCRIPTION
"curl | sh" reports sh's exit code, and sh succeeds on empty input when curl fails (GitHub Actions does not enable pipefail for the default shell), so the loop would break on the first failed attempt. Download to a file and execute it as a separate step, both inside the retry condition - this also avoids executing a partially downloaded script.