### PR TITLE
Optimize perfetto traces (from 40GiB -> ~400MiB, or even less)

### DIFF
--- a/src/bin.rs
+++ b/src/bin.rs
@@ -11,8 +11,9 @@ use cursive::view::Resizable;
 
 use crate::{
     interpreter::{
-        ClickHouse, Context, ContextArc, Query, fetch_and_populate_perfetto_trace,
+        ClickHouse, Context, ContextArc, fetch_and_populate_perfetto_trace,
         fetch_server_perfetto_sources, options, perfetto::PerfettoTraceBuilder,
+        stream_queries_into_perfetto_trace,
     },
     view::Navigation,
 };
@@ -88,17 +89,6 @@ async fn run_cli_perfetto_export(
     // Match TUI behavior: include events that arrived in the same second as the query end.
     scope.end += TimeDelta::seconds(1);
 
-    let query_block = clickhouse
-        .get_queries_for_perfetto(scope.start, scope.end, &scope.query_ids)
-        .await?;
-    let mut queries = Vec::new();
-    for i in 0..query_block.row_count() {
-        match Query::from_clickhouse_block(&query_block, i, false) {
-            Ok(q) => queries.push(q),
-            Err(e) => log::warn!("Perfetto: failed to parse query row {}: {}", i, e),
-        }
-    }
-
     let output = derive_output_path(
         options.view.output.as_deref(),
         is_server_scope,
@@ -110,7 +100,14 @@ async fn run_cli_perfetto_export(
         perfetto_options.per_server,
         perfetto_options.text_log_android,
     )?;
-    builder.add_queries(&queries);
+    stream_queries_into_perfetto_trace(
+        clickhouse,
+        &mut builder,
+        &scope.query_ids,
+        scope.start,
+        scope.end,
+    )
+    .await;
     fetch_and_populate_perfetto_trace(
         clickhouse,
         &mut builder,

--- a/src/interpreter/clickhouse.rs
+++ b/src/interpreter/clickhouse.rs
@@ -1623,8 +1623,12 @@ impl ClickHouse {
                         thread_name,
                         event_time_microseconds,
                         query_duration_ms,
-                        ProfileEvents.Names,
-                        ProfileEvents.Values,
+                        -- Most of ~2K ProfileEvents are zero per thread and Names repeat
+                        -- in every row - do not transfer them (GBs for busy servers)
+                        arrayFilter((n, v) -> v != 0, ProfileEvents.Names, ProfileEvents.Values)
+                            AS `ProfileEvents.Names`,
+                        arrayFilter(v -> v != 0, ProfileEvents.Values)
+                            AS `ProfileEvents.Values`,
                         peak_memory_usage,
                         {host_expr} AS host_name
                     FROM {dbtable}
@@ -2118,8 +2122,12 @@ impl ClickHouse {
         tx: &mut futures::channel::mpsc::Sender<T>,
         wrap: impl Fn(Block) -> T,
     ) -> Result<()> {
+        // Blocks are capped by rows, not bytes: with wide rows (e.g. ~2K
+        // metric_log columns) a default 65K-row block is GBs of allocations,
+        // and the channel keeps several blocks in flight.
+        let query = format!("{} SETTINGS max_block_size=8192", query);
         let mut client = self.pool.get_handle().await?;
-        let mut stream = client.query(query).stream_blocks();
+        let mut stream = client.query(&query).stream_blocks();
         let mut rows = 0;
         while let Some(block) = stream.next().await {
             let block = block?;

--- a/src/interpreter/clickhouse.rs
+++ b/src/interpreter/clickhouse.rs
@@ -10,8 +10,9 @@ use chrono::{DateTime, Local};
 use chrono_tz::Tz;
 use clickhouse_rs::{
     Block, Options, Pool,
-    types::{Complex, FromSql},
+    types::{ColumnType, Complex, FromSql},
 };
+use futures::SinkExt;
 use futures_util::StreamExt;
 use std::collections::HashMap;
 use std::str::FromStr;
@@ -176,6 +177,85 @@ pub struct MetricLogRow {
     pub timestamp_ns: u64,
     pub profile_events: HashMap<String, u64>,
     pub current_metrics: HashMap<String, i64>,
+}
+
+// Lookup by column index: by-name lookup is a linear scan in clickhouse-rs,
+// which is quadratic over ~2K ProfileEvent_*/CurrentMetric_* columns.
+fn metric_columns<'a, K: ColumnType>(block: &'a Block<K>, prefix: &str) -> Vec<(usize, &'a str)> {
+    block
+        .columns()
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, c)| c.name().strip_prefix(prefix).map(|name| (idx, name)))
+        .collect()
+}
+
+fn block_timestamp_ns<K: ColumnType>(block: &Block<K>, i: usize, log: &str) -> Option<u64> {
+    match block.get::<DateTime<Tz>, _>(i, "event_time_microseconds") {
+        Ok(dt) => Some(dt.with_timezone(&Local).timestamp_nanos_opt().unwrap_or(0) as u64),
+        Err(e) => {
+            log::warn!("Perfetto: {} row {} event_time_microseconds: {}", log, i, e);
+            None
+        }
+    }
+}
+
+pub fn parse_query_metric_log_block<K: ColumnType>(block: &Block<K>) -> Vec<QueryMetricRow> {
+    let pe_columns = metric_columns(block, "ProfileEvent_");
+
+    let mut rows = Vec::with_capacity(block.row_count());
+    for i in 0..block.row_count() {
+        let mut profile_events = HashMap::new();
+        for &(idx, name) in &pe_columns {
+            let value: u64 = block.get(i, idx).unwrap_or(0);
+            if value != 0 {
+                profile_events.insert(name.to_string(), value);
+            }
+        }
+        let Some(ts_ns) = block_timestamp_ns(block, i, "query_metric_log") else {
+            continue;
+        };
+        rows.push(QueryMetricRow {
+            host_name: block.get(i, "host_name").unwrap_or_default(),
+            timestamp_ns: ts_ns,
+            memory_usage: block.get(i, "memory_usage").unwrap_or(0),
+            peak_memory_usage: block.get(i, "peak_memory_usage").unwrap_or(0),
+            profile_events,
+        });
+    }
+    rows
+}
+
+pub fn parse_metric_log_block<K: ColumnType>(block: &Block<K>) -> Vec<MetricLogRow> {
+    let pe_columns = metric_columns(block, "ProfileEvent_");
+    let cm_columns = metric_columns(block, "CurrentMetric_");
+
+    let mut rows = Vec::with_capacity(block.row_count());
+    for i in 0..block.row_count() {
+        let Some(ts_ns) = block_timestamp_ns(block, i, "metric_log") else {
+            continue;
+        };
+        let mut profile_events = HashMap::new();
+        for &(idx, name) in &pe_columns {
+            let value: u64 = block.get(i, idx).unwrap_or(0);
+            if value != 0 {
+                profile_events.insert(name.to_string(), value);
+            }
+        }
+        let mut current_metrics = HashMap::new();
+        for &(idx, name) in &cm_columns {
+            let value: i64 = block.get(i, idx).unwrap_or(0);
+            if value != 0 {
+                current_metrics.insert(name.to_string(), value);
+            }
+        }
+        rows.push(MetricLogRow {
+            timestamp_ns: ts_ns,
+            profile_events,
+            current_metrics,
+        });
+    }
+    rows
 }
 
 fn collect_values<'b, T: FromSql<'b>>(block: &'b Columns, column: &str) -> Vec<T> {
@@ -1224,12 +1304,12 @@ impl ClickHouse {
         Ok(query_ids)
     }
 
-    pub async fn get_otel_spans_for_perfetto(
+    pub fn otel_spans_for_perfetto_sql(
         &self,
         query_ids: Option<&[String]>,
         start: DateTime<Local>,
         end: DateTime<Local>,
-    ) -> Result<Columns> {
+    ) -> Result<String> {
         let dbtable = self.get_log_table_name("opentelemetry_span_log");
         let start_us = start.timestamp_micros();
         let end_us = end.timestamp_micros();
@@ -1241,9 +1321,8 @@ impl ClickHouse {
         } else {
             String::new()
         };
-        return self
-            .execute(&format!(
-                r#"
+        Ok(format!(
+            r#"
                     SELECT
                         operation_name,
                         start_time_us,
@@ -1255,30 +1334,28 @@ impl ClickHouse {
                       {query_id_filter}
                     ORDER BY start_time_us
                     "#,
-                dbtable = dbtable,
-                start_us = start_us,
-                end_us = end_us,
-                query_id_filter = query_id_filter,
-                host_expr = self.get_log_hostname_column(),
-            ))
-            .await;
+            dbtable = dbtable,
+            start_us = start_us,
+            end_us = end_us,
+            query_id_filter = query_id_filter,
+            host_expr = self.get_log_hostname_column(),
+        ))
     }
 
-    pub async fn get_trace_log_counters_for_perfetto(
+    pub fn trace_log_counters_for_perfetto_sql(
         &self,
         query_ids: Option<&[String]>,
         start: DateTime<Local>,
         end: DateTime<Local>,
-    ) -> Result<Columns> {
+    ) -> Result<String> {
         let dbtable = self.get_log_table_name("trace_log");
         let query_id_filter = if let Some(ids) = query_ids {
             format!("AND query_id IN ('{}')", ids.join("','"))
         } else {
             String::new()
         };
-        return self
-            .execute(&format!(
-                r#"
+        Ok(format!(
+            r#"
                     WITH
                         fromUnixTimestamp64Nano({start}) AS start_,
                         fromUnixTimestamp64Nano({end}) AS end_
@@ -1295,32 +1372,30 @@ impl ClickHouse {
                       AND event_date <= toDate(end_)   AND event_time <= toDateTime(end_)
                     ORDER BY event_time_microseconds
                     "#,
-                dbtable = dbtable,
-                start = start
-                    .timestamp_nanos_opt()
-                    .ok_or(Error::msg("Invalid start"))?,
-                end = end.timestamp_nanos_opt().ok_or(Error::msg("Invalid end"))?,
-                query_id_filter = query_id_filter,
-                host_expr = self.get_log_hostname_column(),
-            ))
-            .await;
+            dbtable = dbtable,
+            start = start
+                .timestamp_nanos_opt()
+                .ok_or(Error::msg("Invalid start"))?,
+            end = end.timestamp_nanos_opt().ok_or(Error::msg("Invalid end"))?,
+            query_id_filter = query_id_filter,
+            host_expr = self.get_log_hostname_column(),
+        ))
     }
 
-    pub async fn get_query_metrics_for_perfetto(
+    pub fn query_metric_log_for_perfetto_sql(
         &self,
         query_ids: Option<&[String]>,
         start: DateTime<Local>,
         end: DateTime<Local>,
-    ) -> Result<Vec<QueryMetricRow>> {
+    ) -> Result<String> {
         let dbtable = self.get_log_table_name("query_metric_log");
         let query_id_filter = if let Some(ids) = query_ids {
             format!("AND query_id IN ('{}')", ids.join("','"))
         } else {
             String::new()
         };
-        let block = self
-            .execute(&format!(
-                r#"
+        Ok(format!(
+            r#"
                     WITH
                         fromUnixTimestamp64Nano({start}) AS start_,
                         fromUnixTimestamp64Nano({end}) AS end_
@@ -1338,75 +1413,30 @@ impl ClickHouse {
                       AND event_date <= toDate(end_)   AND event_time <= toDateTime(end_)
                     ORDER BY event_time_microseconds
                     "#,
-                dbtable = dbtable,
-                start = start
-                    .timestamp_nanos_opt()
-                    .ok_or(Error::msg("Invalid start"))?,
-                end = end.timestamp_nanos_opt().ok_or(Error::msg("Invalid end"))?,
-                query_id_filter = query_id_filter,
-                host_expr = self.get_log_hostname_column(),
-            ))
-            .await?;
-
-        // Lookup by column index: by-name lookup is a linear scan in
-        // clickhouse-rs, which is quadratic over ~2K ProfileEvent_* columns.
-        let pe_columns: Vec<(usize, &str)> = block
-            .columns()
-            .iter()
-            .enumerate()
-            .filter_map(|(idx, c)| {
-                c.name()
-                    .strip_prefix("ProfileEvent_")
-                    .map(|name| (idx, name))
-            })
-            .collect();
-
-        let mut rows = Vec::with_capacity(block.row_count());
-        for i in 0..block.row_count() {
-            let mut profile_events = HashMap::new();
-            for &(idx, name) in &pe_columns {
-                let value: u64 = block.get(i, idx).unwrap_or(0);
-                if value != 0 {
-                    profile_events.insert(name.to_string(), value);
-                }
-            }
-            let ts_ns = match block.get::<DateTime<Tz>, _>(i, "event_time_microseconds") {
-                Ok(dt) => dt.with_timezone(&Local).timestamp_nanos_opt().unwrap_or(0) as u64,
-                Err(e) => {
-                    log::warn!(
-                        "Perfetto: query_metric_log row {} event_time_microseconds: {}",
-                        i,
-                        e
-                    );
-                    continue;
-                }
-            };
-            rows.push(QueryMetricRow {
-                host_name: block.get(i, "host_name").unwrap_or_default(),
-                timestamp_ns: ts_ns,
-                memory_usage: block.get(i, "memory_usage").unwrap_or(0),
-                peak_memory_usage: block.get(i, "peak_memory_usage").unwrap_or(0),
-                profile_events,
-            });
-        }
-        Ok(rows)
+            dbtable = dbtable,
+            start = start
+                .timestamp_nanos_opt()
+                .ok_or(Error::msg("Invalid start"))?,
+            end = end.timestamp_nanos_opt().ok_or(Error::msg("Invalid end"))?,
+            query_id_filter = query_id_filter,
+            host_expr = self.get_log_hostname_column(),
+        ))
     }
 
-    pub async fn get_part_log_for_perfetto(
+    pub fn part_log_for_perfetto_sql(
         &self,
         query_ids: Option<&[String]>,
         start: DateTime<Local>,
         end: DateTime<Local>,
-    ) -> Result<Columns> {
+    ) -> Result<String> {
         let dbtable = self.get_log_table_name("part_log");
         let query_id_filter = if let Some(ids) = query_ids {
             format!("AND query_id IN ('{}')", ids.join("','"))
         } else {
             String::new()
         };
-        return self
-            .execute(&format!(
-                r#"
+        Ok(format!(
+            r#"
                     WITH
                         fromUnixTimestamp64Nano({start}) AS start_,
                         fromUnixTimestamp64Nano({end}) AS end_
@@ -1428,38 +1458,21 @@ impl ClickHouse {
                       AND event_date <= toDate(end_)   AND event_time <= toDateTime(end_)
                     ORDER BY event_time_microseconds
                     "#,
-                dbtable = dbtable,
-                start = start
-                    .timestamp_nanos_opt()
-                    .ok_or(Error::msg("Invalid start"))?,
-                end = end.timestamp_nanos_opt().ok_or(Error::msg("Invalid end"))?,
-                query_id_filter = query_id_filter,
-                host_expr = self.get_log_hostname_column(),
-            ))
-            .await;
+            dbtable = dbtable,
+            start = start
+                .timestamp_nanos_opt()
+                .ok_or(Error::msg("Invalid start"))?,
+            end = end.timestamp_nanos_opt().ok_or(Error::msg("Invalid end"))?,
+            query_id_filter = query_id_filter,
+            host_expr = self.get_log_hostname_column(),
+        ))
     }
 
-    /// Returns (samples, stacks): samples carry only cityHash64(trace) per row,
-    /// stacks map (host_name, stack_hash) to the symbolized stack of each
-    /// unique trace. Symbolizing/transferring the stack per sample is hundreds
-    /// of MBs even for an hour of trace_log (the dedup factor is ~100x).
-    pub async fn get_stack_traces_for_perfetto(
-        &self,
+    fn stack_trace_with_filter(
         query_ids: Option<&[String]>,
         start: DateTime<Local>,
         end: DateTime<Local>,
-    ) -> Result<(Columns, Columns)> {
-        let dbtable = self.get_log_table_name("trace_log");
-        let symbol_expr = if self
-            .quirks
-            .has(ClickHouseAvailableQuirks::TraceLogHasSymbols)
-        {
-            r#"arrayReverse(if(empty(any(symbols)),
-                arrayMap(addr -> demangle(addressToSymbol(addr)), trace),
-                any(symbols)))"#
-        } else {
-            "arrayReverse(arrayMap(addr -> demangle(addressToSymbol(addr)), trace))"
-        };
+    ) -> Result<(String, String)> {
         let query_id_filter = if let Some(ids) = query_ids {
             format!("AND query_id IN ('{}')", ids.join("','"))
         } else {
@@ -1480,11 +1493,23 @@ impl ClickHouse {
                       AND event_date >= toDate(start_) AND event_time >= toDateTime(start_)
                       AND event_date <= toDate(end_)   AND event_time <= toDateTime(end_)"#,
         );
-        let host_expr = self.get_log_hostname_column();
+        Ok((with, filter))
+    }
 
-        let samples = self
-            .execute(&format!(
-                r#"
+    /// Samples carry only cityHash64(trace) per row; the symbolized stack of
+    /// each unique trace comes from stack_traces_for_perfetto_sql() (the dedup
+    /// factor is ~100x, transferring stacks per sample is GBs of strings).
+    pub fn stack_trace_samples_for_perfetto_sql(
+        &self,
+        query_ids: Option<&[String]>,
+        start: DateTime<Local>,
+        end: DateTime<Local>,
+    ) -> Result<String> {
+        let dbtable = self.get_log_table_name("trace_log");
+        let host_expr = self.get_log_hostname_column();
+        let (with, filter) = Self::stack_trace_with_filter(query_ids, start, end)?;
+        Ok(format!(
+            r#"
                     {with}
                     SELECT
                         event_time_microseconds,
@@ -1495,12 +1520,33 @@ impl ClickHouse {
                     {filter}
                     ORDER BY event_time_microseconds
                     "#,
-            ))
-            .await?;
+        ))
+    }
 
-        let stacks = self
-            .execute(&format!(
-                r#"
+    /// Maps (host_name, stack_hash) to the symbolized stack of each unique
+    /// trace (keyed by host since the same addresses may symbolize
+    /// differently across binaries).
+    pub fn stack_traces_for_perfetto_sql(
+        &self,
+        query_ids: Option<&[String]>,
+        start: DateTime<Local>,
+        end: DateTime<Local>,
+    ) -> Result<String> {
+        let dbtable = self.get_log_table_name("trace_log");
+        let host_expr = self.get_log_hostname_column();
+        let symbol_expr = if self
+            .quirks
+            .has(ClickHouseAvailableQuirks::TraceLogHasSymbols)
+        {
+            r#"arrayReverse(if(empty(any(symbols)),
+                arrayMap(addr -> demangle(addressToSymbol(addr)), trace),
+                any(symbols)))"#
+        } else {
+            "arrayReverse(arrayMap(addr -> demangle(addressToSymbol(addr)), trace))"
+        };
+        let (with, filter) = Self::stack_trace_with_filter(query_ids, start, end)?;
+        Ok(format!(
+            r#"
                     {with}
                     SELECT
                         {host_expr} AS host_name,
@@ -1511,27 +1557,23 @@ impl ClickHouse {
                     GROUP BY host_name, trace
                     SETTINGS allow_introspection_functions=1
                     "#,
-            ))
-            .await?;
-
-        Ok((samples, stacks))
+        ))
     }
 
-    pub async fn get_text_log_for_perfetto(
+    pub fn text_log_for_perfetto_sql(
         &self,
         query_ids: Option<&[String]>,
         start: DateTime<Local>,
         end: DateTime<Local>,
-    ) -> Result<Columns> {
+    ) -> Result<String> {
         let dbtable = self.get_log_table_name("text_log");
         let query_id_filter = if let Some(ids) = query_ids {
             format!("AND query_id IN ('{}')", ids.join("','"))
         } else {
             String::new()
         };
-        return self
-            .execute(&format!(
-                r#"
+        Ok(format!(
+            r#"
                     WITH
                         fromUnixTimestamp64Nano({start}) AS start_,
                         fromUnixTimestamp64Nano({end}) AS end_
@@ -1549,32 +1591,30 @@ impl ClickHouse {
                       AND event_date <= toDate(end_)   AND event_time <= toDateTime(end_)
                     ORDER BY event_time_microseconds
                     "#,
-                dbtable = dbtable,
-                start = start
-                    .timestamp_nanos_opt()
-                    .ok_or(Error::msg("Invalid start"))?,
-                end = end.timestamp_nanos_opt().ok_or(Error::msg("Invalid end"))?,
-                query_id_filter = query_id_filter,
-                host_expr = self.get_log_hostname_column(),
-            ))
-            .await;
+            dbtable = dbtable,
+            start = start
+                .timestamp_nanos_opt()
+                .ok_or(Error::msg("Invalid start"))?,
+            end = end.timestamp_nanos_opt().ok_or(Error::msg("Invalid end"))?,
+            query_id_filter = query_id_filter,
+            host_expr = self.get_log_hostname_column(),
+        ))
     }
 
-    pub async fn get_query_thread_log_for_perfetto(
+    pub fn query_thread_log_for_perfetto_sql(
         &self,
         query_ids: Option<&[String]>,
         start: DateTime<Local>,
         end: DateTime<Local>,
-    ) -> Result<Columns> {
+    ) -> Result<String> {
         let dbtable = self.get_log_table_name("query_thread_log");
         let query_id_filter = if let Some(ids) = query_ids {
             format!("AND query_id IN ('{}')", ids.join("','"))
         } else {
             String::new()
         };
-        return self
-            .execute(&format!(
-                r#"
+        Ok(format!(
+            r#"
                     WITH
                         fromUnixTimestamp64Nano({start}) AS start_,
                         fromUnixTimestamp64Nano({end}) AS end_
@@ -1594,15 +1634,14 @@ impl ClickHouse {
                       AND event_date <= toDate(end_)   AND event_time <= toDateTime(end_)
                     ORDER BY event_time_microseconds
                     "#,
-                dbtable = dbtable,
-                start = start
-                    .timestamp_nanos_opt()
-                    .ok_or(Error::msg("Invalid start"))?,
-                end = end.timestamp_nanos_opt().ok_or(Error::msg("Invalid end"))?,
-                query_id_filter = query_id_filter,
-                host_expr = self.get_log_hostname_column(),
-            ))
-            .await;
+            dbtable = dbtable,
+            start = start
+                .timestamp_nanos_opt()
+                .ok_or(Error::msg("Invalid start"))?,
+            end = end.timestamp_nanos_opt().ok_or(Error::msg("Invalid end"))?,
+            query_id_filter = query_id_filter,
+            host_expr = self.get_log_hostname_column(),
+        ))
     }
 
     pub async fn get_queries_for_perfetto(
@@ -1720,15 +1759,14 @@ impl ClickHouse {
         });
     }
 
-    pub async fn get_metric_log_for_perfetto(
+    pub fn metric_log_for_perfetto_sql(
         &self,
         start: DateTime<Local>,
         end: DateTime<Local>,
-    ) -> Result<Vec<MetricLogRow>> {
+    ) -> Result<String> {
         let dbtable = self.get_log_table_name("metric_log");
-        let block = self
-            .execute(&format!(
-                r#"
+        Ok(format!(
+            r#"
                     WITH
                         fromUnixTimestamp64Nano({start}) AS start_,
                         fromUnixTimestamp64Nano({end}) AS end_
@@ -1742,83 +1780,22 @@ impl ClickHouse {
                       AND event_date <= toDate(end_)   AND event_time <= toDateTime(end_)
                     ORDER BY event_time_microseconds
                     "#,
-                dbtable = dbtable,
-                start = start
-                    .timestamp_nanos_opt()
-                    .ok_or(Error::msg("Invalid start"))?,
-                end = end.timestamp_nanos_opt().ok_or(Error::msg("Invalid end"))?,
-            ))
-            .await?;
-
-        // Lookup by column index: by-name lookup is a linear scan in
-        // clickhouse-rs, which is quadratic over ~2K metric columns
-        // (hours of CPU for a one hour window, i.e. ~3.6K rows).
-        let pe_columns: Vec<(usize, &str)> = block
-            .columns()
-            .iter()
-            .enumerate()
-            .filter_map(|(idx, c)| {
-                c.name()
-                    .strip_prefix("ProfileEvent_")
-                    .map(|name| (idx, name))
-            })
-            .collect();
-        let cm_columns: Vec<(usize, &str)> = block
-            .columns()
-            .iter()
-            .enumerate()
-            .filter_map(|(idx, c)| {
-                c.name()
-                    .strip_prefix("CurrentMetric_")
-                    .map(|name| (idx, name))
-            })
-            .collect();
-
-        let mut rows = Vec::with_capacity(block.row_count());
-        for i in 0..block.row_count() {
-            let ts_ns = match block.get::<DateTime<Tz>, _>(i, "event_time_microseconds") {
-                Ok(dt) => dt.with_timezone(&Local).timestamp_nanos_opt().unwrap_or(0) as u64,
-                Err(e) => {
-                    log::warn!(
-                        "Perfetto: metric_log row {} event_time_microseconds: {}",
-                        i,
-                        e
-                    );
-                    continue;
-                }
-            };
-            let mut profile_events = HashMap::new();
-            for &(idx, name) in &pe_columns {
-                let value: u64 = block.get(i, idx).unwrap_or(0);
-                if value != 0 {
-                    profile_events.insert(name.to_string(), value);
-                }
-            }
-            let mut current_metrics = HashMap::new();
-            for &(idx, name) in &cm_columns {
-                let value: i64 = block.get(i, idx).unwrap_or(0);
-                if value != 0 {
-                    current_metrics.insert(name.to_string(), value);
-                }
-            }
-            rows.push(MetricLogRow {
-                timestamp_ns: ts_ns,
-                profile_events,
-                current_metrics,
-            });
-        }
-        Ok(rows)
+            dbtable = dbtable,
+            start = start
+                .timestamp_nanos_opt()
+                .ok_or(Error::msg("Invalid start"))?,
+            end = end.timestamp_nanos_opt().ok_or(Error::msg("Invalid end"))?,
+        ))
     }
 
-    pub async fn get_asynchronous_metric_log_for_perfetto(
+    pub fn asynchronous_metric_log_for_perfetto_sql(
         &self,
         start: DateTime<Local>,
         end: DateTime<Local>,
-    ) -> Result<Columns> {
+    ) -> Result<String> {
         let dbtable = self.get_log_table_name("asynchronous_metric_log");
-        return self
-            .execute(&format!(
-                r#"
+        Ok(format!(
+            r#"
                     WITH
                         fromUnixTimestamp64Nano({start}) AS start_,
                         fromUnixTimestamp64Nano({end}) AS end_
@@ -1833,24 +1810,22 @@ impl ClickHouse {
                       AND event_date <= toDate(end_)   AND event_time <= toDateTime(end_)
                     ORDER BY event_time_microseconds
                     "#,
-                dbtable = dbtable,
-                start = start
-                    .timestamp_nanos_opt()
-                    .ok_or(Error::msg("Invalid start"))?,
-                end = end.timestamp_nanos_opt().ok_or(Error::msg("Invalid end"))?,
-            ))
-            .await;
+            dbtable = dbtable,
+            start = start
+                .timestamp_nanos_opt()
+                .ok_or(Error::msg("Invalid start"))?,
+            end = end.timestamp_nanos_opt().ok_or(Error::msg("Invalid end"))?,
+        ))
     }
 
-    pub async fn get_asynchronous_insert_log_for_perfetto(
+    pub fn asynchronous_insert_log_for_perfetto_sql(
         &self,
         start: DateTime<Local>,
         end: DateTime<Local>,
-    ) -> Result<Columns> {
+    ) -> Result<String> {
         let dbtable = self.get_log_table_name("asynchronous_insert_log");
-        return self
-            .execute(&format!(
-                r#"
+        Ok(format!(
+            r#"
                     WITH
                         fromUnixTimestamp64Nano({start}) AS start_,
                         fromUnixTimestamp64Nano({end}) AS end_
@@ -1870,24 +1845,22 @@ impl ClickHouse {
                       AND event_date <= toDate(end_)   AND event_time <= toDateTime(end_)
                     ORDER BY event_time_microseconds
                     "#,
-                dbtable = dbtable,
-                start = start
-                    .timestamp_nanos_opt()
-                    .ok_or(Error::msg("Invalid start"))?,
-                end = end.timestamp_nanos_opt().ok_or(Error::msg("Invalid end"))?,
-            ))
-            .await;
+            dbtable = dbtable,
+            start = start
+                .timestamp_nanos_opt()
+                .ok_or(Error::msg("Invalid start"))?,
+            end = end.timestamp_nanos_opt().ok_or(Error::msg("Invalid end"))?,
+        ))
     }
 
-    pub async fn get_error_log_for_perfetto(
+    pub fn error_log_for_perfetto_sql(
         &self,
         start: DateTime<Local>,
         end: DateTime<Local>,
-    ) -> Result<Columns> {
+    ) -> Result<String> {
         let dbtable = self.get_log_table_name("error_log");
-        return self
-            .execute(&format!(
-                r#"
+        Ok(format!(
+            r#"
                     WITH
                         fromUnixTimestamp64Nano({start}) AS start_,
                         fromUnixTimestamp64Nano({end}) AS end_
@@ -1904,24 +1877,22 @@ impl ClickHouse {
                       AND event_date <= toDate(end_)   AND event_time <= toDateTime(end_)
                     ORDER BY event_time
                     "#,
-                dbtable = dbtable,
-                start = start
-                    .timestamp_nanos_opt()
-                    .ok_or(Error::msg("Invalid start"))?,
-                end = end.timestamp_nanos_opt().ok_or(Error::msg("Invalid end"))?,
-            ))
-            .await;
+            dbtable = dbtable,
+            start = start
+                .timestamp_nanos_opt()
+                .ok_or(Error::msg("Invalid start"))?,
+            end = end.timestamp_nanos_opt().ok_or(Error::msg("Invalid end"))?,
+        ))
     }
 
-    pub async fn get_s3_queue_log_for_perfetto(
+    pub fn s3_queue_log_for_perfetto_sql(
         &self,
         start: DateTime<Local>,
         end: DateTime<Local>,
-    ) -> Result<Columns> {
+    ) -> Result<String> {
         let dbtable = self.get_log_table_name("s3queue_log");
-        return self
-            .execute(&format!(
-                r#"
+        Ok(format!(
+            r#"
                     SELECT
                         file_name,
                         rows_processed,
@@ -1934,24 +1905,22 @@ impl ClickHouse {
                       AND processing_start_time <= toDateTime(fromUnixTimestamp64Nano({end}))
                     ORDER BY processing_start_time
                     "#,
-                dbtable = dbtable,
-                start = start
-                    .timestamp_nanos_opt()
-                    .ok_or(Error::msg("Invalid start"))?,
-                end = end.timestamp_nanos_opt().ok_or(Error::msg("Invalid end"))?,
-            ))
-            .await;
+            dbtable = dbtable,
+            start = start
+                .timestamp_nanos_opt()
+                .ok_or(Error::msg("Invalid start"))?,
+            end = end.timestamp_nanos_opt().ok_or(Error::msg("Invalid end"))?,
+        ))
     }
 
-    pub async fn get_azure_queue_log_for_perfetto(
+    pub fn azure_queue_log_for_perfetto_sql(
         &self,
         start: DateTime<Local>,
         end: DateTime<Local>,
-    ) -> Result<Columns> {
+    ) -> Result<String> {
         let dbtable = self.get_log_table_name("azure_queue_log");
-        return self
-            .execute(&format!(
-                r#"
+        Ok(format!(
+            r#"
                     SELECT
                         database,
                         table,
@@ -1966,24 +1935,22 @@ impl ClickHouse {
                       AND processing_start_time <= toDateTime(fromUnixTimestamp64Nano({end}))
                     ORDER BY processing_start_time
                     "#,
-                dbtable = dbtable,
-                start = start
-                    .timestamp_nanos_opt()
-                    .ok_or(Error::msg("Invalid start"))?,
-                end = end.timestamp_nanos_opt().ok_or(Error::msg("Invalid end"))?,
-            ))
-            .await;
+            dbtable = dbtable,
+            start = start
+                .timestamp_nanos_opt()
+                .ok_or(Error::msg("Invalid start"))?,
+            end = end.timestamp_nanos_opt().ok_or(Error::msg("Invalid end"))?,
+        ))
     }
 
-    pub async fn get_blob_storage_log_for_perfetto(
+    pub fn blob_storage_log_for_perfetto_sql(
         &self,
         start: DateTime<Local>,
         end: DateTime<Local>,
-    ) -> Result<Columns> {
+    ) -> Result<String> {
         let dbtable = self.get_log_table_name("blob_storage_log");
-        return self
-            .execute(&format!(
-                r#"
+        Ok(format!(
+            r#"
                     WITH
                         fromUnixTimestamp64Nano({start}) AS start_,
                         fromUnixTimestamp64Nano({end}) AS end_
@@ -2002,24 +1969,22 @@ impl ClickHouse {
                       AND event_date <= toDate(end_)   AND event_time <= toDateTime(end_)
                     ORDER BY event_time_microseconds
                     "#,
-                dbtable = dbtable,
-                start = start
-                    .timestamp_nanos_opt()
-                    .ok_or(Error::msg("Invalid start"))?,
-                end = end.timestamp_nanos_opt().ok_or(Error::msg("Invalid end"))?,
-            ))
-            .await;
+            dbtable = dbtable,
+            start = start
+                .timestamp_nanos_opt()
+                .ok_or(Error::msg("Invalid start"))?,
+            end = end.timestamp_nanos_opt().ok_or(Error::msg("Invalid end"))?,
+        ))
     }
 
-    pub async fn get_background_schedule_pool_log_for_perfetto(
+    pub fn background_schedule_pool_log_for_perfetto_sql(
         &self,
         start: DateTime<Local>,
         end: DateTime<Local>,
-    ) -> Result<Columns> {
+    ) -> Result<String> {
         let dbtable = self.get_log_table_name("background_schedule_pool_log");
-        return self
-            .execute(&format!(
-                r#"
+        Ok(format!(
+            r#"
                     WITH
                         fromUnixTimestamp64Nano({start}) AS start_,
                         fromUnixTimestamp64Nano({end}) AS end_
@@ -2038,24 +2003,22 @@ impl ClickHouse {
                       AND event_date <= toDate(end_)   AND event_time <= toDateTime(end_)
                     ORDER BY event_time_microseconds
                     "#,
-                dbtable = dbtable,
-                start = start
-                    .timestamp_nanos_opt()
-                    .ok_or(Error::msg("Invalid start"))?,
-                end = end.timestamp_nanos_opt().ok_or(Error::msg("Invalid end"))?,
-            ))
-            .await;
+            dbtable = dbtable,
+            start = start
+                .timestamp_nanos_opt()
+                .ok_or(Error::msg("Invalid start"))?,
+            end = end.timestamp_nanos_opt().ok_or(Error::msg("Invalid end"))?,
+        ))
     }
 
-    pub async fn get_session_log_for_perfetto(
+    pub fn session_log_for_perfetto_sql(
         &self,
         start: DateTime<Local>,
         end: DateTime<Local>,
-    ) -> Result<Columns> {
+    ) -> Result<String> {
         let dbtable = self.get_log_table_name("session_log");
-        return self
-            .execute(&format!(
-                r#"
+        Ok(format!(
+            r#"
                     WITH
                         fromUnixTimestamp64Nano({start}) AS start_,
                         fromUnixTimestamp64Nano({end}) AS end_
@@ -2075,24 +2038,22 @@ impl ClickHouse {
                       AND event_date <= toDate(end_)   AND event_time <= toDateTime(end_)
                     ORDER BY event_time_microseconds
                     "#,
-                dbtable = dbtable,
-                start = start
-                    .timestamp_nanos_opt()
-                    .ok_or(Error::msg("Invalid start"))?,
-                end = end.timestamp_nanos_opt().ok_or(Error::msg("Invalid end"))?,
-            ))
-            .await;
+            dbtable = dbtable,
+            start = start
+                .timestamp_nanos_opt()
+                .ok_or(Error::msg("Invalid start"))?,
+            end = end.timestamp_nanos_opt().ok_or(Error::msg("Invalid end"))?,
+        ))
     }
 
-    pub async fn get_aggregated_zookeeper_log_for_perfetto(
+    pub fn aggregated_zookeeper_log_for_perfetto_sql(
         &self,
         start: DateTime<Local>,
         end: DateTime<Local>,
-    ) -> Result<Columns> {
+    ) -> Result<String> {
         let dbtable = self.get_log_table_name("aggregated_zookeeper_log");
-        return self
-            .execute(&format!(
-                r#"
+        Ok(format!(
+            r#"
                     SELECT
                         event_time,
                         session_id,
@@ -2108,13 +2069,12 @@ impl ClickHouse {
                       AND event_time <= toDateTime(fromUnixTimestamp64Nano({end}))
                     ORDER BY event_time
                     "#,
-                dbtable = dbtable,
-                start = start
-                    .timestamp_nanos_opt()
-                    .ok_or(Error::msg("Invalid start"))?,
-                end = end.timestamp_nanos_opt().ok_or(Error::msg("Invalid end"))?,
-            ))
-            .await;
+            dbtable = dbtable,
+            start = start
+                .timestamp_nanos_opt()
+                .ok_or(Error::msg("Invalid start"))?,
+            end = end.timestamp_nanos_opt().ok_or(Error::msg("Invalid end"))?,
+        ))
     }
 
     pub async fn get_warnings(&self) -> Result<Vec<String>> {
@@ -2147,6 +2107,32 @@ impl ClickHouse {
             .await?;
         log::trace!("Received {} rows for query: {}", columns.row_count(), query);
         Ok(columns)
+    }
+
+    /// Stream the result block-by-block into a bounded channel (each block is
+    /// wrapped with `wrap`), so the whole result is never materialized in
+    /// memory and a slow consumer backpressures the server.
+    pub async fn execute_into<T>(
+        &self,
+        query: &str,
+        tx: &mut futures::channel::mpsc::Sender<T>,
+        wrap: impl Fn(Block) -> T,
+    ) -> Result<()> {
+        let mut client = self.pool.get_handle().await?;
+        let mut stream = client.query(query).stream_blocks();
+        let mut rows = 0;
+        while let Some(block) = stream.next().await {
+            let block = block?;
+            if block.row_count() == 0 {
+                continue;
+            }
+            rows += block.row_count();
+            if tx.send(wrap(block)).await.is_err() {
+                break;
+            }
+        }
+        log::trace!("Received {} rows (streamed) for query: {}", rows, query);
+        Ok(())
     }
 
     async fn execute_simple(&self, query: &str) -> Result<()> {

--- a/src/interpreter/clickhouse.rs
+++ b/src/interpreter/clickhouse.rs
@@ -1625,10 +1625,12 @@ impl ClickHouse {
                         query_duration_ms,
                         -- Most of ~2K ProfileEvents are zero per thread and Names repeat
                         -- in every row - do not transfer them (GBs for busy servers)
+                        -- Plain aliases: `AS ProfileEvents.Names` collides with the Map
+                        -- sugar expression (DUPLICATE_COLUMN with the old analyzer)
                         arrayFilter((n, v) -> v != 0, ProfileEvents.Names, ProfileEvents.Values)
-                            AS `ProfileEvents.Names`,
+                            AS profile_event_names,
                         arrayFilter(v -> v != 0, ProfileEvents.Values)
-                            AS `ProfileEvents.Values`,
+                            AS profile_event_values,
                         peak_memory_usage,
                         {host_expr} AS host_name
                     FROM {dbtable}
@@ -1648,25 +1650,25 @@ impl ClickHouse {
         ))
     }
 
-    pub async fn get_queries_for_perfetto(
+    pub fn queries_for_perfetto_sql(
         &self,
         start: DateTime<Local>,
         end: DateTime<Local>,
         query_ids: &Option<Vec<String>>,
-    ) -> Result<Columns> {
+    ) -> Result<String> {
         let dbtable = self.get_log_table_name("query_log");
-        return self
-            .execute(
-                format!(
-                    r#"
+        Ok(format!(
+            r#"
                     WITH
                         fromUnixTimestamp64Nano({start}) AS start_,
                         fromUnixTimestamp64Nano({end}) AS end_
                     SELECT
-                        ProfileEvents.Names,
-                        ProfileEvents.Values,
-                        Settings.Names,
-                        Settings.Values,
+                        -- Query::from_clickhouse_block() compatibility, the perfetto
+                        -- export does not use them (and they are heavy to transfer)
+                        []::Array(String) AS `ProfileEvents.Names`,
+                        []::Array(UInt64) AS `ProfileEvents.Values`,
+                        []::Array(String) AS `Settings.Names`,
+                        []::Array(String) AS `Settings.Values`,
                         {peak_threads_usage} AS peak_threads_usage,
                         memory_usage::Int64 AS peak_memory_usage,
                         query_duration_ms/1e3 AS elapsed,
@@ -1690,28 +1692,25 @@ impl ClickHouse {
                       AND event_date <= toDate(end_)   AND event_time <= toDateTime(end_)
                       {query_ids}
                     "#,
-                    start = start
-                        .timestamp_nanos_opt()
-                        .ok_or(Error::msg("Invalid start"))?,
-                    end = end.timestamp_nanos_opt().ok_or(Error::msg("Invalid end"))?,
-                    dbtable = dbtable,
-                    peak_threads_usage = if self
-                        .quirks
-                        .has(ClickHouseAvailableQuirks::QueryLogPeakThreadsUsage)
-                    {
-                        "peak_threads_usage"
-                    } else {
-                        "length(thread_ids)"
-                    },
-                    query_ids = if let Some(query_id) = query_ids {
-                        format!("AND query_id IN ('{}')", query_id.join("','"))
-                    } else {
-                        String::new()
-                    },
-                )
-                .as_str(),
-            )
-            .await;
+            start = start
+                .timestamp_nanos_opt()
+                .ok_or(Error::msg("Invalid start"))?,
+            end = end.timestamp_nanos_opt().ok_or(Error::msg("Invalid end"))?,
+            dbtable = dbtable,
+            peak_threads_usage = if self
+                .quirks
+                .has(ClickHouseAvailableQuirks::QueryLogPeakThreadsUsage)
+            {
+                "peak_threads_usage"
+            } else {
+                "length(thread_ids)"
+            },
+            query_ids = if let Some(query_id) = query_ids {
+                format!("AND query_id IN ('{}')", query_id.join("','"))
+            } else {
+                String::new()
+            },
+        ))
     }
 
     pub async fn get_perfetto_query_scope(

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -18,7 +18,10 @@ pub use clickhouse_quirks::ClickHouseQuirks;
 pub use context::Context;
 pub use context::ContextArc;
 pub use worker::Worker;
-pub(crate) use worker::{fetch_and_populate_perfetto_trace, fetch_server_perfetto_sources};
+pub(crate) use worker::{
+    fetch_and_populate_perfetto_trace, fetch_server_perfetto_sources,
+    stream_queries_into_perfetto_trace,
+};
 
 pub type WorkerEvent = worker::Event;
 pub type Query = query::Query;

--- a/src/interpreter/perfetto.rs
+++ b/src/interpreter/perfetto.rs
@@ -97,6 +97,12 @@ pub struct PerfettoTraceBuilder {
     host_uuids: HashMap<String, u64>,
     // (host_name, category) → category track uuid
     host_category_uuids: HashMap<(String, &'static str), u64>,
+    // (parent uuid, name) → uuid, parent 0 = process track. Streamed add_*
+    // methods run once per block, so tracks must be cached across calls.
+    track_uuids: HashMap<(u64, String), u64>,
+    // Running totals of cumulative counters (per track uuid), must survive
+    // across blocks as well.
+    counter_totals: HashMap<u64, i64>,
     per_server: bool,
     text_log_android: bool,
 }
@@ -163,6 +169,8 @@ impl PerfettoTraceBuilder {
 
             host_uuids: HashMap::new(),
             host_category_uuids: HashMap::new(),
+            track_uuids: HashMap::new(),
+            counter_totals: HashMap::new(),
             per_server,
             text_log_android,
         };
@@ -432,19 +440,50 @@ impl PerfettoTraceBuilder {
         }
     }
 
+    fn process_track_uuid(&mut self, name: &str) -> u64 {
+        self.child_track_uuid(0, name)
+    }
+
+    fn child_track_uuid(&mut self, parent_uuid: u64, name: &str) -> u64 {
+        if let Some(&uuid) = self.track_uuids.get(&(parent_uuid, name.to_string())) {
+            return uuid;
+        }
+        let uuid = self.alloc_uuid();
+        if parent_uuid == 0 {
+            self.add_process_track(uuid, name);
+        } else {
+            self.add_child_track(uuid, parent_uuid, name);
+        }
+        self.track_uuids
+            .insert((parent_uuid, name.to_string()), uuid);
+        uuid
+    }
+
+    fn counter_track_uuid(&mut self, parent_uuid: u64, name: &str, unit: Unit) -> u64 {
+        if let Some(&uuid) = self.track_uuids.get(&(parent_uuid, name.to_string())) {
+            return uuid;
+        }
+        let uuid = self.alloc_uuid();
+        self.add_counter_track(uuid, parent_uuid, name, unit);
+        self.track_uuids
+            .insert((parent_uuid, name.to_string()), uuid);
+        uuid
+    }
+
+    fn add_counter_increment(&mut self, track_uuid: u64, ts_ns: u64, increment: i64) {
+        let total = self.counter_totals.entry(track_uuid).or_default();
+        *total += increment;
+        let value = *total;
+        self.add_counter_value(track_uuid, ts_ns, value);
+    }
+
     pub fn add_otel_spans<K: ColumnType>(&mut self, columns: &Block<K>) {
         if columns.row_count() == 0 {
             return;
         }
 
-        // Group spans by operation_name → thread track under query's host process
-        // Use a single process track for OTel spans
-        let process_uuid = self.alloc_uuid();
-        self.add_process_track(process_uuid, "OpenTelemetry Spans");
-
-        let mut op_uuids: HashMap<String, u64> = HashMap::new();
-        // (host_uuid, operation_name) → track_uuid
-        let mut server_op_uuids: HashMap<(u64, String), u64> = HashMap::new();
+        // Group spans by operation_name → thread track under a single process track
+        let process_uuid = self.process_track_uuid("OpenTelemetry Spans");
 
         for i in 0..columns.row_count() {
             let operation_name: String = columns.get(i, "operation_name").unwrap_or_default();
@@ -468,15 +507,8 @@ impl PerfettoTraceBuilder {
             let start_ns = start_us.saturating_mul(1000);
             let end_ns = finish_us.saturating_mul(1000);
 
-            let track_uuid = *op_uuids.entry(operation_name.clone()).or_insert_with(|| {
-                let uuid = self.alloc_uuid();
-                self.add_child_track(
-                    uuid,
-                    process_uuid,
-                    &format!("Processor: {}", operation_name),
-                );
-                uuid
-            });
+            let track_uuid =
+                self.child_track_uuid(process_uuid, &format!("Processor: {}", operation_name));
 
             let annotations = vec![Self::make_annotation_str("query_id", &query_id)];
 
@@ -485,13 +517,7 @@ impl PerfettoTraceBuilder {
 
             if let Some(cat_uuid) = self.get_host_category_track(&host_name, "OpenTelemetry Spans")
             {
-                let server_track = *server_op_uuids
-                    .entry((cat_uuid, operation_name.clone()))
-                    .or_insert_with(|| {
-                        let uuid = self.alloc_uuid();
-                        self.add_child_track(uuid, cat_uuid, &operation_name);
-                        uuid
-                    });
+                let server_track = self.child_track_uuid(cat_uuid, &operation_name);
                 self.add_slice_begin(server_track, &operation_name, start_ns, annotations);
                 self.add_slice_end(server_track, end_ns);
             }
@@ -503,13 +529,7 @@ impl PerfettoTraceBuilder {
             return;
         }
 
-        let process_uuid = self.alloc_uuid();
-        self.add_process_track(process_uuid, "ProfileEvent Counters");
-
-        // event_name → (track_uuid, running_total)
-        let mut counter_tracks: HashMap<String, (u64, i64)> = HashMap::new();
-        // (host_uuid, event_name) → (track_uuid, running_total)
-        let mut server_tracks: HashMap<(u64, String), (u64, i64)> = HashMap::new();
+        let process_uuid = self.process_track_uuid("ProfileEvent Counters");
 
         for i in 0..columns.row_count() {
             let event: String = columns.get(i, "event").unwrap_or_default();
@@ -530,28 +550,14 @@ impl PerfettoTraceBuilder {
 
             let (unit, scale) = Self::unit_for_event(&event);
             let scaled_increment = increment * scale;
-            let (track_uuid, running_total) =
-                counter_tracks.entry(event.clone()).or_insert_with(|| {
-                    let uuid = self.alloc_uuid();
-                    self.add_counter_track(uuid, process_uuid, &event, unit);
-                    (uuid, 0)
-                });
-
-            *running_total += scaled_increment;
-            self.add_counter_value(*track_uuid, timestamp_ns, *running_total);
+            let track_uuid = self.counter_track_uuid(process_uuid, &event, unit);
+            self.add_counter_increment(track_uuid, timestamp_ns, scaled_increment);
 
             if let Some(cat_uuid) =
                 self.get_host_category_track(&host_name, "ProfileEvent Counters")
             {
-                let (track_uuid, running_total) = server_tracks
-                    .entry((cat_uuid, event.clone()))
-                    .or_insert_with(|| {
-                        let uuid = self.alloc_uuid();
-                        self.add_counter_track(uuid, cat_uuid, &event, unit);
-                        (uuid, 0)
-                    });
-                *running_total += scaled_increment;
-                self.add_counter_value(*track_uuid, timestamp_ns, *running_total);
+                let track_uuid = self.counter_track_uuid(cat_uuid, &event, unit);
+                self.add_counter_increment(track_uuid, timestamp_ns, scaled_increment);
             }
         }
     }
@@ -561,13 +567,7 @@ impl PerfettoTraceBuilder {
             return;
         }
 
-        let process_uuid = self.alloc_uuid();
-        self.add_process_track(process_uuid, "Query Metrics");
-
-        // metric_name → track_uuid
-        let mut counter_tracks: HashMap<String, u64> = HashMap::new();
-        // (host_uuid, metric_name) → track_uuid
-        let mut server_tracks: HashMap<(u64, String), u64> = HashMap::new();
+        let process_uuid = self.process_track_uuid("Query Metrics");
 
         for row in rows {
             // memory_usage / peak_memory_usage
@@ -579,23 +579,13 @@ impl PerfettoTraceBuilder {
                     Unit::UNIT_SIZE_BYTES,
                 ),
             ] {
-                let track_uuid = *counter_tracks.entry(name.to_string()).or_insert_with(|| {
-                    let uuid = self.alloc_uuid();
-                    self.add_counter_track(uuid, process_uuid, name, unit);
-                    uuid
-                });
+                let track_uuid = self.counter_track_uuid(process_uuid, name, unit);
                 self.add_counter_value(track_uuid, row.timestamp_ns, value);
 
                 if let Some(cat_uuid) =
                     self.get_host_category_track(&row.host_name, "Query Metrics")
                 {
-                    let server_track = *server_tracks
-                        .entry((cat_uuid, name.to_string()))
-                        .or_insert_with(|| {
-                            let uuid = self.alloc_uuid();
-                            self.add_counter_track(uuid, cat_uuid, name, unit);
-                            uuid
-                        });
+                    let server_track = self.counter_track_uuid(cat_uuid, name, unit);
                     self.add_counter_value(server_track, row.timestamp_ns, value);
                 }
             }
@@ -604,23 +594,13 @@ impl PerfettoTraceBuilder {
             for (name, value) in &row.profile_events {
                 let (unit, scale) = Self::unit_for_event(name);
                 let scaled_value = *value as i64 * scale;
-                let track_uuid = *counter_tracks.entry(name.clone()).or_insert_with(|| {
-                    let uuid = self.alloc_uuid();
-                    self.add_counter_track(uuid, process_uuid, name, unit);
-                    uuid
-                });
+                let track_uuid = self.counter_track_uuid(process_uuid, name, unit);
                 self.add_counter_value(track_uuid, row.timestamp_ns, scaled_value);
 
                 if let Some(cat_uuid) =
                     self.get_host_category_track(&row.host_name, "Query Metrics")
                 {
-                    let server_track = *server_tracks
-                        .entry((cat_uuid, name.clone()))
-                        .or_insert_with(|| {
-                            let uuid = self.alloc_uuid();
-                            self.add_counter_track(uuid, cat_uuid, name, unit);
-                            uuid
-                        });
+                    let server_track = self.counter_track_uuid(cat_uuid, name, unit);
                     self.add_counter_value(server_track, row.timestamp_ns, scaled_value);
                 }
             }
@@ -632,13 +612,7 @@ impl PerfettoTraceBuilder {
             return;
         }
 
-        let process_uuid = self.alloc_uuid();
-        self.add_process_track(process_uuid, "Part Log");
-
-        // "db.table" → thread_uuid
-        let mut table_uuids: HashMap<String, u64> = HashMap::new();
-        // (host_uuid, "db.table") → track_uuid
-        let mut server_table_uuids: HashMap<(u64, String), u64> = HashMap::new();
+        let process_uuid = self.process_track_uuid("Part Log");
 
         for i in 0..columns.row_count() {
             let event_type: String = columns.get(i, "event_type").unwrap_or_default();
@@ -663,11 +637,7 @@ impl PerfettoTraceBuilder {
             let host_name: String = columns.get(i, "host_name").unwrap_or_default();
 
             let table_key = format!("{}.{}", database, table);
-            let track_uuid = *table_uuids.entry(table_key.clone()).or_insert_with(|| {
-                let uuid = self.alloc_uuid();
-                self.add_child_track(uuid, process_uuid, &table_key);
-                uuid
-            });
+            let track_uuid = self.child_track_uuid(process_uuid, &table_key);
 
             let end_ns = match event_time.with_timezone(&Local).timestamp_nanos_opt() {
                 Some(ns) => ns as u64,
@@ -690,13 +660,7 @@ impl PerfettoTraceBuilder {
             self.add_slice_end(track_uuid, end_ns);
 
             if let Some(cat_uuid) = self.get_host_category_track(&host_name, "Part Log") {
-                let server_track = *server_table_uuids
-                    .entry((cat_uuid, table_key.clone()))
-                    .or_insert_with(|| {
-                        let uuid = self.alloc_uuid();
-                        self.add_child_track(uuid, cat_uuid, &table_key);
-                        uuid
-                    });
+                let server_track = self.child_track_uuid(cat_uuid, &table_key);
                 self.add_slice_begin(server_track, &label, start_ns, annotations);
                 self.add_slice_end(server_track, end_ns);
             }
@@ -708,13 +672,7 @@ impl PerfettoTraceBuilder {
             return;
         }
 
-        let process_uuid = self.alloc_uuid();
-        self.add_process_track(process_uuid, "Query Threads");
-
-        // thread_name → track_uuid
-        let mut thread_uuids: HashMap<String, u64> = HashMap::new();
-        // (host_uuid, thread_name) → track_uuid
-        let mut server_thread_uuids: HashMap<(u64, String), u64> = HashMap::new();
+        let process_uuid = self.process_track_uuid("Query Threads");
 
         for i in 0..columns.row_count() {
             let query_id: String = columns.get(i, "query_id").unwrap_or_default();
@@ -738,11 +696,7 @@ impl PerfettoTraceBuilder {
             let names: Vec<String> = columns.get(i, "ProfileEvents.Names").unwrap_or_default();
             let values: Vec<u64> = columns.get(i, "ProfileEvents.Values").unwrap_or_default();
 
-            let track_uuid = *thread_uuids.entry(thread_name.clone()).or_insert_with(|| {
-                let uuid = self.alloc_uuid();
-                self.add_child_track(uuid, process_uuid, &thread_name);
-                uuid
-            });
+            let track_uuid = self.child_track_uuid(process_uuid, &thread_name);
 
             let end_ns = timestamp_ns;
             let start_ns = end_ns.saturating_sub(duration_ms * 1_000_000);
@@ -766,13 +720,7 @@ impl PerfettoTraceBuilder {
             self.add_slice_end(track_uuid, end_ns);
 
             if let Some(cat_uuid) = self.get_host_category_track(&host_name, "Query Threads") {
-                let server_track = *server_thread_uuids
-                    .entry((cat_uuid, thread_name.clone()))
-                    .or_insert_with(|| {
-                        let uuid = self.alloc_uuid();
-                        self.add_child_track(uuid, cat_uuid, &thread_name);
-                        uuid
-                    });
+                let server_track = self.child_track_uuid(cat_uuid, &thread_name);
                 self.add_slice_begin(server_track, &query_id, start_ns, annotations);
                 self.add_slice_end(server_track, end_ns);
             }
@@ -784,13 +732,7 @@ impl PerfettoTraceBuilder {
             return;
         }
 
-        let process_uuid = self.alloc_uuid();
-        self.add_process_track(process_uuid, "Query Logs");
-
-        // level → track_uuid
-        let mut level_uuids: HashMap<String, u64> = HashMap::new();
-        // (host_uuid, level) → track_uuid
-        let mut server_level_uuids: HashMap<(u64, String), u64> = HashMap::new();
+        let process_uuid = self.process_track_uuid("Query Logs");
 
         let mut alp = if self.text_log_android {
             Some(AndroidLogPacket::new())
@@ -817,11 +759,7 @@ impl PerfettoTraceBuilder {
                     }
                 };
 
-            let track_uuid = *level_uuids.entry(level.clone()).or_insert_with(|| {
-                let uuid = self.alloc_uuid();
-                self.add_child_track(uuid, process_uuid, &level);
-                uuid
-            });
+            let track_uuid = self.child_track_uuid(process_uuid, &level);
 
             let annotations = vec![
                 Self::make_annotation_str("query_id", &query_id),
@@ -832,13 +770,7 @@ impl PerfettoTraceBuilder {
             self.add_instant(track_uuid, &message, timestamp_ns, annotations.clone());
 
             if let Some(cat_uuid) = self.get_host_category_track(&host_name, "Query Logs") {
-                let server_track = *server_level_uuids
-                    .entry((cat_uuid, level.clone()))
-                    .or_insert_with(|| {
-                        let uuid = self.alloc_uuid();
-                        self.add_child_track(uuid, cat_uuid, &level);
-                        uuid
-                    });
+                let server_track = self.child_track_uuid(cat_uuid, &level);
                 self.add_instant(server_track, &message, timestamp_ns, annotations);
             }
 
@@ -865,35 +797,19 @@ impl PerfettoTraceBuilder {
             return;
         }
 
-        let process_uuid = self.alloc_uuid();
-        self.add_process_track(process_uuid, "Metric Log");
-
-        // event_name → (track_uuid, running_total)
-        let mut pe_tracks: HashMap<String, (u64, i64)> = HashMap::new();
-        // metric_name → track_uuid
-        let mut cm_tracks: HashMap<String, u64> = HashMap::new();
+        let process_uuid = self.process_track_uuid("Metric Log");
 
         for row in rows {
             for (name, value) in &row.profile_events {
                 let (unit, scale) = Self::unit_for_event(name);
                 let scaled = *value as i64 * scale;
-                let (track_uuid, running_total) =
-                    pe_tracks.entry(name.clone()).or_insert_with(|| {
-                        let uuid = self.alloc_uuid();
-                        self.add_counter_track(uuid, process_uuid, name, unit);
-                        (uuid, 0)
-                    });
-                *running_total += scaled;
-                self.add_counter_value(*track_uuid, row.timestamp_ns, *running_total);
+                let track_uuid = self.counter_track_uuid(process_uuid, name, unit);
+                self.add_counter_increment(track_uuid, row.timestamp_ns, scaled);
             }
 
             for (name, value) in &row.current_metrics {
                 let (unit, scale) = Self::unit_for_event(name);
-                let track_uuid = *cm_tracks.entry(name.clone()).or_insert_with(|| {
-                    let uuid = self.alloc_uuid();
-                    self.add_counter_track(uuid, process_uuid, name, unit);
-                    uuid
-                });
+                let track_uuid = self.counter_track_uuid(process_uuid, name, unit);
                 self.add_counter_value(track_uuid, row.timestamp_ns, *value * scale);
             }
         }
@@ -904,10 +820,7 @@ impl PerfettoTraceBuilder {
             return;
         }
 
-        let process_uuid = self.alloc_uuid();
-        self.add_process_track(process_uuid, "Async Metrics");
-
-        let mut counter_tracks: HashMap<String, u64> = HashMap::new();
+        let process_uuid = self.process_track_uuid("Async Metrics");
 
         for i in 0..columns.row_count() {
             let metric: String = columns.get(i, "metric").unwrap_or_default();
@@ -925,11 +838,7 @@ impl PerfettoTraceBuilder {
                     }
                 };
 
-            let track_uuid = *counter_tracks.entry(metric.clone()).or_insert_with(|| {
-                let uuid = self.alloc_uuid();
-                self.add_counter_track(uuid, process_uuid, &metric, Unit::UNIT_UNSPECIFIED);
-                uuid
-            });
+            let track_uuid = self.counter_track_uuid(process_uuid, &metric, Unit::UNIT_UNSPECIFIED);
 
             self.add_counter_value(track_uuid, timestamp_ns, value as i64);
         }
@@ -940,10 +849,7 @@ impl PerfettoTraceBuilder {
             return;
         }
 
-        let process_uuid = self.alloc_uuid();
-        self.add_process_track(process_uuid, "Async Inserts");
-
-        let mut table_uuids: HashMap<String, u64> = HashMap::new();
+        let process_uuid = self.process_track_uuid("Async Inserts");
 
         for i in 0..columns.row_count() {
             let database: String = columns.get(i, "database").unwrap_or_default();
@@ -971,11 +877,7 @@ impl PerfettoTraceBuilder {
             };
 
             let table_key = format!("{}.{}", database, table);
-            let track_uuid = *table_uuids.entry(table_key.clone()).or_insert_with(|| {
-                let uuid = self.alloc_uuid();
-                self.add_child_track(uuid, process_uuid, &table_key);
-                uuid
-            });
+            let track_uuid = self.child_track_uuid(process_uuid, &table_key);
 
             let label = format!("{} ({})", table_key, status);
             let mut annotations = vec![
@@ -998,10 +900,7 @@ impl PerfettoTraceBuilder {
             return;
         }
 
-        let process_uuid = self.alloc_uuid();
-        self.add_process_track(process_uuid, "Error Log");
-
-        let mut error_uuids: HashMap<String, u64> = HashMap::new();
+        let process_uuid = self.process_track_uuid("Error Log");
 
         for i in 0..columns.row_count() {
             let error: String = columns.get(i, "error").unwrap_or_default();
@@ -1018,11 +917,7 @@ impl PerfettoTraceBuilder {
                 }
             };
 
-            let track_uuid = *error_uuids.entry(error.clone()).or_insert_with(|| {
-                let uuid = self.alloc_uuid();
-                self.add_child_track(uuid, process_uuid, &error);
-                uuid
-            });
+            let track_uuid = self.child_track_uuid(process_uuid, &error);
 
             let mut annotations = vec![
                 Self::make_annotation_int("code", code),
@@ -1045,11 +940,8 @@ impl PerfettoTraceBuilder {
             return;
         }
 
-        let process_uuid = self.alloc_uuid();
-        self.add_process_track(process_uuid, "S3 Queue");
-
-        let track_uuid = self.alloc_uuid();
-        self.add_child_track(track_uuid, process_uuid, "files");
+        let process_uuid = self.process_track_uuid("S3 Queue");
+        let track_uuid = self.child_track_uuid(process_uuid, "files");
 
         for i in 0..columns.row_count() {
             let file_name: String = columns.get(i, "file_name").unwrap_or_default();
@@ -1085,10 +977,7 @@ impl PerfettoTraceBuilder {
             return;
         }
 
-        let process_uuid = self.alloc_uuid();
-        self.add_process_track(process_uuid, "Azure Queue");
-
-        let mut table_uuids: HashMap<String, u64> = HashMap::new();
+        let process_uuid = self.process_track_uuid("Azure Queue");
 
         for i in 0..columns.row_count() {
             let database: String = columns.get(i, "database").unwrap_or_default();
@@ -1108,11 +997,7 @@ impl PerfettoTraceBuilder {
             };
 
             let table_key = format!("{}.{}", database, table);
-            let track_uuid = *table_uuids.entry(table_key.clone()).or_insert_with(|| {
-                let uuid = self.alloc_uuid();
-                self.add_child_track(uuid, process_uuid, &table_key);
-                uuid
-            });
+            let track_uuid = self.child_track_uuid(process_uuid, &table_key);
 
             let mut annotations = vec![
                 Self::make_annotation_str("file_name", &file_name),
@@ -1133,10 +1018,7 @@ impl PerfettoTraceBuilder {
             return;
         }
 
-        let process_uuid = self.alloc_uuid();
-        self.add_process_track(process_uuid, "Blob Storage");
-
-        let mut type_uuids: HashMap<String, u64> = HashMap::new();
+        let process_uuid = self.process_track_uuid("Blob Storage");
 
         for i in 0..columns.row_count() {
             let event_type: String = columns.get(i, "event_type").unwrap_or_default();
@@ -1159,11 +1041,7 @@ impl PerfettoTraceBuilder {
                     }
                 };
 
-            let track_uuid = *type_uuids.entry(event_type.clone()).or_insert_with(|| {
-                let uuid = self.alloc_uuid();
-                self.add_child_track(uuid, process_uuid, &event_type);
-                uuid
-            });
+            let track_uuid = self.child_track_uuid(process_uuid, &event_type);
 
             let mut annotations = vec![
                 Self::make_annotation_str("query_id", &query_id),
@@ -1185,10 +1063,7 @@ impl PerfettoTraceBuilder {
             return;
         }
 
-        let process_uuid = self.alloc_uuid();
-        self.add_process_track(process_uuid, "Background Pool");
-
-        let mut log_name_uuids: HashMap<String, u64> = HashMap::new();
+        let process_uuid = self.process_track_uuid("Background Pool");
 
         for i in 0..columns.row_count() {
             let log_name: String = columns.get(i, "log_name").unwrap_or_default();
@@ -1211,11 +1086,7 @@ impl PerfettoTraceBuilder {
             };
             let start_ns = end_ns.saturating_sub(duration_ms * 1_000_000);
 
-            let track_uuid = *log_name_uuids.entry(log_name.clone()).or_insert_with(|| {
-                let uuid = self.alloc_uuid();
-                self.add_child_track(uuid, process_uuid, &log_name);
-                uuid
-            });
+            let track_uuid = self.child_track_uuid(process_uuid, &log_name);
 
             let mut annotations = vec![
                 Self::make_annotation_str("database", &database),
@@ -1240,10 +1111,7 @@ impl PerfettoTraceBuilder {
             return;
         }
 
-        let process_uuid = self.alloc_uuid();
-        self.add_process_track(process_uuid, "Sessions");
-
-        let mut type_uuids: HashMap<String, u64> = HashMap::new();
+        let process_uuid = self.process_track_uuid("Sessions");
 
         for i in 0..columns.row_count() {
             let session_type: String = columns.get(i, "type").unwrap_or_default();
@@ -1266,11 +1134,7 @@ impl PerfettoTraceBuilder {
                     }
                 };
 
-            let track_uuid = *type_uuids.entry(session_type.clone()).or_insert_with(|| {
-                let uuid = self.alloc_uuid();
-                self.add_child_track(uuid, process_uuid, &session_type);
-                uuid
-            });
+            let track_uuid = self.child_track_uuid(process_uuid, &session_type);
 
             let mut annotations = vec![
                 Self::make_annotation_str("user", &user),
@@ -1293,11 +1157,7 @@ impl PerfettoTraceBuilder {
             return;
         }
 
-        let process_uuid = self.alloc_uuid();
-        self.add_process_track(process_uuid, "ZooKeeper");
-
-        // operation → (count_track, latency_track)
-        let mut op_tracks: HashMap<String, (u64, u64)> = HashMap::new();
+        let process_uuid = self.process_track_uuid("ZooKeeper");
 
         for i in 0..columns.row_count() {
             let operation: String = columns.get(i, "operation").unwrap_or_default();
@@ -1318,24 +1178,16 @@ impl PerfettoTraceBuilder {
                 }
             };
 
-            let (count_track, latency_track) =
-                *op_tracks.entry(operation.clone()).or_insert_with(|| {
-                    let ct = self.alloc_uuid();
-                    self.add_counter_track(
-                        ct,
-                        process_uuid,
-                        &format!("{} count", operation),
-                        Unit::UNIT_UNSPECIFIED,
-                    );
-                    let lt = self.alloc_uuid();
-                    self.add_counter_track(
-                        lt,
-                        process_uuid,
-                        &format!("{} avg_latency", operation),
-                        Unit::UNIT_UNSPECIFIED,
-                    );
-                    (ct, lt)
-                });
+            let count_track = self.counter_track_uuid(
+                process_uuid,
+                &format!("{} count", operation),
+                Unit::UNIT_UNSPECIFIED,
+            );
+            let latency_track = self.counter_track_uuid(
+                process_uuid,
+                &format!("{} avg_latency", operation),
+                Unit::UNIT_UNSPECIFIED,
+            );
 
             self.add_counter_value(count_track, timestamp_ns, count as i64);
             self.add_counter_value(latency_track, timestamp_ns, average_latency as i64);

--- a/src/interpreter/perfetto.rs
+++ b/src/interpreter/perfetto.rs
@@ -362,18 +362,9 @@ impl PerfettoTraceBuilder {
     // --- High-level methods ---
 
     pub fn add_queries(&mut self, queries: &[Query]) {
-        // (host, user) → thread_uuid
-        let mut user_uuids: HashMap<(String, String), u64> = HashMap::new();
-
         for q in queries {
             let host_uuid = self.get_or_create_host_uuid(&q.host_name);
-
-            let user_key = (q.host_name.clone(), q.user.clone());
-            let user_uuid = *user_uuids.entry(user_key).or_insert_with(|| {
-                let uuid = self.alloc_uuid();
-                self.add_child_track(uuid, host_uuid, &q.user);
-                uuid
-            });
+            let user_uuid = self.child_track_uuid(host_uuid, &q.user);
 
             let start_ns = match Self::datetime_to_ns(&q.query_start_time_microseconds) {
                 Some(ns) => ns,
@@ -693,8 +684,8 @@ impl PerfettoTraceBuilder {
             let duration_ms: u64 = columns.get(i, "query_duration_ms").unwrap_or(0);
             let peak_memory: i64 = columns.get(i, "peak_memory_usage").unwrap_or(0);
 
-            let names: Vec<String> = columns.get(i, "ProfileEvents.Names").unwrap_or_default();
-            let values: Vec<u64> = columns.get(i, "ProfileEvents.Values").unwrap_or_default();
+            let names: Vec<String> = columns.get(i, "profile_event_names").unwrap_or_default();
+            let values: Vec<u64> = columns.get(i, "profile_event_values").unwrap_or_default();
 
             let track_uuid = self.child_track_uuid(process_uuid, &thread_name);
 

--- a/src/interpreter/perfetto.rs
+++ b/src/interpreter/perfetto.rs
@@ -1,8 +1,9 @@
 use crate::interpreter::Query;
-use crate::interpreter::clickhouse::{Columns, MetricLogRow, QueryMetricRow};
+use crate::interpreter::clickhouse::{MetricLogRow, QueryMetricRow};
 use anyhow::Result;
 use chrono::{DateTime, Local};
 use chrono_tz::Tz;
+use clickhouse_rs::{Block, types::ColumnType};
 use perfetto_protos::android_log::AndroidLogPacket;
 use perfetto_protos::android_log::android_log_packet::LogEvent;
 use perfetto_protos::android_log_constants::AndroidLogPriority;
@@ -82,6 +83,17 @@ pub struct PerfettoTraceBuilder {
     callstack_iids: HashMap<Vec<u64>, u64>,
     next_intern_id: u64,
 
+    // Streamed stack-trace state, flushed by finalize_stack_traces() in build()
+    stack_mapping_iid: Option<u64>,
+    stack_callstacks_by_hash: HashMap<(String, u64), u64>,
+    stack_interned_strings: Vec<InternedString>,
+    stack_interned_frames: Vec<Frame>,
+    stack_interned_callstacks: Vec<Callstack>,
+    // Global: trace_type → samples
+    stack_samples_by_type: HashMap<String, Vec<Sample>>,
+    // Per-server: (host_name, trace_type) → samples
+    stack_samples_by_host_type: HashMap<(String, String), Vec<Sample>>,
+
     host_uuids: HashMap<String, u64>,
     // (host_name, category) → category track uuid
     host_category_uuids: HashMap<(String, &'static str), u64>,
@@ -140,6 +152,14 @@ impl PerfettoTraceBuilder {
             frame_iids: HashMap::new(),
             callstack_iids: HashMap::new(),
             next_intern_id: 1,
+
+            stack_mapping_iid: None,
+            stack_callstacks_by_hash: HashMap::new(),
+            stack_interned_strings: Vec::new(),
+            stack_interned_frames: Vec::new(),
+            stack_interned_callstacks: Vec::new(),
+            stack_samples_by_type: HashMap::new(),
+            stack_samples_by_host_type: HashMap::new(),
 
             host_uuids: HashMap::new(),
             host_category_uuids: HashMap::new(),
@@ -412,7 +432,7 @@ impl PerfettoTraceBuilder {
         }
     }
 
-    pub fn add_otel_spans(&mut self, columns: &Columns) {
+    pub fn add_otel_spans<K: ColumnType>(&mut self, columns: &Block<K>) {
         if columns.row_count() == 0 {
             return;
         }
@@ -478,7 +498,7 @@ impl PerfettoTraceBuilder {
         }
     }
 
-    pub fn add_trace_log_counters(&mut self, columns: &Columns) {
+    pub fn add_trace_log_counters<K: ColumnType>(&mut self, columns: &Block<K>) {
         if columns.row_count() == 0 {
             return;
         }
@@ -607,7 +627,7 @@ impl PerfettoTraceBuilder {
         }
     }
 
-    pub fn add_part_log(&mut self, columns: &Columns) {
+    pub fn add_part_log<K: ColumnType>(&mut self, columns: &Block<K>) {
         if columns.row_count() == 0 {
             return;
         }
@@ -683,7 +703,7 @@ impl PerfettoTraceBuilder {
         }
     }
 
-    pub fn add_query_thread_log(&mut self, columns: &Columns) {
+    pub fn add_query_thread_log<K: ColumnType>(&mut self, columns: &Block<K>) {
         if columns.row_count() == 0 {
             return;
         }
@@ -759,7 +779,7 @@ impl PerfettoTraceBuilder {
         }
     }
 
-    pub fn add_text_logs(&mut self, columns: &Columns) {
+    pub fn add_text_logs<K: ColumnType>(&mut self, columns: &Block<K>) {
         if columns.row_count() == 0 {
             return;
         }
@@ -879,7 +899,7 @@ impl PerfettoTraceBuilder {
         }
     }
 
-    pub fn add_asynchronous_metric_log(&mut self, columns: &Columns) {
+    pub fn add_asynchronous_metric_log<K: ColumnType>(&mut self, columns: &Block<K>) {
         if columns.row_count() == 0 {
             return;
         }
@@ -915,7 +935,7 @@ impl PerfettoTraceBuilder {
         }
     }
 
-    pub fn add_asynchronous_insert_log(&mut self, columns: &Columns) {
+    pub fn add_asynchronous_insert_log<K: ColumnType>(&mut self, columns: &Block<K>) {
         if columns.row_count() == 0 {
             return;
         }
@@ -973,7 +993,7 @@ impl PerfettoTraceBuilder {
         }
     }
 
-    pub fn add_error_log(&mut self, columns: &Columns) {
+    pub fn add_error_log<K: ColumnType>(&mut self, columns: &Block<K>) {
         if columns.row_count() == 0 {
             return;
         }
@@ -1020,7 +1040,7 @@ impl PerfettoTraceBuilder {
         }
     }
 
-    pub fn add_s3_queue_log(&mut self, columns: &Columns) {
+    pub fn add_s3_queue_log<K: ColumnType>(&mut self, columns: &Block<K>) {
         if columns.row_count() == 0 {
             return;
         }
@@ -1060,7 +1080,7 @@ impl PerfettoTraceBuilder {
         }
     }
 
-    pub fn add_azure_queue_log(&mut self, columns: &Columns) {
+    pub fn add_azure_queue_log<K: ColumnType>(&mut self, columns: &Block<K>) {
         if columns.row_count() == 0 {
             return;
         }
@@ -1108,7 +1128,7 @@ impl PerfettoTraceBuilder {
         }
     }
 
-    pub fn add_blob_storage_log(&mut self, columns: &Columns) {
+    pub fn add_blob_storage_log<K: ColumnType>(&mut self, columns: &Block<K>) {
         if columns.row_count() == 0 {
             return;
         }
@@ -1160,7 +1180,7 @@ impl PerfettoTraceBuilder {
         }
     }
 
-    pub fn add_background_pool_log(&mut self, columns: &Columns) {
+    pub fn add_background_pool_log<K: ColumnType>(&mut self, columns: &Block<K>) {
         if columns.row_count() == 0 {
             return;
         }
@@ -1215,7 +1235,7 @@ impl PerfettoTraceBuilder {
         }
     }
 
-    pub fn add_session_log(&mut self, columns: &Columns) {
+    pub fn add_session_log<K: ColumnType>(&mut self, columns: &Block<K>) {
         if columns.row_count() == 0 {
             return;
         }
@@ -1268,7 +1288,7 @@ impl PerfettoTraceBuilder {
         }
     }
 
-    pub fn add_aggregated_zookeeper_log(&mut self, columns: &Columns) {
+    pub fn add_aggregated_zookeeper_log<K: ColumnType>(&mut self, columns: &Block<K>) {
         if columns.row_count() == 0 {
             return;
         }
@@ -1361,26 +1381,21 @@ impl PerfettoTraceBuilder {
     // The working approach: each trace type gets its own sequence with a ThreadDescriptor
     // that carries reference_timestamp_us (microseconds). No clock_id needed on the
     // packets — timing is entirely from reference_timestamp_us + deltas.
-    pub fn add_stack_traces(&mut self, samples: &Columns, stacks: &Columns) {
-        if samples.row_count() == 0 {
-            return;
+    fn stack_mapping_iid(&mut self) -> u64 {
+        if let Some(iid) = self.stack_mapping_iid {
+            return iid;
         }
+        let iid = self.alloc_intern_id();
+        self.stack_mapping_iid = Some(iid);
+        iid
+    }
 
-        // Global: trace_type → samples
-        let mut samples_by_type: HashMap<String, Vec<Sample>> = HashMap::new();
-        // Per-server: (host_name, trace_type) → samples
-        let mut samples_by_host_type: HashMap<(String, String), Vec<Sample>> = HashMap::new();
+    /// Intern each unique stack once; samples reference them by
+    /// (host_name, stack_hash), see stack_traces_for_perfetto_sql().
+    /// Must be fed before add_stack_samples().
+    pub fn add_stack_frames<K: ColumnType>(&mut self, stacks: &Block<K>) {
+        let mapping_iid = self.stack_mapping_iid();
 
-        // Interning accumulators for this batch
-        let mut interned_strings: Vec<InternedString> = Vec::new();
-        let mut interned_frames: Vec<Frame> = Vec::new();
-        let mut interned_callstacks: Vec<Callstack> = Vec::new();
-
-        let mapping_iid = self.alloc_intern_id();
-
-        // Intern each unique stack once; samples reference them by
-        // (host_name, stack_hash), see get_stack_traces_for_perfetto().
-        let mut callstacks_by_hash: HashMap<(String, u64), u64> = HashMap::new();
         for i in 0..stacks.row_count() {
             let host_name: String = stacks.get(i, "host_name").unwrap_or_default();
             let stack_hash: u64 = stacks.get(i, "stack_hash").unwrap_or_default();
@@ -1402,7 +1417,7 @@ impl PerfettoTraceBuilder {
                         let mut is = InternedString::new();
                         is.iid = Some(iid);
                         is.str = Some(func_name.as_bytes().to_vec());
-                        interned_strings.push(is);
+                        self.stack_interned_strings.push(is);
                         iid
                     });
 
@@ -1414,7 +1429,7 @@ impl PerfettoTraceBuilder {
                     f.iid = Some(iid);
                     f.function_name_id = Some(func_iid);
                     f.mapping_id = Some(mapping_iid);
-                    interned_frames.push(f);
+                    self.stack_interned_frames.push(f);
                     iid
                 });
 
@@ -1431,19 +1446,26 @@ impl PerfettoTraceBuilder {
                         let mut cs = Callstack::new();
                         cs.iid = Some(iid);
                         cs.frame_ids = frame_ids;
-                        interned_callstacks.push(cs);
+                        self.stack_interned_callstacks.push(cs);
                         iid
                     });
 
-            callstacks_by_hash.insert((host_name, stack_hash), callstack_iid);
+            self.stack_callstacks_by_hash
+                .insert((host_name, stack_hash), callstack_iid);
         }
+    }
 
+    /// Accumulates samples (compact, 16B each); the profile sequences are
+    /// emitted by finalize_stack_traces() from build().
+    pub fn add_stack_samples<K: ColumnType>(&mut self, samples: &Block<K>) {
         for i in 0..samples.row_count() {
             let trace_type: String = samples.get(i, "trace_type").unwrap_or_default();
             let stack_hash: u64 = samples.get(i, "stack_hash").unwrap_or_default();
             let host_name: String = samples.get(i, "host_name").unwrap_or_default();
 
-            let Some(&callstack_iid) = callstacks_by_hash.get(&(host_name.clone(), stack_hash))
+            let Some(&callstack_iid) = self
+                .stack_callstacks_by_hash
+                .get(&(host_name.clone(), stack_hash))
             else {
                 continue;
             };
@@ -1461,7 +1483,7 @@ impl PerfettoTraceBuilder {
                     }
                 };
 
-            samples_by_type
+            self.stack_samples_by_type
                 .entry(trace_type.clone())
                 .or_default()
                 .push(Sample {
@@ -1470,7 +1492,7 @@ impl PerfettoTraceBuilder {
                 });
 
             if self.per_server && !host_name.is_empty() {
-                samples_by_host_type
+                self.stack_samples_by_host_type
                     .entry((host_name, trace_type))
                     .or_default()
                     .push(Sample {
@@ -1479,10 +1501,21 @@ impl PerfettoTraceBuilder {
                     });
             }
         }
+    }
+
+    fn finalize_stack_traces(&mut self) {
+        let samples_by_type = std::mem::take(&mut self.stack_samples_by_type);
+        let samples_by_host_type = std::mem::take(&mut self.stack_samples_by_host_type);
+        if samples_by_type.is_empty() && samples_by_host_type.is_empty() {
+            return;
+        }
+        let interned_strings = std::mem::take(&mut self.stack_interned_strings);
+        let interned_frames = std::mem::take(&mut self.stack_interned_frames);
+        let interned_callstacks = std::mem::take(&mut self.stack_interned_callstacks);
 
         // Build one dummy mapping
         let mut mapping = Mapping::new();
-        mapping.iid = Some(mapping_iid);
+        mapping.iid = Some(self.stack_mapping_iid());
 
         // Each trace_type gets its own sequence with a dedicated ThreadDescriptor.
         // Sample timestamps come from ThreadDescriptor.reference_timestamp_us + deltas,
@@ -1601,6 +1634,7 @@ impl PerfettoTraceBuilder {
     }
 
     pub fn build(mut self) -> Result<(TraceFile, u64)> {
+        self.finalize_stack_traces();
         if let Some(e) = self.write_error {
             return Err(e.into());
         }

--- a/src/interpreter/query.rs
+++ b/src/interpreter/query.rs
@@ -5,7 +5,7 @@ use size::{Base, SizeFormatter, Style};
 use std::collections::HashMap;
 use std::fmt;
 
-use super::clickhouse::Columns;
+use clickhouse_rs::{Block, types::ColumnType};
 
 // Analog of mapFromArrays() in ClickHouse
 fn map_from_arrays<K, V>(keys: Vec<K>, values: Vec<V>) -> HashMap<K, V>
@@ -59,8 +59,8 @@ pub struct Query {
 }
 impl Query {
     /// Creates a Query from a ClickHouse block at the specified row index
-    pub fn from_clickhouse_block(
-        columns: &Columns,
+    pub fn from_clickhouse_block<K: ColumnType>(
+        columns: &Block<K>,
         row_index: usize,
         running: bool,
     ) -> Result<Self> {

--- a/src/interpreter/worker.rs
+++ b/src/interpreter/worker.rs
@@ -403,6 +403,41 @@ async fn stream_perfetto_source(
     }
 }
 
+// Streams query_log queries into the builder block-by-block (the full window
+// of a server-wide export is hundreds of thousands of rows).
+pub(crate) async fn stream_queries_into_perfetto_trace(
+    clickhouse: &Arc<ClickHouse>,
+    builder: &mut PerfettoTraceBuilder,
+    query_ids: &Option<Vec<String>>,
+    start: DateTime<Local>,
+    end_time: DateTime<Local>,
+) {
+    let (tx, mut rx) = mpsc::channel::<ApplyBlock>(1);
+    tokio::join!(
+        stream_perfetto_source(
+            clickhouse,
+            "query_log queries",
+            clickhouse.queries_for_perfetto_sql(start, end_time, query_ids),
+            tx,
+            |b, blk| {
+                let mut queries = Vec::with_capacity(blk.row_count());
+                for i in 0..blk.row_count() {
+                    match Query::from_clickhouse_block(&blk, i, false) {
+                        Ok(q) => queries.push(q),
+                        Err(e) => log::warn!("Perfetto: failed to parse query row {}: {}", i, e),
+                    }
+                }
+                b.add_queries(&queries);
+            },
+        ),
+        async {
+            while let Some(apply) = rx.next().await {
+                apply(builder);
+            }
+        },
+    );
+}
+
 // Sources are fetched in parallel, but their blocks are applied to the
 // builder by a single consumer through a bounded channel, so the peak memory
 // is a few blocks instead of every result set at once (#242).
@@ -1240,22 +1275,13 @@ async fn process_event(context: ContextArc, event: Event, need_clear: &mut bool)
         }
         Event::ServerPerfettoExport(start, end) => {
             let perfetto_cfg = context.lock().unwrap().options.perfetto.clone();
-            let query_block = clickhouse
-                .get_queries_for_perfetto(start, end, &None)
-                .await?;
-            let mut queries = Vec::new();
-            for i in 0..query_block.row_count() {
-                match Query::from_clickhouse_block(&query_block, i, false) {
-                    Ok(q) => queries.push(q),
-                    Err(e) => log::warn!("Perfetto: failed to parse query row {}: {}", i, e),
-                }
-            }
             let end_time = end + chrono::TimeDelta::seconds(1);
             let mut builder = PerfettoTraceBuilder::new_temp(
                 perfetto_cfg.per_server,
                 perfetto_cfg.text_log_android,
             )?;
-            builder.add_queries(&queries);
+            stream_queries_into_perfetto_trace(&clickhouse, &mut builder, &None, start, end_time)
+                .await;
             fetch_and_populate_perfetto_trace(
                 &clickhouse,
                 &mut builder,

--- a/src/interpreter/worker.rs
+++ b/src/interpreter/worker.rs
@@ -376,6 +376,10 @@ use crate::interpreter::options::ChDigPerfettoConfig;
 
 type ApplyBlock = Box<dyn FnOnce(&mut PerfettoTraceBuilder) + Send>;
 
+// ClickHouse error codes (src/Common/ErrorCodes.cpp)
+const UNKNOWN_TABLE: u32 = 60;
+const CANNOT_EXTRACT_TABLE_STRUCTURE: u32 = 636;
+
 // Streams one source's blocks into the channel; fetch errors only skip this
 // source (same tolerance as the old fetch_all-based code).
 async fn stream_perfetto_source(
@@ -399,6 +403,12 @@ async fn stream_perfetto_source(
         })
         .await;
     if let Err(e) = result {
+        if let Some(ClickHouseError::Server(se)) = e.downcast_ref::<ClickHouseError>()
+            && (se.code == UNKNOWN_TABLE || se.code == CANNOT_EXTRACT_TABLE_STRUCTURE)
+        {
+            log::debug!("Skipping {}: {}", name, e);
+            return;
+        }
         log::warn!("Failed to fetch {}: {}", name, e);
     }
 }

--- a/src/interpreter/worker.rs
+++ b/src/interpreter/worker.rs
@@ -2,7 +2,10 @@ use crate::{
     common::{RelativeDateTime, Stopwatch},
     interpreter::{
         ContextArc, Query,
-        clickhouse::{ClickHouse, TextLogArguments, TraceType},
+        clickhouse::{
+            ClickHouse, TextLogArguments, TraceType, parse_metric_log_block,
+            parse_query_metric_log_block,
+        },
         flamegraph,
         perfetto::PerfettoTraceBuilder,
     },
@@ -13,9 +16,11 @@ use crate::{
 use anyhow::{Result, anyhow};
 use chrono::{DateTime, Local};
 // FIXME: "leaky abstractions"
+use clickhouse_rs::Block;
 use clickhouse_rs::errors::Error as ClickHouseError;
 use cursive::traits::*;
 use cursive::views;
+use futures::StreamExt;
 use futures::channel::mpsc;
 use std::collections::{HashMap, hash_map::Entry};
 use std::sync::{Arc, Mutex};
@@ -369,6 +374,38 @@ async fn render_or_share_flamegraph(
 
 use crate::interpreter::options::ChDigPerfettoConfig;
 
+type ApplyBlock = Box<dyn FnOnce(&mut PerfettoTraceBuilder) + Send>;
+
+// Streams one source's blocks into the channel; fetch errors only skip this
+// source (same tolerance as the old fetch_all-based code).
+async fn stream_perfetto_source(
+    clickhouse: &Arc<ClickHouse>,
+    name: &'static str,
+    sql: Result<String>,
+    mut tx: mpsc::Sender<ApplyBlock>,
+    apply: impl Fn(&mut PerfettoTraceBuilder, Block) + Clone + Send + 'static,
+) {
+    let sql = match sql {
+        Ok(sql) => sql,
+        Err(e) => {
+            log::warn!("Failed to build {} query: {}", name, e);
+            return;
+        }
+    };
+    let result = clickhouse
+        .execute_into(&sql, &mut tx, |block| -> ApplyBlock {
+            let apply = apply.clone();
+            Box::new(move |builder| apply(builder, block))
+        })
+        .await;
+    if let Err(e) = result {
+        log::warn!("Failed to fetch {}: {}", name, e);
+    }
+}
+
+// Sources are fetched in parallel, but their blocks are applied to the
+// builder by a single consumer through a bounded channel, so the peak memory
+// is a few blocks instead of every result set at once (#242).
 pub(crate) async fn fetch_and_populate_perfetto_trace(
     clickhouse: &Arc<ClickHouse>,
     builder: &mut PerfettoTraceBuilder,
@@ -377,121 +414,117 @@ pub(crate) async fn fetch_and_populate_perfetto_trace(
     start: DateTime<Local>,
     end_time: DateTime<Local>,
 ) {
-    let (otel, trace_log, metrics, parts, threads, stack_traces, text_logs) = tokio::join!(
-        async {
+    let (tx, mut rx) = mpsc::channel::<ApplyBlock>(1);
+    let tx_otel = tx.clone();
+    let tx_counters = tx.clone();
+    let tx_metrics = tx.clone();
+    let tx_parts = tx.clone();
+    let tx_threads = tx.clone();
+    let tx_stacks = tx.clone();
+    let tx_text = tx.clone();
+    // The consumer finishes once every producer dropped its sender
+    drop(tx);
+
+    tokio::join!(
+        async move {
             if cfg.opentelemetry_span_log {
-                Some(
-                    clickhouse
-                        .get_otel_spans_for_perfetto(query_ids, start, end_time)
-                        .await,
+                stream_perfetto_source(
+                    clickhouse,
+                    "opentelemetry_span_log",
+                    clickhouse.otel_spans_for_perfetto_sql(query_ids, start, end_time),
+                    tx_otel,
+                    |b, blk| b.add_otel_spans(&blk),
                 )
-            } else {
-                None
+                .await;
             }
         },
-        async {
+        async move {
             if cfg.trace_log {
-                Some(
-                    clickhouse
-                        .get_trace_log_counters_for_perfetto(query_ids, start, end_time)
-                        .await,
+                stream_perfetto_source(
+                    clickhouse,
+                    "trace_log counters",
+                    clickhouse.trace_log_counters_for_perfetto_sql(query_ids, start, end_time),
+                    tx_counters,
+                    |b, blk| b.add_trace_log_counters(&blk),
                 )
-            } else {
-                None
+                .await;
             }
         },
-        async {
+        async move {
             if cfg.query_metric_log {
-                Some(
-                    clickhouse
-                        .get_query_metrics_for_perfetto(query_ids, start, end_time)
-                        .await,
+                stream_perfetto_source(
+                    clickhouse,
+                    "query_metric_log",
+                    clickhouse.query_metric_log_for_perfetto_sql(query_ids, start, end_time),
+                    tx_metrics,
+                    |b, blk| b.add_query_metrics(&parse_query_metric_log_block(&blk)),
                 )
-            } else {
-                None
+                .await;
             }
         },
-        async {
+        async move {
             if cfg.part_log {
-                Some(
-                    clickhouse
-                        .get_part_log_for_perfetto(query_ids, start, end_time)
-                        .await,
+                stream_perfetto_source(
+                    clickhouse,
+                    "part_log",
+                    clickhouse.part_log_for_perfetto_sql(query_ids, start, end_time),
+                    tx_parts,
+                    |b, blk| b.add_part_log(&blk),
                 )
-            } else {
-                None
+                .await;
             }
         },
-        async {
+        async move {
             if cfg.query_thread_log {
-                Some(
-                    clickhouse
-                        .get_query_thread_log_for_perfetto(query_ids, start, end_time)
-                        .await,
+                stream_perfetto_source(
+                    clickhouse,
+                    "query_thread_log",
+                    clickhouse.query_thread_log_for_perfetto_sql(query_ids, start, end_time),
+                    tx_threads,
+                    |b, blk| b.add_query_thread_log(&blk),
                 )
-            } else {
-                None
+                .await;
             }
         },
-        async {
+        async move {
             if cfg.trace_log {
-                Some(
-                    clickhouse
-                        .get_stack_traces_for_perfetto(query_ids, start, end_time)
-                        .await,
+                // Frames must be interned before samples reference them
+                stream_perfetto_source(
+                    clickhouse,
+                    "trace_log stack traces",
+                    clickhouse.stack_traces_for_perfetto_sql(query_ids, start, end_time),
+                    tx_stacks.clone(),
+                    |b, blk| b.add_stack_frames(&blk),
                 )
-            } else {
-                None
+                .await;
+                stream_perfetto_source(
+                    clickhouse,
+                    "trace_log stack samples",
+                    clickhouse.stack_trace_samples_for_perfetto_sql(query_ids, start, end_time),
+                    tx_stacks,
+                    |b, blk| b.add_stack_samples(&blk),
+                )
+                .await;
+            }
+        },
+        async move {
+            if cfg.text_log {
+                stream_perfetto_source(
+                    clickhouse,
+                    "text_log",
+                    clickhouse.text_log_for_perfetto_sql(query_ids, start, end_time),
+                    tx_text,
+                    |b, blk| b.add_text_logs(&blk),
+                )
+                .await;
             }
         },
         async {
-            if cfg.text_log {
-                Some(
-                    clickhouse
-                        .get_text_log_for_perfetto(query_ids, start, end_time)
-                        .await,
-                )
-            } else {
-                None
+            while let Some(apply) = rx.next().await {
+                apply(builder);
             }
         },
     );
-
-    match otel {
-        Some(Ok(block)) => builder.add_otel_spans(&block),
-        Some(Err(e)) => log::warn!("Failed to fetch opentelemetry_span_log: {}", e),
-        None => {}
-    }
-    match trace_log {
-        Some(Ok(block)) => builder.add_trace_log_counters(&block),
-        Some(Err(e)) => log::warn!("Failed to fetch trace_log counters: {}", e),
-        None => {}
-    }
-    match metrics {
-        Some(Ok(rows)) => builder.add_query_metrics(&rows),
-        Some(Err(e)) => log::warn!("Failed to fetch query_metric_log: {}", e),
-        None => {}
-    }
-    match parts {
-        Some(Ok(block)) => builder.add_part_log(&block),
-        Some(Err(e)) => log::warn!("Failed to fetch part_log: {}", e),
-        None => {}
-    }
-    match threads {
-        Some(Ok(block)) => builder.add_query_thread_log(&block),
-        Some(Err(e)) => log::warn!("Failed to fetch query_thread_log: {}", e),
-        None => {}
-    }
-    match stack_traces {
-        Some(Ok((samples, stacks))) => builder.add_stack_traces(&samples, &stacks),
-        Some(Err(e)) => log::warn!("Failed to fetch trace_log stack traces: {}", e),
-        None => {}
-    }
-    match text_logs {
-        Some(Ok(block)) => builder.add_text_logs(&block),
-        Some(Err(e)) => log::warn!("Failed to fetch text_log: {}", e),
-        None => {}
-    }
 }
 
 pub(crate) async fn fetch_server_perfetto_sources(
@@ -501,176 +534,146 @@ pub(crate) async fn fetch_server_perfetto_sources(
     start: DateTime<Local>,
     end_time: DateTime<Local>,
 ) {
-    let (
-        metric_log,
-        async_metric_log,
-        async_insert_log,
-        error_log,
-        s3_queue_log,
-        azure_queue_log,
-        blob_storage_log,
-        bg_pool_log,
-        session_log,
-        zk_log,
-    ) = tokio::join!(
-        async {
+    let (tx, mut rx) = mpsc::channel::<ApplyBlock>(1);
+    let tx_metric = tx.clone();
+    let tx_async_metric = tx.clone();
+    let tx_async_insert = tx.clone();
+    let tx_error = tx.clone();
+    let tx_s3_queue = tx.clone();
+    let tx_azure_queue = tx.clone();
+    let tx_blob_storage = tx.clone();
+    let tx_bg_pool = tx.clone();
+    let tx_session = tx.clone();
+    let tx_zk = tx.clone();
+    drop(tx);
+
+    tokio::join!(
+        async move {
             if cfg.metric_log {
-                Some(
-                    clickhouse
-                        .get_metric_log_for_perfetto(start, end_time)
-                        .await,
+                stream_perfetto_source(
+                    clickhouse,
+                    "metric_log",
+                    clickhouse.metric_log_for_perfetto_sql(start, end_time),
+                    tx_metric,
+                    |b, blk| b.add_metric_log(&parse_metric_log_block(&blk)),
                 )
-            } else {
-                None
+                .await;
             }
         },
-        async {
+        async move {
             if cfg.asynchronous_metric_log {
-                Some(
-                    clickhouse
-                        .get_asynchronous_metric_log_for_perfetto(start, end_time)
-                        .await,
+                stream_perfetto_source(
+                    clickhouse,
+                    "asynchronous_metric_log",
+                    clickhouse.asynchronous_metric_log_for_perfetto_sql(start, end_time),
+                    tx_async_metric,
+                    |b, blk| b.add_asynchronous_metric_log(&blk),
                 )
-            } else {
-                None
+                .await;
             }
         },
-        async {
+        async move {
             if cfg.asynchronous_insert_log {
-                Some(
-                    clickhouse
-                        .get_asynchronous_insert_log_for_perfetto(start, end_time)
-                        .await,
+                stream_perfetto_source(
+                    clickhouse,
+                    "asynchronous_insert_log",
+                    clickhouse.asynchronous_insert_log_for_perfetto_sql(start, end_time),
+                    tx_async_insert,
+                    |b, blk| b.add_asynchronous_insert_log(&blk),
                 )
-            } else {
-                None
+                .await;
             }
         },
-        async {
+        async move {
             if cfg.error_log {
-                Some(clickhouse.get_error_log_for_perfetto(start, end_time).await)
-            } else {
-                None
+                stream_perfetto_source(
+                    clickhouse,
+                    "error_log",
+                    clickhouse.error_log_for_perfetto_sql(start, end_time),
+                    tx_error,
+                    |b, blk| b.add_error_log(&blk),
+                )
+                .await;
             }
         },
-        async {
+        async move {
             if cfg.s3_queue_log {
-                Some(
-                    clickhouse
-                        .get_s3_queue_log_for_perfetto(start, end_time)
-                        .await,
+                stream_perfetto_source(
+                    clickhouse,
+                    "s3queue_log",
+                    clickhouse.s3_queue_log_for_perfetto_sql(start, end_time),
+                    tx_s3_queue,
+                    |b, blk| b.add_s3_queue_log(&blk),
                 )
-            } else {
-                None
+                .await;
             }
         },
-        async {
+        async move {
             if cfg.azure_queue_log {
-                Some(
-                    clickhouse
-                        .get_azure_queue_log_for_perfetto(start, end_time)
-                        .await,
+                stream_perfetto_source(
+                    clickhouse,
+                    "azure_queue_log",
+                    clickhouse.azure_queue_log_for_perfetto_sql(start, end_time),
+                    tx_azure_queue,
+                    |b, blk| b.add_azure_queue_log(&blk),
                 )
-            } else {
-                None
+                .await;
             }
         },
-        async {
+        async move {
             if cfg.blob_storage_log {
-                Some(
-                    clickhouse
-                        .get_blob_storage_log_for_perfetto(start, end_time)
-                        .await,
+                stream_perfetto_source(
+                    clickhouse,
+                    "blob_storage_log",
+                    clickhouse.blob_storage_log_for_perfetto_sql(start, end_time),
+                    tx_blob_storage,
+                    |b, blk| b.add_blob_storage_log(&blk),
                 )
-            } else {
-                None
+                .await;
             }
         },
-        async {
+        async move {
             if cfg.background_schedule_pool_log {
-                Some(
-                    clickhouse
-                        .get_background_schedule_pool_log_for_perfetto(start, end_time)
-                        .await,
+                stream_perfetto_source(
+                    clickhouse,
+                    "background_schedule_pool_log",
+                    clickhouse.background_schedule_pool_log_for_perfetto_sql(start, end_time),
+                    tx_bg_pool,
+                    |b, blk| b.add_background_pool_log(&blk),
                 )
-            } else {
-                None
+                .await;
             }
         },
-        async {
+        async move {
             if cfg.session_log {
-                Some(
-                    clickhouse
-                        .get_session_log_for_perfetto(start, end_time)
-                        .await,
+                stream_perfetto_source(
+                    clickhouse,
+                    "session_log",
+                    clickhouse.session_log_for_perfetto_sql(start, end_time),
+                    tx_session,
+                    |b, blk| b.add_session_log(&blk),
                 )
-            } else {
-                None
+                .await;
+            }
+        },
+        async move {
+            if cfg.aggregated_zookeeper_log {
+                stream_perfetto_source(
+                    clickhouse,
+                    "aggregated_zookeeper_log",
+                    clickhouse.aggregated_zookeeper_log_for_perfetto_sql(start, end_time),
+                    tx_zk,
+                    |b, blk| b.add_aggregated_zookeeper_log(&blk),
+                )
+                .await;
             }
         },
         async {
-            if cfg.aggregated_zookeeper_log {
-                Some(
-                    clickhouse
-                        .get_aggregated_zookeeper_log_for_perfetto(start, end_time)
-                        .await,
-                )
-            } else {
-                None
+            while let Some(apply) = rx.next().await {
+                apply(builder);
             }
         },
     );
-
-    match metric_log {
-        Some(Ok(rows)) => builder.add_metric_log(&rows),
-        Some(Err(e)) => log::warn!("Failed to fetch metric_log: {}", e),
-        None => {}
-    }
-    match async_metric_log {
-        Some(Ok(block)) => builder.add_asynchronous_metric_log(&block),
-        Some(Err(e)) => log::warn!("Failed to fetch asynchronous_metric_log: {}", e),
-        None => {}
-    }
-    match async_insert_log {
-        Some(Ok(block)) => builder.add_asynchronous_insert_log(&block),
-        Some(Err(e)) => log::warn!("Failed to fetch asynchronous_insert_log: {}", e),
-        None => {}
-    }
-    match error_log {
-        Some(Ok(block)) => builder.add_error_log(&block),
-        Some(Err(e)) => log::warn!("Failed to fetch error_log: {}", e),
-        None => {}
-    }
-    match s3_queue_log {
-        Some(Ok(block)) => builder.add_s3_queue_log(&block),
-        Some(Err(e)) => log::warn!("Failed to fetch s3queue_log: {}", e),
-        None => {}
-    }
-    match azure_queue_log {
-        Some(Ok(block)) => builder.add_azure_queue_log(&block),
-        Some(Err(e)) => log::warn!("Failed to fetch azure_queue_log: {}", e),
-        None => {}
-    }
-    match blob_storage_log {
-        Some(Ok(block)) => builder.add_blob_storage_log(&block),
-        Some(Err(e)) => log::warn!("Failed to fetch blob_storage_log: {}", e),
-        None => {}
-    }
-    match bg_pool_log {
-        Some(Ok(block)) => builder.add_background_pool_log(&block),
-        Some(Err(e)) => log::warn!("Failed to fetch background_schedule_pool_log: {}", e),
-        None => {}
-    }
-    match session_log {
-        Some(Ok(block)) => builder.add_session_log(&block),
-        Some(Err(e)) => log::warn!("Failed to fetch session_log: {}", e),
-        None => {}
-    }
-    match zk_log {
-        Some(Ok(block)) => builder.add_aggregated_zookeeper_log(&block),
-        Some(Err(e)) => log::warn!("Failed to fetch aggregated_zookeeper_log: {}", e),
-        None => {}
-    }
 }
 
 fn serve_perfetto_trace(

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -486,7 +486,11 @@ async fn test_queries_for_perfetto() {
     let chdig = server.chdig().await;
     let (start, end) = perfetto_window();
     let block = chdig
-        .get_queries_for_perfetto(start, end, &Some(vec!["it-pq-1".to_string()]))
+        .execute(
+            &chdig
+                .queries_for_perfetto_sql(start, end, &Some(vec!["it-pq-1".to_string()]))
+                .unwrap(),
+        )
         .await
         .unwrap();
     assert_eq!(block.row_count(), 1);

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,7 +1,9 @@
 mod common;
 
 use chdig::common::RelativeDateTime;
-use chdig::interpreter::clickhouse::TraceType;
+use chdig::interpreter::clickhouse::{
+    TraceType, parse_metric_log_block, parse_query_metric_log_block,
+};
 use chdig::interpreter::options::ClickHouseOptions;
 use chdig::interpreter::{ClickHouse, TextLogArguments};
 use chrono::{DateTime, Local, TimeDelta};
@@ -411,8 +413,20 @@ async fn test_stack_traces_for_perfetto() {
 
     let chdig = server.chdig().await;
     let (start, end) = perfetto_window();
-    let (samples, stacks) = chdig
-        .get_stack_traces_for_perfetto(Some(&["it-stack-1".to_string()]), start, end)
+    let samples = chdig
+        .execute(
+            &chdig
+                .stack_trace_samples_for_perfetto_sql(Some(&["it-stack-1".to_string()]), start, end)
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let stacks = chdig
+        .execute(
+            &chdig
+                .stack_traces_for_perfetto_sql(Some(&["it-stack-1".to_string()]), start, end)
+                .unwrap(),
+        )
         .await
         .unwrap();
     assert_eq!(samples.row_count(), 1);
@@ -451,7 +465,11 @@ async fn test_trace_log_counters_for_perfetto() {
     let chdig = server.chdig().await;
     let (start, end) = perfetto_window();
     let block = chdig
-        .get_trace_log_counters_for_perfetto(Some(&["it-cnt-1".to_string()]), start, end)
+        .execute(
+            &chdig
+                .trace_log_counters_for_perfetto_sql(Some(&["it-cnt-1".to_string()]), start, end)
+                .unwrap(),
+        )
         .await
         .unwrap();
     assert_eq!(block.row_count(), 1);
@@ -527,7 +545,12 @@ async fn test_metric_log_for_perfetto() {
 
     let chdig = server.chdig().await;
     let (start, end) = perfetto_window();
-    let rows = chdig.get_metric_log_for_perfetto(start, end).await.unwrap();
+    let rows = parse_metric_log_block(
+        &chdig
+            .execute(&chdig.metric_log_for_perfetto_sql(start, end).unwrap())
+            .await
+            .unwrap(),
+    );
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0].profile_events["Query"], 5);
     assert_eq!(rows[0].current_metrics["Query"], 2);
@@ -550,7 +573,11 @@ async fn test_asynchronous_metric_log_for_perfetto() {
     let chdig = server.chdig().await;
     let (start, end) = perfetto_window();
     let block = chdig
-        .get_asynchronous_metric_log_for_perfetto(start, end)
+        .execute(
+            &chdig
+                .asynchronous_metric_log_for_perfetto_sql(start, end)
+                .unwrap(),
+        )
         .await
         .unwrap();
     let rows = find_rows(&block, "metric", "ITTestMetric");
@@ -577,7 +604,11 @@ async fn test_part_log_for_perfetto() {
     let chdig = server.chdig().await;
     let (start, end) = perfetto_window();
     let block = chdig
-        .get_part_log_for_perfetto(Some(&["it-part-1".to_string()]), start, end)
+        .execute(
+            &chdig
+                .part_log_for_perfetto_sql(Some(&["it-part-1".to_string()]), start, end)
+                .unwrap(),
+        )
         .await
         .unwrap();
     assert_eq!(block.row_count(), 1);
@@ -606,7 +637,11 @@ async fn test_otel_spans_for_perfetto() {
     let chdig = server.chdig().await;
     let (start, end) = perfetto_window();
     let block = chdig
-        .get_otel_spans_for_perfetto(Some(&["it-otel-1".to_string()]), start, end)
+        .execute(
+            &chdig
+                .otel_spans_for_perfetto_sql(Some(&["it-otel-1".to_string()]), start, end)
+                .unwrap(),
+        )
         .await
         .unwrap();
     assert_eq!(block.row_count(), 1);
@@ -636,7 +671,11 @@ async fn test_asynchronous_insert_log_for_perfetto() {
     let chdig = server.chdig().await;
     let (start, end) = perfetto_window();
     let block = chdig
-        .get_asynchronous_insert_log_for_perfetto(start, end)
+        .execute(
+            &chdig
+                .asynchronous_insert_log_for_perfetto_sql(start, end)
+                .unwrap(),
+        )
         .await
         .unwrap();
     let rows = find_rows(&block, "query_id", "it-ai-1");
@@ -661,7 +700,10 @@ async fn test_error_log_for_perfetto() {
 
     let chdig = server.chdig().await;
     let (start, end) = perfetto_window();
-    let block = chdig.get_error_log_for_perfetto(start, end).await.unwrap();
+    let block = chdig
+        .execute(&chdig.error_log_for_perfetto_sql(start, end).unwrap())
+        .await
+        .unwrap();
     let rows = find_rows(&block, "error", "UNKNOWN_TABLE");
     assert_eq!(rows.len(), 1);
     assert_eq!(block.get::<u64, _>(rows[0], "value").unwrap(), 3);
@@ -686,7 +728,7 @@ async fn test_blob_storage_log_for_perfetto() {
     let chdig = server.chdig().await;
     let (start, end) = perfetto_window();
     let block = chdig
-        .get_blob_storage_log_for_perfetto(start, end)
+        .execute(&chdig.blob_storage_log_for_perfetto_sql(start, end).unwrap())
         .await
         .unwrap();
     let rows = find_rows(&block, "query_id", "it-blob-1");
@@ -717,7 +759,7 @@ async fn test_session_log_for_perfetto() {
     let chdig = server.chdig().await;
     let (start, end) = perfetto_window();
     let block = chdig
-        .get_session_log_for_perfetto(start, end)
+        .execute(&chdig.session_log_for_perfetto_sql(start, end).unwrap())
         .await
         .unwrap();
     let rows = find_rows(&block, "user", "it_sess");
@@ -776,7 +818,11 @@ async fn test_background_schedule_pool_log() {
 
     let (start, end) = perfetto_window();
     let block = chdig
-        .get_background_schedule_pool_log_for_perfetto(start, end)
+        .execute(
+            &chdig
+                .background_schedule_pool_log_for_perfetto_sql(start, end)
+                .unwrap(),
+        )
         .await
         .unwrap();
     let rows = find_rows(&block, "query_id", "it-bg-1");
@@ -804,10 +850,16 @@ async fn test_query_metrics_for_perfetto() {
 
     let chdig = server.chdig().await;
     let (start, end) = perfetto_window();
-    let rows = chdig
-        .get_query_metrics_for_perfetto(Some(&["it-qm-1".to_string()]), start, end)
-        .await
-        .unwrap();
+    let rows = parse_query_metric_log_block(
+        &chdig
+            .execute(
+                &chdig
+                    .query_metric_log_for_perfetto_sql(Some(&["it-qm-1".to_string()]), start, end)
+                    .unwrap(),
+            )
+            .await
+            .unwrap(),
+    );
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0].memory_usage, 123);
     assert_eq!(rows[0].peak_memory_usage, 456);
@@ -832,7 +884,11 @@ async fn test_query_thread_log_for_perfetto() {
     let chdig = server.chdig().await;
     let (start, end) = perfetto_window();
     let block = chdig
-        .get_query_thread_log_for_perfetto(Some(&["it-qt-1".to_string()]), start, end)
+        .execute(
+            &chdig
+                .query_thread_log_for_perfetto_sql(Some(&["it-qt-1".to_string()]), start, end)
+                .unwrap(),
+        )
         .await
         .unwrap();
     assert_eq!(block.row_count(), 1);
@@ -862,7 +918,7 @@ async fn test_s3_queue_log_for_perfetto() {
     let chdig = server.chdig().await;
     let (start, end) = perfetto_window();
     let block = chdig
-        .get_s3_queue_log_for_perfetto(start, end)
+        .execute(&chdig.s3_queue_log_for_perfetto_sql(start, end).unwrap())
         .await
         .unwrap();
     let rows = find_rows(&block, "file_name", "it.csv");
@@ -893,7 +949,7 @@ async fn test_azure_queue_log_for_perfetto() {
     let chdig = server.chdig().await;
     let (start, end) = perfetto_window();
     let block = chdig
-        .get_azure_queue_log_for_perfetto(start, end)
+        .execute(&chdig.azure_queue_log_for_perfetto_sql(start, end).unwrap())
         .await
         .unwrap();
     let rows = find_rows(&block, "file_name", "it.csv");
@@ -917,7 +973,11 @@ async fn test_aggregated_zookeeper_log_for_perfetto() {
     let chdig = server.chdig().await;
     let (start, end) = perfetto_window();
     let block = chdig
-        .get_aggregated_zookeeper_log_for_perfetto(start, end)
+        .execute(
+            &chdig
+                .aggregated_zookeeper_log_for_perfetto_sql(start, end)
+                .unwrap(),
+        )
         .await
         .unwrap();
     let rows = find_rows(&block, "parent_path", "/it");


### PR DESCRIPTION
- block streaming
- and do not query unused fields, i.e. ProfileEvents/Settings from query_log