### PR TITLE
Persistent storage for logs and perfetto traces

### DIFF
--- a/src/bin.rs
+++ b/src/bin.rs
@@ -99,10 +99,17 @@ async fn run_cli_perfetto_export(
         }
     }
 
+    let output = derive_output_path(
+        options.view.output.as_deref(),
+        is_server_scope,
+        options.view.query_id.as_deref(),
+    );
+
     let mut builder = PerfettoTraceBuilder::new(
+        output,
         perfetto_options.per_server,
         perfetto_options.text_log_android,
-    );
+    )?;
     builder.add_queries(&queries);
     fetch_and_populate_perfetto_trace(
         clickhouse,
@@ -125,13 +132,7 @@ async fn run_cli_perfetto_export(
         .await;
     }
 
-    let output = derive_output_path(
-        options.view.output.as_deref(),
-        is_server_scope,
-        options.view.query_id.as_deref(),
-    );
-
-    std::fs::write(&output, builder.build())?;
+    let (output, _) = builder.build()?;
     println!("Perfetto trace exported to {}", output.display());
     Ok(())
 }

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -133,7 +133,7 @@ async fn run_cli_perfetto_export(
     }
 
     let (output, _) = builder.build()?;
-    println!("Perfetto trace exported to {}", output.display());
+    println!("Perfetto trace exported to {}", output.path().display());
     Ok(())
 }
 

--- a/src/interpreter/clickhouse.rs
+++ b/src/interpreter/clickhouse.rs
@@ -1439,20 +1439,24 @@ impl ClickHouse {
             .await;
     }
 
+    /// Returns (samples, stacks): samples carry only cityHash64(trace) per row,
+    /// stacks map (host_name, stack_hash) to the symbolized stack of each
+    /// unique trace. Symbolizing/transferring the stack per sample is hundreds
+    /// of MBs even for an hour of trace_log (the dedup factor is ~100x).
     pub async fn get_stack_traces_for_perfetto(
         &self,
         query_ids: Option<&[String]>,
         start: DateTime<Local>,
         end: DateTime<Local>,
-    ) -> Result<Columns> {
+    ) -> Result<(Columns, Columns)> {
         let dbtable = self.get_log_table_name("trace_log");
         let symbol_expr = if self
             .quirks
             .has(ClickHouseAvailableQuirks::TraceLogHasSymbols)
         {
-            r#"arrayReverse(if(empty(symbols),
+            r#"arrayReverse(if(empty(any(symbols)),
                 arrayMap(addr -> demangle(addressToSymbol(addr)), trace),
-                symbols))"#
+                any(symbols)))"#
         } else {
             "arrayReverse(arrayMap(addr -> demangle(addressToSymbol(addr)), trace))"
         };
@@ -1461,38 +1465,56 @@ impl ClickHouse {
         } else {
             String::new()
         };
-        return self
-            .execute(&format!(
-                r#"
-                    WITH
+        let with = format!(
+            r#"WITH
                         fromUnixTimestamp64Nano({start}) AS start_,
-                        fromUnixTimestamp64Nano({end}) AS end_
-                    SELECT
-                        event_time_microseconds,
-                        thread_id,
-                        trace_type::String AS trace_type,
-                        {symbol_expr} AS stack,
-                        size,
-                        query_id,
-                        {host_expr} AS host_name
-                    FROM {dbtable}
-                    WHERE trace_type IN ('CPU', 'Real', 'Memory')
+                        fromUnixTimestamp64Nano({end}) AS end_"#,
+            start = start
+                .timestamp_nanos_opt()
+                .ok_or(Error::msg("Invalid start"))?,
+            end = end.timestamp_nanos_opt().ok_or(Error::msg("Invalid end"))?,
+        );
+        let filter = format!(
+            r#"WHERE trace_type IN ('CPU', 'Real', 'Memory')
                       {query_id_filter}
                       AND event_date >= toDate(start_) AND event_time >= toDateTime(start_)
-                      AND event_date <= toDate(end_)   AND event_time <= toDateTime(end_)
+                      AND event_date <= toDate(end_)   AND event_time <= toDateTime(end_)"#,
+        );
+        let host_expr = self.get_log_hostname_column();
+
+        let samples = self
+            .execute(&format!(
+                r#"
+                    {with}
+                    SELECT
+                        event_time_microseconds,
+                        trace_type::String AS trace_type,
+                        cityHash64(trace) AS stack_hash,
+                        {host_expr} AS host_name
+                    FROM {dbtable}
+                    {filter}
                     ORDER BY event_time_microseconds
+                    "#,
+            ))
+            .await?;
+
+        let stacks = self
+            .execute(&format!(
+                r#"
+                    {with}
+                    SELECT
+                        {host_expr} AS host_name,
+                        cityHash64(trace) AS stack_hash,
+                        {symbol_expr} AS stack
+                    FROM {dbtable}
+                    {filter}
+                    GROUP BY host_name, trace
                     SETTINGS allow_introspection_functions=1
                     "#,
-                dbtable = dbtable,
-                symbol_expr = symbol_expr,
-                start = start
-                    .timestamp_nanos_opt()
-                    .ok_or(Error::msg("Invalid start"))?,
-                end = end.timestamp_nanos_opt().ok_or(Error::msg("Invalid end"))?,
-                query_id_filter = query_id_filter,
-                host_expr = self.get_log_hostname_column(),
             ))
-            .await;
+            .await?;
+
+        Ok((samples, stacks))
     }
 
     pub async fn get_text_log_for_perfetto(

--- a/src/interpreter/clickhouse.rs
+++ b/src/interpreter/clickhouse.rs
@@ -1348,20 +1348,25 @@ impl ClickHouse {
             ))
             .await?;
 
-        let pe_columns: Vec<String> = block
+        // Lookup by column index: by-name lookup is a linear scan in
+        // clickhouse-rs, which is quadratic over ~2K ProfileEvent_* columns.
+        let pe_columns: Vec<(usize, &str)> = block
             .columns()
             .iter()
-            .map(|c| c.name().to_string())
-            .filter(|name| name.starts_with("ProfileEvent_"))
+            .enumerate()
+            .filter_map(|(idx, c)| {
+                c.name()
+                    .strip_prefix("ProfileEvent_")
+                    .map(|name| (idx, name))
+            })
             .collect();
 
         let mut rows = Vec::with_capacity(block.row_count());
         for i in 0..block.row_count() {
             let mut profile_events = HashMap::new();
-            for col in &pe_columns {
-                let value: u64 = block.get(i, col.as_str()).unwrap_or(0);
+            for &(idx, name) in &pe_columns {
+                let value: u64 = block.get(i, idx).unwrap_or(0);
                 if value != 0 {
-                    let name = col.strip_prefix("ProfileEvent_").unwrap();
                     profile_events.insert(name.to_string(), value);
                 }
             }
@@ -1723,17 +1728,28 @@ impl ClickHouse {
             ))
             .await?;
 
-        let pe_columns: Vec<String> = block
+        // Lookup by column index: by-name lookup is a linear scan in
+        // clickhouse-rs, which is quadratic over ~2K metric columns
+        // (hours of CPU for a one hour window, i.e. ~3.6K rows).
+        let pe_columns: Vec<(usize, &str)> = block
             .columns()
             .iter()
-            .map(|c| c.name().to_string())
-            .filter(|name| name.starts_with("ProfileEvent_"))
+            .enumerate()
+            .filter_map(|(idx, c)| {
+                c.name()
+                    .strip_prefix("ProfileEvent_")
+                    .map(|name| (idx, name))
+            })
             .collect();
-        let cm_columns: Vec<String> = block
+        let cm_columns: Vec<(usize, &str)> = block
             .columns()
             .iter()
-            .map(|c| c.name().to_string())
-            .filter(|name| name.starts_with("CurrentMetric_"))
+            .enumerate()
+            .filter_map(|(idx, c)| {
+                c.name()
+                    .strip_prefix("CurrentMetric_")
+                    .map(|name| (idx, name))
+            })
             .collect();
 
         let mut rows = Vec::with_capacity(block.row_count());
@@ -1750,18 +1766,16 @@ impl ClickHouse {
                 }
             };
             let mut profile_events = HashMap::new();
-            for col in &pe_columns {
-                let value: u64 = block.get(i, col.as_str()).unwrap_or(0);
+            for &(idx, name) in &pe_columns {
+                let value: u64 = block.get(i, idx).unwrap_or(0);
                 if value != 0 {
-                    let name = col.strip_prefix("ProfileEvent_").unwrap();
                     profile_events.insert(name.to_string(), value);
                 }
             }
             let mut current_metrics = HashMap::new();
-            for col in &cm_columns {
-                let value: i64 = block.get(i, col.as_str()).unwrap_or(0);
+            for &(idx, name) in &cm_columns {
+                let value: i64 = block.get(i, idx).unwrap_or(0);
                 if value != 0 {
-                    let name = col.strip_prefix("CurrentMetric_").unwrap();
                     current_metrics.insert(name.to_string(), value);
                 }
             }

--- a/src/interpreter/clickhouse.rs
+++ b/src/interpreter/clickhouse.rs
@@ -1601,7 +1601,10 @@ impl ClickHouse {
                         memory_usage::Int64 AS peak_memory_usage,
                         query_duration_ms/1e3 AS elapsed,
                         user,
+                        initial_user,
+                        exception,
                         is_initial_query,
+                        (exception_code = 394)::UInt8 AS is_cancelled,
                         initial_query_id,
                         query_id,
                         hostname as host_name,
@@ -1609,7 +1612,8 @@ impl ClickHouse {
                         query_start_time_microseconds,
                         event_time_microseconds AS query_end_time_microseconds,
                         toValidUTF8(query) AS original_query,
-                        normalizeQuery(query) AS normalized_query
+                        normalizeQuery(query) AS normalized_query,
+                        normalized_query_hash
                     FROM {dbtable}
                     WHERE type != 'QueryStart'
                       AND event_date >= toDate(start_) AND event_time >= toDateTime(start_)

--- a/src/interpreter/options.rs
+++ b/src/interpreter/options.rs
@@ -328,6 +328,10 @@ pub struct ClickHouseOptions {
     #[arg(long, action = ArgAction::SetTrue, overrides_with = "internal_queries")]
     pub no_internal_queries: bool,
     /// Limit for logs
+    // Retained entries are disk-backed (LogStore, ~24B of RAM per entry), but a
+    // single fetch still materializes the whole result set in memory (Block +
+    // Vec<LogEntry>), so this bounds the per-fetch transient, not total logs.
+    // Raising it aggressively requires streaming the fetch block-by-block first.
     #[arg(long, default_value_t = 100000)]
     pub limit: u64,
     /// Sort order for logs (desc returns the newest --limit rows, useful for long backups)

--- a/src/interpreter/perfetto.rs
+++ b/src/interpreter/perfetto.rs
@@ -27,8 +27,9 @@ use protobuf::{EnumOrUnknown, Message, MessageField};
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::{BufWriter, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
+use tempfile::TempPath;
 
 const SEQUENCE_ID: u32 = 1;
 // Sequence-scoped clock (>=64), mapped to BOOTTIME via ClockSnapshot.
@@ -51,12 +52,26 @@ struct Sample {
     timestamp_us: i64,
 }
 
+/// A built trace on disk. Holding it keeps a temporary trace alive,
+/// dropping it deletes the file (no-op for explicit output paths).
+pub struct TraceFile {
+    path: PathBuf,
+    _temp: Option<TempPath>,
+}
+
+impl TraceFile {
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
 pub struct PerfettoTraceBuilder {
     // Packets are streamed to disk as they are added (a Trace is just a
     // repeated TracePacket, so concatenated single-packet Trace messages form
     // a valid trace), keeping only the interning state in memory.
     out: BufWriter<File>,
     path: PathBuf,
+    temp: Option<TempPath>,
     write_error: Option<protobuf::Error>,
     next_uuid: u64,
     next_sequence_id: u32,
@@ -76,11 +91,46 @@ pub struct PerfettoTraceBuilder {
 
 impl PerfettoTraceBuilder {
     pub fn new(path: PathBuf, per_server: bool, text_log_android: bool) -> Result<Self> {
-        let out = BufWriter::new(File::create(&path)?);
-
-        let mut builder = PerfettoTraceBuilder {
-            out,
+        let file = File::create(&path)?;
+        Ok(Self::with_output(
+            file,
             path,
+            None,
+            per_server,
+            text_log_android,
+        ))
+    }
+
+    /// Trace in a temporary file, which lives as long as the TraceFile
+    /// returned by build() (must be named, since the HTTP server reopens
+    /// it by path on every request).
+    pub fn new_temp(per_server: bool, text_log_android: bool) -> Result<Self> {
+        let (file, temp) = tempfile::Builder::new()
+            .prefix("chdig.")
+            .suffix(".pftrace")
+            .tempfile()?
+            .into_parts();
+        let path = temp.to_path_buf();
+        Ok(Self::with_output(
+            file,
+            path,
+            Some(temp),
+            per_server,
+            text_log_android,
+        ))
+    }
+
+    fn with_output(
+        file: File,
+        path: PathBuf,
+        temp: Option<TempPath>,
+        per_server: bool,
+        text_log_android: bool,
+    ) -> Self {
+        let mut builder = PerfettoTraceBuilder {
+            out: BufWriter::new(file),
+            path,
+            temp,
             write_error: None,
             next_uuid: 1,
             next_sequence_id: SEQUENCE_ID + 1,
@@ -109,7 +159,7 @@ impl PerfettoTraceBuilder {
         cs_pkt.data = Some(Data::ClockSnapshot(cs));
         builder.write_packet(cs_pkt);
 
-        Ok(builder)
+        builder
     }
 
     // All add_* methods stay infallible: the first write error is remembered
@@ -1536,18 +1586,25 @@ impl PerfettoTraceBuilder {
         cs
     }
 
-    pub fn build(mut self) -> Result<(PathBuf, u64)> {
+    pub fn build(mut self) -> Result<(TraceFile, u64)> {
         if let Some(e) = self.write_error {
             return Err(e.into());
         }
         self.out.flush()?;
         let size = self.out.get_ref().metadata()?.len();
-        Ok((self.path, size))
+        Ok((
+            TraceFile {
+                path: self.path,
+                _temp: self.temp,
+            },
+            size,
+        ))
     }
 }
 
 pub struct PerfettoServer {
-    trace_path: Arc<Mutex<Option<PathBuf>>>,
+    // Replacing the trace drops the previous TraceFile, deleting its temp file
+    trace_file: Arc<Mutex<Option<TraceFile>>>,
     #[allow(dead_code)]
     server_thread: Option<std::thread::JoinHandle<()>>,
 }
@@ -1555,8 +1612,8 @@ pub struct PerfettoServer {
 impl PerfettoServer {
     #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
-        let trace_path: Arc<Mutex<Option<PathBuf>>> = Arc::new(Mutex::new(None));
-        let trace_path_clone = trace_path.clone();
+        let trace_file: Arc<Mutex<Option<TraceFile>>> = Arc::new(Mutex::new(None));
+        let trace_file_clone = trace_file.clone();
 
         let server_thread = std::thread::spawn(move || {
             let server = match tiny_http::Server::http("127.0.0.1:9001") {
@@ -1594,10 +1651,16 @@ impl PerfettoServer {
                 }
 
                 if url == "/trace" {
-                    let path: Option<PathBuf> = trace_path_clone.lock().unwrap().clone();
                     // Fresh handle per request: tiny_http streams the file, and
-                    // concurrent requests must not share a cursor.
-                    match path.and_then(|p| File::open(p).ok()) {
+                    // concurrent requests must not share a cursor. Opened under
+                    // the lock so the temp file cannot be deleted in between
+                    // (the fd keeps it readable even if replaced mid-stream).
+                    let file = trace_file_clone
+                        .lock()
+                        .unwrap()
+                        .as_ref()
+                        .and_then(|t| File::open(t.path()).ok());
+                    match file {
                         Some(file) => {
                             let response = tiny_http::Response::from_file(file)
                                 .with_header(
@@ -1638,13 +1701,13 @@ impl PerfettoServer {
         });
 
         PerfettoServer {
-            trace_path,
+            trace_file,
             server_thread: Some(server_thread),
         }
     }
 
-    pub fn set_trace_path(&self, path: PathBuf) {
-        *self.trace_path.lock().unwrap() = Some(path);
+    pub fn set_trace_file(&self, file: TraceFile) {
+        *self.trace_file.lock().unwrap() = Some(file);
     }
 
     pub fn get_perfetto_url(&self) -> String {

--- a/src/interpreter/perfetto.rs
+++ b/src/interpreter/perfetto.rs
@@ -1,5 +1,6 @@
 use crate::interpreter::Query;
 use crate::interpreter::clickhouse::{Columns, MetricLogRow, QueryMetricRow};
+use anyhow::Result;
 use chrono::{DateTime, Local};
 use chrono_tz::Tz;
 use perfetto_protos::android_log::AndroidLogPacket;
@@ -24,6 +25,9 @@ use perfetto_protos::track_event::TrackEvent;
 use perfetto_protos::track_event::track_event::{Counter_value_field, Name_field, Type};
 use protobuf::{EnumOrUnknown, Message, MessageField};
 use std::collections::HashMap;
+use std::fs::File;
+use std::io::{BufWriter, Write};
+use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 const SEQUENCE_ID: u32 = 1;
@@ -48,7 +52,12 @@ struct Sample {
 }
 
 pub struct PerfettoTraceBuilder {
-    packets: Vec<TracePacket>,
+    // Packets are streamed to disk as they are added (a Trace is just a
+    // repeated TracePacket, so concatenated single-packet Trace messages form
+    // a valid trace), keeping only the interning state in memory.
+    out: BufWriter<File>,
+    path: PathBuf,
+    write_error: Option<protobuf::Error>,
     next_uuid: u64,
     next_sequence_id: u32,
     first_event_emitted: bool,
@@ -66,9 +75,13 @@ pub struct PerfettoTraceBuilder {
 }
 
 impl PerfettoTraceBuilder {
-    pub fn new(per_server: bool, text_log_android: bool) -> Self {
-        PerfettoTraceBuilder {
-            packets: Vec::new(),
+    pub fn new(path: PathBuf, per_server: bool, text_log_android: bool) -> Result<Self> {
+        let out = BufWriter::new(File::create(&path)?);
+
+        let mut builder = PerfettoTraceBuilder {
+            out,
+            path,
+            write_error: None,
             next_uuid: 1,
             next_sequence_id: SEQUENCE_ID + 1,
             first_event_emitted: false,
@@ -82,6 +95,33 @@ impl PerfettoTraceBuilder {
             host_category_uuids: HashMap::new(),
             per_server,
             text_log_android,
+        };
+
+        // ClockSnapshot with timestamp=0 in its own clock (self-referencing).
+        // The trace processor resolves this specially for ClockSnapshot packets,
+        // placing it at the very start of the trace (time 0).
+        let cs = Self::make_clock_snapshot();
+        let mut cs_pkt = TracePacket::new();
+        cs_pkt.set_trusted_packet_sequence_id(SEQUENCE_ID);
+        cs_pkt.sequence_flags = Some(1 | 2);
+        cs_pkt.timestamp = Some(0);
+        cs_pkt.timestamp_clock_id = Some(CLOCK_ID_UNIXTIME);
+        cs_pkt.data = Some(Data::ClockSnapshot(cs));
+        builder.write_packet(cs_pkt);
+
+        Ok(builder)
+    }
+
+    // All add_* methods stay infallible: the first write error is remembered
+    // and surfaced by build(), later writes become no-ops (ferror() pattern).
+    fn write_packet(&mut self, pkt: TracePacket) {
+        if self.write_error.is_some() {
+            return;
+        }
+        let mut trace = Trace::new();
+        trace.packet.push(pkt);
+        if let Err(e) = trace.write_to_writer(&mut self.out) {
+            self.write_error = Some(e);
         }
     }
 
@@ -116,7 +156,7 @@ impl PerfettoTraceBuilder {
         td.uuid = Some(uuid);
         td.static_or_dynamic_name = Some(Static_or_dynamic_name::Name(name.to_string()));
         pkt.data = Some(Data::TrackDescriptor(td));
-        self.packets.push(pkt);
+        self.write_packet(pkt);
     }
 
     fn add_child_track(&mut self, uuid: u64, parent_uuid: u64, name: &str) {
@@ -126,7 +166,7 @@ impl PerfettoTraceBuilder {
         td.parent_uuid = Some(parent_uuid);
         td.static_or_dynamic_name = Some(Static_or_dynamic_name::Name(name.to_string()));
         pkt.data = Some(Data::TrackDescriptor(td));
-        self.packets.push(pkt);
+        self.write_packet(pkt);
     }
 
     fn add_counter_track(&mut self, uuid: u64, parent_uuid: u64, name: &str, unit: Unit) {
@@ -139,7 +179,7 @@ impl PerfettoTraceBuilder {
         cd.unit = Some(EnumOrUnknown::new(unit));
         td.counter = MessageField::some(cd);
         pkt.data = Some(Data::TrackDescriptor(td));
-        self.packets.push(pkt);
+        self.write_packet(pkt);
     }
 
     fn add_slice_begin(
@@ -156,7 +196,7 @@ impl PerfettoTraceBuilder {
         te.name_field = Some(Name_field::Name(name.to_string()));
         te.debug_annotations = annotations;
         pkt.data = Some(Data::TrackEvent(te));
-        self.packets.push(pkt);
+        self.write_packet(pkt);
     }
 
     fn add_slice_end(&mut self, track_uuid: u64, ts_ns: u64) {
@@ -165,7 +205,7 @@ impl PerfettoTraceBuilder {
         te.type_ = Some(EnumOrUnknown::new(Type::TYPE_SLICE_END));
         te.track_uuid = Some(track_uuid);
         pkt.data = Some(Data::TrackEvent(te));
-        self.packets.push(pkt);
+        self.write_packet(pkt);
     }
 
     fn add_instant(
@@ -182,7 +222,7 @@ impl PerfettoTraceBuilder {
         te.name_field = Some(Name_field::Name(name.to_string()));
         te.debug_annotations = annotations;
         pkt.data = Some(Data::TrackEvent(te));
-        self.packets.push(pkt);
+        self.write_packet(pkt);
     }
 
     fn add_counter_value(&mut self, track_uuid: u64, ts_ns: u64, value: i64) {
@@ -192,7 +232,7 @@ impl PerfettoTraceBuilder {
         te.track_uuid = Some(track_uuid);
         te.counter_value_field = Some(Counter_value_field::CounterValue(value));
         pkt.data = Some(Data::TrackEvent(te));
-        self.packets.push(pkt);
+        self.write_packet(pkt);
     }
 
     /// Returns (unit, scale_factor) for a ProfileEvent name.
@@ -746,7 +786,7 @@ impl PerfettoTraceBuilder {
             let first_ts = alp.events[0].timestamp.unwrap_or(0);
             let mut pkt = self.make_event_packet(first_ts);
             pkt.data = Some(Data::AndroidLog(alp));
-            self.packets.push(pkt);
+            self.write_packet(pkt);
         }
     }
 
@@ -1437,7 +1477,7 @@ impl PerfettoTraceBuilder {
         desc_pkt.sequence_flags = Some(1 | 2);
         desc_pkt.trusted_pid = Some(1);
         desc_pkt.data = Some(Data::ThreadDescriptor(td));
-        self.packets.push(desc_pkt);
+        self.write_packet(desc_pkt);
 
         let mut callstack_iids = Vec::with_capacity(samples.len());
         let mut timestamp_deltas = Vec::with_capacity(samples.len());
@@ -1469,7 +1509,7 @@ impl PerfettoTraceBuilder {
         pkt.trusted_pid = Some(1);
         pkt.interned_data = MessageField::some(interned_data);
         pkt.data = Some(Data::StreamingProfilePacket(spp));
-        self.packets.push(pkt);
+        self.write_packet(pkt);
     }
 
     /// Build a ClockSnapshot mapping all clocks with an identity transform.
@@ -1496,28 +1536,18 @@ impl PerfettoTraceBuilder {
         cs
     }
 
-    pub fn build(self) -> Vec<u8> {
-        // ClockSnapshot with timestamp=0 in its own clock (self-referencing).
-        // The trace processor resolves this specially for ClockSnapshot packets,
-        // placing it at the very start of the trace (time 0).
-        let cs = Self::make_clock_snapshot();
-        let mut cs_pkt = TracePacket::new();
-        cs_pkt.set_trusted_packet_sequence_id(SEQUENCE_ID);
-        cs_pkt.sequence_flags = Some(1 | 2);
-        cs_pkt.timestamp = Some(0);
-        cs_pkt.timestamp_clock_id = Some(CLOCK_ID_UNIXTIME);
-        cs_pkt.data = Some(Data::ClockSnapshot(cs));
-
-        let mut trace = Trace::new();
-        trace.packet = Vec::with_capacity(self.packets.len() + 1);
-        trace.packet.push(cs_pkt);
-        trace.packet.extend(self.packets);
-        trace.write_to_bytes().unwrap_or_default()
+    pub fn build(mut self) -> Result<(PathBuf, u64)> {
+        if let Some(e) = self.write_error {
+            return Err(e.into());
+        }
+        self.out.flush()?;
+        let size = self.out.get_ref().metadata()?.len();
+        Ok((self.path, size))
     }
 }
 
 pub struct PerfettoServer {
-    trace_data: Arc<Mutex<Option<Arc<Vec<u8>>>>>,
+    trace_path: Arc<Mutex<Option<PathBuf>>>,
     #[allow(dead_code)]
     server_thread: Option<std::thread::JoinHandle<()>>,
 }
@@ -1525,8 +1555,8 @@ pub struct PerfettoServer {
 impl PerfettoServer {
     #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
-        let trace_data: Arc<Mutex<Option<Arc<Vec<u8>>>>> = Arc::new(Mutex::new(None));
-        let trace_data_clone = trace_data.clone();
+        let trace_path: Arc<Mutex<Option<PathBuf>>> = Arc::new(Mutex::new(None));
+        let trace_path_clone = trace_path.clone();
 
         let server_thread = std::thread::spawn(move || {
             let server = match tiny_http::Server::http("127.0.0.1:9001") {
@@ -1564,10 +1594,12 @@ impl PerfettoServer {
                 }
 
                 if url == "/trace" {
-                    let data: Option<Arc<Vec<u8>>> = trace_data_clone.lock().unwrap().clone();
-                    match data {
-                        Some(bytes) => {
-                            let response = tiny_http::Response::from_data((*bytes).clone())
+                    let path: Option<PathBuf> = trace_path_clone.lock().unwrap().clone();
+                    // Fresh handle per request: tiny_http streams the file, and
+                    // concurrent requests must not share a cursor.
+                    match path.and_then(|p| File::open(p).ok()) {
+                        Some(file) => {
+                            let response = tiny_http::Response::from_file(file)
                                 .with_header(
                                     "Content-Type: application/octet-stream"
                                         .parse::<tiny_http::Header>()
@@ -1606,13 +1638,13 @@ impl PerfettoServer {
         });
 
         PerfettoServer {
-            trace_data,
+            trace_path,
             server_thread: Some(server_thread),
         }
     }
 
-    pub fn set_trace(&self, data: Vec<u8>) {
-        *self.trace_data.lock().unwrap() = Some(Arc::new(data));
+    pub fn set_trace_path(&self, path: PathBuf) {
+        *self.trace_path.lock().unwrap() = Some(path);
     }
 
     pub fn get_perfetto_url(&self) -> String {

--- a/src/interpreter/perfetto.rs
+++ b/src/interpreter/perfetto.rs
@@ -1361,8 +1361,8 @@ impl PerfettoTraceBuilder {
     // The working approach: each trace type gets its own sequence with a ThreadDescriptor
     // that carries reference_timestamp_us (microseconds). No clock_id needed on the
     // packets — timing is entirely from reference_timestamp_us + deltas.
-    pub fn add_stack_traces(&mut self, columns: &Columns) {
-        if columns.row_count() == 0 {
+    pub fn add_stack_traces(&mut self, samples: &Columns, stacks: &Columns) {
+        if samples.row_count() == 0 {
             return;
         }
 
@@ -1378,26 +1378,17 @@ impl PerfettoTraceBuilder {
 
         let mapping_iid = self.alloc_intern_id();
 
-        for i in 0..columns.row_count() {
-            let trace_type: String = columns.get(i, "trace_type").unwrap_or_default();
-            let stack: Vec<String> = columns.get(i, "stack").unwrap_or_default();
+        // Intern each unique stack once; samples reference them by
+        // (host_name, stack_hash), see get_stack_traces_for_perfetto().
+        let mut callstacks_by_hash: HashMap<(String, u64), u64> = HashMap::new();
+        for i in 0..stacks.row_count() {
+            let host_name: String = stacks.get(i, "host_name").unwrap_or_default();
+            let stack_hash: u64 = stacks.get(i, "stack_hash").unwrap_or_default();
+            let stack: Vec<String> = stacks.get(i, "stack").unwrap_or_default();
 
             if stack.is_empty() {
                 continue;
             }
-
-            let timestamp_us: i64 =
-                match columns.get::<DateTime<Tz>, _>(i, "event_time_microseconds") {
-                    Ok(dt) => dt.with_timezone(&Local).timestamp_micros(),
-                    Err(e) => {
-                        log::warn!(
-                            "Perfetto: stack trace row {} event_time_microseconds: {}",
-                            i,
-                            e
-                        );
-                        continue;
-                    }
-                };
 
             // Intern each frame in the stack
             let mut frame_ids = Vec::with_capacity(stack.len());
@@ -1444,6 +1435,32 @@ impl PerfettoTraceBuilder {
                         iid
                     });
 
+            callstacks_by_hash.insert((host_name, stack_hash), callstack_iid);
+        }
+
+        for i in 0..samples.row_count() {
+            let trace_type: String = samples.get(i, "trace_type").unwrap_or_default();
+            let stack_hash: u64 = samples.get(i, "stack_hash").unwrap_or_default();
+            let host_name: String = samples.get(i, "host_name").unwrap_or_default();
+
+            let Some(&callstack_iid) = callstacks_by_hash.get(&(host_name.clone(), stack_hash))
+            else {
+                continue;
+            };
+
+            let timestamp_us: i64 =
+                match samples.get::<DateTime<Tz>, _>(i, "event_time_microseconds") {
+                    Ok(dt) => dt.with_timezone(&Local).timestamp_micros(),
+                    Err(e) => {
+                        log::warn!(
+                            "Perfetto: stack trace row {} event_time_microseconds: {}",
+                            i,
+                            e
+                        );
+                        continue;
+                    }
+                };
+
             samples_by_type
                 .entry(trace_type.clone())
                 .or_default()
@@ -1452,17 +1469,14 @@ impl PerfettoTraceBuilder {
                     timestamp_us,
                 });
 
-            if self.per_server {
-                let host_name: String = columns.get(i, "host_name").unwrap_or_default();
-                if !host_name.is_empty() {
-                    samples_by_host_type
-                        .entry((host_name, trace_type))
-                        .or_default()
-                        .push(Sample {
-                            callstack_iid,
-                            timestamp_us,
-                        });
-                }
+            if self.per_server && !host_name.is_empty() {
+                samples_by_host_type
+                    .entry((host_name, trace_type))
+                    .or_default()
+                    .push(Sample {
+                        callstack_iid,
+                        timestamp_us,
+                    });
             }
         }
 

--- a/src/interpreter/worker.rs
+++ b/src/interpreter/worker.rs
@@ -678,19 +678,11 @@ fn serve_perfetto_trace(
     cb_sink: cursive::CbSink,
     builder: PerfettoTraceBuilder,
 ) -> Result<()> {
-    let data = builder.build();
-    let data_len = data.len();
-    if let Err(e) = std::fs::write("/tmp/chdig_perfetto.pftrace", &data) {
-        log::warn!("Failed to save debug trace: {}", e);
-    } else {
-        log::info!(
-            "Saved debug trace to /tmp/chdig_perfetto.pftrace ({} bytes)",
-            data_len
-        );
-    }
+    let (path, data_len) = builder.build()?;
+    log::info!("Saved trace to {} ({} bytes)", path.display(), data_len);
 
     let server = context.lock().unwrap().get_or_start_perfetto_server();
-    server.set_trace(data);
+    server.set_trace_path(path);
     let url = server.get_perfetto_url();
 
     let url_clone = url.clone();
@@ -1209,8 +1201,11 @@ async fn process_event(context: ContextArc, event: Event, need_clear: &mut bool)
         Event::PerfettoExport(queries, query_ids, start, end) => {
             let perfetto_cfg = context.lock().unwrap().options.perfetto.clone();
             let end_time = end.unwrap_or_else(Local::now) + chrono::TimeDelta::seconds(1);
-            let mut builder =
-                PerfettoTraceBuilder::new(perfetto_cfg.per_server, perfetto_cfg.text_log_android);
+            let mut builder = PerfettoTraceBuilder::new(
+                "/tmp/chdig_perfetto.pftrace".into(),
+                perfetto_cfg.per_server,
+                perfetto_cfg.text_log_android,
+            )?;
 
             for q in &queries {
                 log::info!(
@@ -1250,8 +1245,11 @@ async fn process_event(context: ContextArc, event: Event, need_clear: &mut bool)
                 }
             }
             let end_time = end + chrono::TimeDelta::seconds(1);
-            let mut builder =
-                PerfettoTraceBuilder::new(perfetto_cfg.per_server, perfetto_cfg.text_log_android);
+            let mut builder = PerfettoTraceBuilder::new(
+                "/tmp/chdig_perfetto.pftrace".into(),
+                perfetto_cfg.per_server,
+                perfetto_cfg.text_log_android,
+            )?;
             builder.add_queries(&queries);
             fetch_and_populate_perfetto_trace(
                 &clickhouse,

--- a/src/interpreter/worker.rs
+++ b/src/interpreter/worker.rs
@@ -678,11 +678,15 @@ fn serve_perfetto_trace(
     cb_sink: cursive::CbSink,
     builder: PerfettoTraceBuilder,
 ) -> Result<()> {
-    let (path, data_len) = builder.build()?;
-    log::info!("Saved trace to {} ({} bytes)", path.display(), data_len);
+    let (trace_file, data_len) = builder.build()?;
+    log::info!(
+        "Saved trace to {} ({} bytes)",
+        trace_file.path().display(),
+        data_len
+    );
 
     let server = context.lock().unwrap().get_or_start_perfetto_server();
-    server.set_trace_path(path);
+    server.set_trace_file(trace_file);
     let url = server.get_perfetto_url();
 
     let url_clone = url.clone();
@@ -1201,8 +1205,7 @@ async fn process_event(context: ContextArc, event: Event, need_clear: &mut bool)
         Event::PerfettoExport(queries, query_ids, start, end) => {
             let perfetto_cfg = context.lock().unwrap().options.perfetto.clone();
             let end_time = end.unwrap_or_else(Local::now) + chrono::TimeDelta::seconds(1);
-            let mut builder = PerfettoTraceBuilder::new(
-                "/tmp/chdig_perfetto.pftrace".into(),
+            let mut builder = PerfettoTraceBuilder::new_temp(
                 perfetto_cfg.per_server,
                 perfetto_cfg.text_log_android,
             )?;
@@ -1245,8 +1248,7 @@ async fn process_event(context: ContextArc, event: Event, need_clear: &mut bool)
                 }
             }
             let end_time = end + chrono::TimeDelta::seconds(1);
-            let mut builder = PerfettoTraceBuilder::new(
-                "/tmp/chdig_perfetto.pftrace".into(),
+            let mut builder = PerfettoTraceBuilder::new_temp(
                 perfetto_cfg.per_server,
                 perfetto_cfg.text_log_android,
             )?;

--- a/src/interpreter/worker.rs
+++ b/src/interpreter/worker.rs
@@ -483,7 +483,7 @@ pub(crate) async fn fetch_and_populate_perfetto_trace(
         None => {}
     }
     match stack_traces {
-        Some(Ok(block)) => builder.add_stack_traces(&block),
+        Some(Ok((samples, stacks))) => builder.add_stack_traces(&samples, &stacks),
         Some(Err(e)) => log::warn!("Failed to fetch trace_log stack traces: {}", e),
         None => {}
     }

--- a/src/view/log_store.rs
+++ b/src/view/log_store.rs
@@ -1,0 +1,407 @@
+use chrono::{DateTime, Local};
+use std::fs::File;
+use std::io::{self, BufWriter, Seek, SeekFrom, Write};
+use std::sync::Mutex;
+
+#[derive(Clone)]
+pub struct LogEntry {
+    pub host_name: String,
+    pub display_host_name: Option<String>,
+    pub event_time_microseconds: DateTime<Local>,
+    pub thread_id: u64,
+    pub level: String,
+    pub message: String,
+    pub query_id: Option<String>,
+    pub logger_name: Option<String>,
+}
+
+// Entries are kept in an anonymous temp file instead of memory (the view polls
+// the server indefinitely, so in-memory storage grows unboundedly, see #242).
+// Only the index (offset+len per entry, in logical display order) and a small
+// window of decoded entries stay in memory.
+pub struct LogStore {
+    backing: Backing,
+    // Logical display order; prepend() splices here while the file only appends,
+    // so logical order != file order in descending mode.
+    index: Vec<IndexEntry>,
+    // Reads happen from draw() which takes &self (and cursive requires View to
+    // be Sync, so this has to be a Mutex even though access is single-threaded).
+    cache: Mutex<WindowCache>,
+}
+
+#[derive(Clone, Copy)]
+struct IndexEntry {
+    offset: u64,
+    len: u32,
+}
+
+enum Backing {
+    // Nothing pushed yet, the temp file is created lazily.
+    Unopened,
+    File { file: File, end: u64 },
+    // Fallback if the temp file cannot be created (behaves like the old Vec).
+    Memory(Vec<LogEntry>),
+}
+
+const CACHE_WINDOW: usize = 256;
+
+#[derive(Default)]
+struct WindowCache {
+    start: usize,
+    entries: Vec<LogEntry>,
+}
+
+impl Default for LogStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl LogStore {
+    pub fn new() -> Self {
+        LogStore {
+            backing: Backing::Unopened,
+            index: Vec::new(),
+            cache: Mutex::new(WindowCache::default()),
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        match &self.backing {
+            Backing::Memory(entries) => entries.len(),
+            _ => self.index.len(),
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    pub fn append(&mut self, batch: Vec<LogEntry>) {
+        match self.write_batch(&batch) {
+            Some(index) => self.index.extend(index),
+            None => {
+                if let Backing::Memory(entries) = &mut self.backing {
+                    entries.extend(batch);
+                }
+            }
+        }
+    }
+
+    pub fn prepend(&mut self, batch: Vec<LogEntry>) {
+        match self.write_batch(&batch) {
+            Some(index) => {
+                // Cached indices shift by the amount actually prepended
+                self.cache.lock().unwrap().start += index.len();
+                self.index.splice(0..0, index);
+            }
+            None => {
+                if let Backing::Memory(entries) = &mut self.backing {
+                    entries.splice(0..0, batch);
+                }
+            }
+        }
+    }
+
+    pub fn with_entry<R>(&self, idx: usize, f: impl FnOnce(&LogEntry) -> R) -> Option<R> {
+        let file = match &self.backing {
+            Backing::Memory(entries) => return entries.get(idx).map(f),
+            Backing::Unopened => return None,
+            Backing::File { file, .. } => file,
+        };
+        if idx >= self.index.len() {
+            return None;
+        }
+
+        {
+            let cache = self.cache.lock().unwrap();
+            if idx >= cache.start && idx < cache.start + cache.entries.len() {
+                return Some(f(&cache.entries[idx - cache.start]));
+            }
+        }
+
+        // Miss: load a window centered on idx, so both forward scans and
+        // reverse scans hit the cache for the neighbouring entries.
+        let start = idx.saturating_sub(CACHE_WINDOW / 2);
+        let end = usize::min(start + CACHE_WINDOW, self.index.len());
+        let mut entries = Vec::with_capacity(end - start);
+        let mut buf = Vec::new();
+        for entry in &self.index[start..end] {
+            buf.resize(entry.len as usize, 0);
+            if let Err(e) = read_exact_at(file, entry.offset, &mut buf) {
+                log::error!("LogStore: failed to read log entry: {}", e);
+                return None;
+            }
+            match decode_entry(&buf) {
+                Some(entry) => entries.push(entry),
+                None => {
+                    log::error!("LogStore: failed to decode log entry");
+                    return None;
+                }
+            }
+        }
+        let mut cache = self.cache.lock().unwrap();
+        *cache = WindowCache { start, entries };
+        Some(f(&cache.entries[idx - cache.start]))
+    }
+
+    // Returns the index entries for the batch, or None for the Memory backing
+    // (including the case when it has just degraded to it).
+    fn write_batch(&mut self, batch: &[LogEntry]) -> Option<Vec<IndexEntry>> {
+        if let Backing::Unopened = self.backing {
+            self.backing = match tempfile::tempfile() {
+                Ok(file) => Backing::File { file, end: 0 },
+                Err(e) => {
+                    log::error!(
+                        "LogStore: cannot create temporary file, keeping logs in memory: {}",
+                        e
+                    );
+                    Backing::Memory(Vec::new())
+                }
+            };
+        }
+        let Backing::File { file, end } = &mut self.backing else {
+            return None;
+        };
+
+        let mut index = Vec::with_capacity(batch.len());
+        let mut buf = Vec::new();
+        let result = (|| -> io::Result<()> {
+            file.seek(SeekFrom::Start(*end))?;
+            let mut out = BufWriter::new(&*file);
+            for entry in batch {
+                buf.clear();
+                encode_entry(entry, &mut buf);
+                out.write_all(&buf)?;
+                index.push(IndexEntry {
+                    offset: *end,
+                    len: buf.len() as u32,
+                });
+                *end += buf.len() as u64;
+            }
+            out.flush()
+        })();
+        if let Err(e) = result {
+            // No fallback here: a write failure (e.g. disk full) would likely
+            // repeat for any further batches, do not start eating memory instead.
+            log::error!("LogStore: failed to write log entries (dropped): {}", e);
+            index.truncate(0);
+        }
+        Some(index)
+    }
+}
+
+#[cfg(unix)]
+fn read_exact_at(file: &File, offset: u64, buf: &mut [u8]) -> io::Result<()> {
+    use std::os::unix::fs::FileExt;
+    file.read_exact_at(buf, offset)
+}
+
+#[cfg(not(unix))]
+fn read_exact_at(mut file: &File, offset: u64, buf: &mut [u8]) -> io::Result<()> {
+    use std::io::Read;
+    file.seek(SeekFrom::Start(offset))?;
+    file.read_exact(buf)
+}
+
+// The format is private, ephemeral and single-process, hence no
+// versioning/compatibility concerns (and no serde machinery needed).
+fn put_str(buf: &mut Vec<u8>, s: &str) {
+    buf.extend_from_slice(&(s.len() as u32).to_le_bytes());
+    buf.extend_from_slice(s.as_bytes());
+}
+
+// None is encoded as u32::MAX length (a single string cannot realistically
+// reach 4GiB, ClickHouse log messages are far smaller).
+fn put_opt_str(buf: &mut Vec<u8>, s: Option<&str>) {
+    match s {
+        Some(s) => put_str(buf, s),
+        None => buf.extend_from_slice(&u32::MAX.to_le_bytes()),
+    }
+}
+
+fn encode_entry(entry: &LogEntry, buf: &mut Vec<u8>) {
+    buf.extend_from_slice(
+        &entry
+            .event_time_microseconds
+            .timestamp_micros()
+            .to_le_bytes(),
+    );
+    buf.extend_from_slice(&entry.thread_id.to_le_bytes());
+    put_str(buf, &entry.host_name);
+    put_str(buf, &entry.level);
+    put_str(buf, &entry.message);
+    put_opt_str(buf, entry.display_host_name.as_deref());
+    put_opt_str(buf, entry.query_id.as_deref());
+    put_opt_str(buf, entry.logger_name.as_deref());
+}
+
+struct Reader<'a> {
+    buf: &'a [u8],
+}
+
+impl<'a> Reader<'a> {
+    fn bytes(&mut self, n: usize) -> Option<&'a [u8]> {
+        let (head, tail) = self.buf.split_at_checked(n)?;
+        self.buf = tail;
+        Some(head)
+    }
+
+    fn u32(&mut self) -> Option<u32> {
+        Some(u32::from_le_bytes(self.bytes(4)?.try_into().unwrap()))
+    }
+
+    fn str(&mut self) -> Option<String> {
+        let len = self.u32()? as usize;
+        String::from_utf8(self.bytes(len)?.to_vec()).ok()
+    }
+
+    fn opt_str(&mut self) -> Option<Option<String>> {
+        if self.buf.len() >= 4 && self.buf[..4] == u32::MAX.to_le_bytes() {
+            let _ = self.bytes(4);
+            return Some(None);
+        }
+        Some(Some(self.str()?))
+    }
+}
+
+fn decode_entry(buf: &[u8]) -> Option<LogEntry> {
+    let mut r = Reader { buf };
+    let micros = i64::from_le_bytes(r.bytes(8)?.try_into().unwrap());
+    let thread_id = u64::from_le_bytes(r.bytes(8)?.try_into().unwrap());
+    Some(LogEntry {
+        event_time_microseconds: DateTime::from_timestamp_micros(micros)?.with_timezone(&Local),
+        thread_id,
+        host_name: r.str()?,
+        level: r.str()?,
+        message: r.str()?,
+        display_host_name: r.opt_str()?,
+        query_id: r.opt_str()?,
+        logger_name: r.opt_str()?,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(n: u64) -> LogEntry {
+        LogEntry {
+            host_name: format!("host{}", n),
+            display_host_name: n.is_multiple_of(2).then(|| format!("h{}", n)),
+            event_time_microseconds: DateTime::from_timestamp_micros(1700000000000000 + n as i64)
+                .unwrap()
+                .with_timezone(&Local),
+            thread_id: n,
+            level: "Trace".to_string(),
+            message: format!("message {} с юникодом", n),
+            query_id: n.is_multiple_of(3).then(|| format!("query-{}", n)),
+            logger_name: None,
+        }
+    }
+
+    fn assert_entry_eq(a: &LogEntry, b: &LogEntry) {
+        assert_eq!(a.host_name, b.host_name);
+        assert_eq!(a.display_host_name, b.display_host_name);
+        assert_eq!(a.event_time_microseconds, b.event_time_microseconds);
+        assert_eq!(a.thread_id, b.thread_id);
+        assert_eq!(a.level, b.level);
+        assert_eq!(a.message, b.message);
+        assert_eq!(a.query_id, b.query_id);
+        assert_eq!(a.logger_name, b.logger_name);
+    }
+
+    #[test]
+    fn codec_roundtrip() {
+        for n in 0..6 {
+            let e = entry(n);
+            let mut buf = Vec::new();
+            encode_entry(&e, &mut buf);
+            assert_entry_eq(&decode_entry(&buf).unwrap(), &e);
+        }
+        // Empty strings and all-None options
+        let e = LogEntry {
+            host_name: String::new(),
+            display_host_name: None,
+            event_time_microseconds: DateTime::from_timestamp_micros(0)
+                .unwrap()
+                .with_timezone(&Local),
+            thread_id: 0,
+            level: String::new(),
+            message: String::new(),
+            query_id: None,
+            logger_name: None,
+        };
+        let mut buf = Vec::new();
+        encode_entry(&e, &mut buf);
+        assert_entry_eq(&decode_entry(&buf).unwrap(), &e);
+        // Truncated input must not panic
+        for cut in 0..buf.len() {
+            decode_entry(&buf[..cut]);
+        }
+    }
+
+    #[test]
+    fn append_order() {
+        let mut store = LogStore::new();
+        assert!(store.is_empty());
+        assert!(store.with_entry(0, |_| ()).is_none());
+
+        store.append((0..10).map(entry).collect());
+        store.append((10..20).map(entry).collect());
+        assert_eq!(store.len(), 20);
+        for i in 0..20 {
+            assert_entry_eq(
+                &store.with_entry(i, |e| e.clone()).unwrap(),
+                &entry(i as u64),
+            );
+        }
+        assert!(store.with_entry(20, |_| ()).is_none());
+    }
+
+    #[test]
+    fn prepend_order() {
+        let mut store = LogStore::new();
+        // Descending mode: each batch is newest-first and goes in front
+        store.prepend((10..20).map(entry).collect());
+        store.prepend((0..10).map(entry).collect());
+        assert_eq!(store.len(), 20);
+        for i in 0..20 {
+            assert_entry_eq(
+                &store.with_entry(i, |e| e.clone()).unwrap(),
+                &entry(i as u64),
+            );
+        }
+    }
+
+    #[test]
+    fn window_boundaries() {
+        let count = CACHE_WINDOW * 3 + 17;
+        let mut store = LogStore::new();
+        store.append((0..count as u64).map(entry).collect());
+        // Jump around to force cache misses at both directions and boundaries
+        for &i in &[count - 1, 0, count / 2, count - 1, 1, count / 2 + 1] {
+            assert_eq!(store.with_entry(i, |e| e.thread_id).unwrap(), i as u64);
+        }
+        // Backward scan (reverse search pattern)
+        for i in (0..count).rev() {
+            assert_eq!(store.with_entry(i, |e| e.thread_id).unwrap(), i as u64);
+        }
+    }
+
+    #[test]
+    fn memory_fallback() {
+        let mut store = LogStore::new();
+        store.backing = Backing::Memory(Vec::new());
+        store.append((5..10).map(entry).collect());
+        store.prepend((0..5).map(entry).collect());
+        assert_eq!(store.len(), 10);
+        for i in 0..10 {
+            assert_entry_eq(
+                &store.with_entry(i, |e| e.clone()).unwrap(),
+                &entry(i as u64),
+            );
+        }
+    }
+}

--- a/src/view/log_view.rs
+++ b/src/view/log_view.rs
@@ -1,5 +1,5 @@
 use anyhow::{Error, Result};
-use chrono::{DateTime, Datelike, Duration, Local, Timelike};
+use chrono::{Datelike, Duration, Timelike};
 use cursive::{
     Cursive, Printer, Vec2,
     event::{Callback, Event, EventResult, Key},
@@ -19,6 +19,7 @@ use unicode_width::UnicodeWidthStr;
 use crate::common::RelativeDateTime;
 use crate::interpreter::{ContextArc, TextLogArguments};
 use crate::utils::find_common_hostname_prefix_and_suffix;
+use crate::view::log_store::{LogEntry, LogStore};
 use crate::view::{TextLogView, show_bottom_prompt};
 
 // Hash-based color function matching ClickHouse's setColor from terminalColors.cpp
@@ -79,18 +80,6 @@ fn string_hash(s: &str) -> u64 {
     let mut hasher = DefaultHasher::new();
     s.hash(&mut hasher);
     hasher.finish()
-}
-
-#[derive(Clone)]
-pub struct LogEntry {
-    pub host_name: String,
-    pub display_host_name: Option<String>,
-    pub event_time_microseconds: DateTime<Local>,
-    pub thread_id: u64,
-    pub level: String,
-    pub message: String,
-    pub query_id: Option<String>,
-    pub logger_name: Option<String>,
 }
 
 struct IdentifierMaps {
@@ -231,7 +220,7 @@ pub struct LogViewBase {
     filter_identifiers: HashMap<String, FilterType>,
     active_filter: Option<FilterType>,
 
-    logs: Vec<LogEntry>,
+    logs: LogStore,
 
     // When filtering is active, stores indices into self.logs for visible entries
     // Empty when no filter is active (all logs visible)
@@ -264,7 +253,7 @@ impl Default for LogViewBase {
             filter_mode: false,
             filter_identifiers: HashMap::new(),
             active_filter: None,
-            logs: Vec::new(),
+            logs: LogStore::new(),
             filtered_log_indices: Vec::new(),
             log_cumulative_rows: Vec::new(),
             last_computed_width: usize::MAX,
@@ -275,15 +264,16 @@ impl Default for LogViewBase {
 cursive::impl_scroller!(LogViewBase::scroll_core);
 
 impl LogViewBase {
-    // Get the log at the given visible index
+    // Call f with the log at the given visible index (logs live on disk, so
+    // only a borrow scoped to the store's cache can be handed out).
     // If filtering is active, maps through filtered_log_indices
-    fn get_visible_log(&self, visible_idx: usize) -> Option<&LogEntry> {
+    fn with_visible_log<R>(&self, visible_idx: usize, f: impl FnOnce(&LogEntry) -> R) -> Option<R> {
         if self.filtered_log_indices.is_empty() {
-            self.logs.get(visible_idx)
+            self.logs.with_entry(visible_idx, f)
         } else {
             self.filtered_log_indices
                 .get(visible_idx)
-                .and_then(|&idx| self.logs.get(idx))
+                .and_then(|&idx| self.logs.with_entry(idx, f))
         }
     }
 
@@ -379,17 +369,19 @@ impl LogViewBase {
         let mut levels: HashMap<String, usize> = HashMap::new();
         let mut host_names: HashMap<String, usize> = HashMap::new();
 
-        for log in &self.logs {
-            if let Some(ref query_id) = log.query_id
-                && !query_id.is_empty()
-            {
-                query_ids.entry(query_id.clone()).or_insert(0);
-            }
-            if let Some(ref logger_name) = log.logger_name {
-                logger_names.entry(logger_name.clone()).or_insert(0);
-            }
-            levels.entry(log.level.clone()).or_insert(0);
-            host_names.entry(log.host_name.clone()).or_insert(0);
+        for i in 0..self.logs.len() {
+            self.logs.with_entry(i, |log| {
+                if let Some(ref query_id) = log.query_id
+                    && !query_id.is_empty()
+                {
+                    query_ids.entry(query_id.clone()).or_insert(0);
+                }
+                if let Some(ref logger_name) = log.logger_name {
+                    logger_names.entry(logger_name.clone()).or_insert(0);
+                }
+                levels.entry(log.level.clone()).or_insert(0);
+                host_names.entry(log.host_name.clone()).or_insert(0);
+            });
         }
 
         self.filter_identifiers.clear();
@@ -443,17 +435,19 @@ impl LogViewBase {
         self.filtered_log_indices.clear();
 
         if let Some(ref filter) = self.active_filter {
-            for (idx, log) in self.logs.iter().enumerate() {
-                let matches = match filter {
+            let mut indices = Vec::new();
+            for idx in 0..self.logs.len() {
+                let matches = self.logs.with_entry(idx, |log| match filter {
                     FilterType::QueryId(val) => log.query_id.as_ref() == Some(val),
                     FilterType::LoggerName(val) => log.logger_name.as_ref() == Some(val),
                     FilterType::Level(val) => &log.level == val,
                     FilterType::HostName(val) => &log.host_name == val,
-                };
-                if matches {
-                    self.filtered_log_indices.push(idx);
+                });
+                if matches == Some(true) {
+                    indices.push(idx);
                 }
             }
+            self.filtered_log_indices = indices;
         }
 
         self.needs_relayout = true;
@@ -503,12 +497,14 @@ impl LogViewBase {
         identifier_maps: &Option<IdentifierMaps>,
         forward: bool,
     ) -> bool {
-        if let Some(log) = self.get_visible_log(log_idx) {
-            let mut styled = if let Some(maps) = identifier_maps {
+        let styled = self.with_visible_log(log_idx, |log| {
+            if let Some(maps) = identifier_maps {
                 log.to_styled_string_with_identifiers(self.cluster, Some(maps))
             } else {
                 log.to_styled_string(self.cluster)
-            };
+            }
+        });
+        if let Some(mut styled) = styled {
             styled.append("\n");
 
             let display_row_start = self.log_to_display_row(log_idx);
@@ -660,11 +656,11 @@ impl LogViewBase {
         if self.descending {
             // Prepend: the batch already arrives newest-first (ORDER BY ... DESC),
             // so splicing at the front keeps the global ordering newest -> oldest.
-            self.logs.splice(0..0, logs);
+            self.logs.prepend(logs);
             // Indices of existing logs shifted, so incremental compute_rows() is unsafe.
             self.log_cumulative_rows.clear();
         } else {
-            self.logs.extend(logs);
+            self.logs.append(logs);
         }
 
         if self.filter_mode {
@@ -737,8 +733,10 @@ impl LogViewBase {
 
         // Build cumulative row counts by computing styled strings on-demand
         // We compute them here just to count rows, then discard them (saves memory)
+        // NOTE: a non-incremental pass (resize, wrap or filter toggle) re-reads
+        // every entry from the store, i.e. the whole backing file.
         for i in start_idx..visible_count {
-            if let Some(log) = self.get_visible_log(i) {
+            let counts = self.with_visible_log(i, |log| {
                 let mut styled = if let Some(ref maps) = identifier_maps {
                     log.to_styled_string_with_identifiers(self.cluster, Some(maps))
                 } else {
@@ -747,10 +745,15 @@ impl LogViewBase {
                 styled.append("\n");
 
                 let mut row_count = 0;
+                let mut row_max_width = 0;
                 for row in LinesIterator::new(&styled, width) {
-                    max_width = usize::max(max_width, row.width);
+                    row_max_width = usize::max(row_max_width, row.width);
                     row_count += 1;
                 }
+                (row_count, row_max_width)
+            });
+            if let Some((row_count, row_max_width)) = counts {
+                max_width = usize::max(max_width, row_max_width);
                 cumulative += row_count;
                 self.log_cumulative_rows.push(cumulative);
             }
@@ -823,13 +826,14 @@ impl LogViewBase {
         for display_row in start_row..end_row.min(total_rows) {
             // Binary search to find which log this display row belongs to
             if let Some((log_idx, row_within_log)) = self.display_row_to_log(display_row)
-                && let Some(log) = self.get_visible_log(log_idx)
+                && let Some(mut styled) = self.with_visible_log(log_idx, |log| {
+                    if let Some(ref maps) = identifier_maps {
+                        log.to_styled_string_with_identifiers(self.cluster, Some(maps))
+                    } else {
+                        log.to_styled_string(self.cluster)
+                    }
+                })
             {
-                let mut styled = if let Some(ref maps) = identifier_maps {
-                    log.to_styled_string_with_identifiers(self.cluster, Some(maps))
-                } else {
-                    log.to_styled_string(self.cluster)
-                };
                 styled.append("\n");
                 if let Some(row) =
                     LinesIterator::new(&styled, self.last_computed_width).nth(row_within_log)
@@ -904,7 +908,7 @@ impl LogViewBase {
         let visible_count = self.visible_log_count();
 
         for i in 0..visible_count {
-            if let Some(log) = self.get_visible_log(i) {
+            let result = self.with_visible_log(i, |log| -> Result<()> {
                 let mut styled = log.to_styled_string(self.cluster);
                 styled.append("\n");
 
@@ -914,7 +918,9 @@ impl LogViewBase {
                     }
                     writer.write_all(b"\n")?;
                 }
-            }
+                Ok(())
+            });
+            result.transpose()?;
         }
         Ok(())
     }
@@ -937,10 +943,8 @@ fn show_filtered_logs_popup(siv: &mut Cursive) {
         let viewport = base.scroll_core.content_viewport();
         let top_row = viewport.top();
 
-        if let Some((log_idx, _)) = base.display_row_to_log(top_row)
-            && let Some(log) = base.get_visible_log(log_idx)
-        {
-            return Some(log.event_time_microseconds);
+        if let Some((log_idx, _)) = base.display_row_to_log(top_row) {
+            return base.with_visible_log(log_idx, |log| log.event_time_microseconds);
         }
         None
     });

--- a/src/view/mod.rs
+++ b/src/view/mod.rs
@@ -1,3 +1,4 @@
+mod log_store;
 mod log_view;
 mod navigation;
 mod provider;
@@ -25,7 +26,7 @@ pub use summary_view::SummaryView;
 
 pub use table_view::TableViewItem;
 
-pub use log_view::LogEntry;
+pub use log_store::LogEntry;
 pub use log_view::LogView;
 pub use text_log_view::TextLogView;
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -411,17 +411,26 @@ async fn test_stack_traces_for_perfetto() {
 
     let chdig = server.chdig().await;
     let (start, end) = perfetto_window();
-    let block = chdig
+    let (samples, stacks) = chdig
         .get_stack_traces_for_perfetto(Some(&["it-stack-1".to_string()]), start, end)
         .await
         .unwrap();
-    assert_eq!(block.row_count(), 1);
+    assert_eq!(samples.row_count(), 1);
+    assert_eq!(samples.get::<String, _>(0, "trace_type").unwrap(), "CPU");
+    assert_eq!(stacks.row_count(), 1);
     assert_eq!(
-        block.get::<Vec<String>, _>(0, "stack").unwrap(),
+        stacks.get::<Vec<String>, _>(0, "stack").unwrap(),
         vec!["it_main".to_string(), "it_leaf".to_string()]
     );
-    assert_eq!(block.get::<String, _>(0, "trace_type").unwrap(), "CPU");
-    assert_eq!(block.get::<u64, _>(0, "thread_id").unwrap(), 7);
+    // Samples reference stacks via (host_name, stack_hash)
+    assert_eq!(
+        samples.get::<u64, _>(0, "stack_hash").unwrap(),
+        stacks.get::<u64, _>(0, "stack_hash").unwrap()
+    );
+    assert_eq!(
+        samples.get::<String, _>(0, "host_name").unwrap(),
+        stacks.get::<String, _>(0, "host_name").unwrap()
+    );
 }
 
 async fn test_trace_log_counters_for_perfetto() {


### PR DESCRIPTION
perfertto traces/logs can take a lot of RAM, recently I was trying to expose some traces that eat > 60GiB of RAM

This PR also includes some optimizations for perfetto traces, that drastically improve the loading speed (several magnitudes).

And also contains a fix for perfetto to load queries

Fixes: https://github.com/azat/chdig/issues/242