### PR TITLE
Re-enable LowCardinality over native protocol

### DIFF
--- a/src/interpreter/clickhouse.rs
+++ b/src/interpreter/clickhouse.rs
@@ -275,22 +275,11 @@ impl ClickHouse {
             options.url.clone().unwrap(),
             get_client_name()
         );
-        let connect_options: Options = Options::from_str(&url)?
-            .with_setting(
-                "storage_system_stack_trace_pipe_read_timeout_ms",
-                1000,
-                /* is_important= */ false,
-            )
-            // Disable parallel blocks marshalling due to bug with handling LC [1]
-            //
-            //   [1]: https://github.com/ClickHouse/ClickHouse/pull/107319
-            .with_setting(
-                "enable_parallel_blocks_marshalling",
-                0,
-                /* is_important= */ false,
-            )
-            // TODO: add support of Map type for LowCardinality in the driver
-            .with_setting("low_cardinality_allow_in_native_format", false, true);
+        let connect_options: Options = Options::from_str(&url)?.with_setting(
+            "storage_system_stack_trace_pipe_read_timeout_ms",
+            1000,
+            /* is_important= */ false,
+        );
         let pool = Pool::new(connect_options);
 
         let mut handle = pool.get_handle().await.map_err(|e| {


### PR DESCRIPTION
clickhouse-rs does not support Map(LowCardinality), but we do not have such type in our queries, so we do not need to touch low_cardinality_allow_in_native_format, besides there is [1]

  [1]: https://github.com/ClickHouse/ClickHouse/pull/107319

So instead of tunning 2 settings, better tune 0.

Plus, right now I'm more confident about this change after tests has been added.