### PR TITLE
More metrics for Query Patterns

### DIFF
--- a/src/interpreter/context.rs
+++ b/src/interpreter/context.rs
@@ -54,6 +54,8 @@ pub struct Context {
 
     pub queries_filter: Arc<Mutex<String>>,
     pub queries_limit: Arc<Mutex<u64>>,
+    pub query_patterns_metric:
+        Arc<Mutex<&'static crate::view::providers::query_patterns_metrics::Metric>>,
 
     pub debug_metrics: Arc<DebugMetrics>,
 }
@@ -75,6 +77,9 @@ impl Context {
 
         let queries_filter = Arc::new(Mutex::new(String::new()));
         let queries_limit = Arc::new(Mutex::new(options.view.queries_limit));
+        let query_patterns_metric = Arc::new(Mutex::new(
+            crate::view::providers::query_patterns_metrics::default_metric(),
+        ));
 
         // Metrics are always collected; display is toggled with `!`. The refresh thread
         // sleeps when hidden, so this is free when unused.
@@ -101,6 +106,7 @@ impl Context {
             perfetto_server: None,
             queries_filter,
             queries_limit,
+            query_patterns_metric,
             debug_metrics,
         }));
 

--- a/src/interpreter/context.rs
+++ b/src/interpreter/context.rs
@@ -54,8 +54,7 @@ pub struct Context {
 
     pub queries_filter: Arc<Mutex<String>>,
     pub queries_limit: Arc<Mutex<u64>>,
-    pub query_patterns_metric:
-        Arc<Mutex<&'static crate::view::providers::query_patterns_metrics::Metric>>,
+    pub query_patterns_metric: &'static crate::view::providers::query_patterns_metrics::Metric,
 
     pub debug_metrics: Arc<DebugMetrics>,
 }
@@ -77,9 +76,8 @@ impl Context {
 
         let queries_filter = Arc::new(Mutex::new(String::new()));
         let queries_limit = Arc::new(Mutex::new(options.view.queries_limit));
-        let query_patterns_metric = Arc::new(Mutex::new(
-            crate::view::providers::query_patterns_metrics::default_metric(),
-        ));
+        let query_patterns_metric =
+            crate::view::providers::query_patterns_metrics::default_metric();
 
         // Metrics are always collected; display is toggled with `!`. The refresh thread
         // sleeps when hidden, so this is free when unused.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,8 @@ pub mod interpreter;
 mod pastila;
 mod utils;
 mod view;
+// pub for integration tests (tests/)
+pub use view::providers::query_patterns::query_patterns_sql;
 
 mod bin;
 pub use bin::chdig_main;

--- a/src/view/mod.rs
+++ b/src/view/mod.rs
@@ -22,6 +22,7 @@ pub use query_view::QueryView;
 pub use registry::ViewRegistry;
 pub use sql_query_view::Row as QueryResultRow;
 pub use sql_query_view::SQLQueryView;
+pub use sql_query_view::Unit;
 pub use summary_view::SummaryView;
 
 pub use table_view::TableViewItem;

--- a/src/view/providers/mod.rs
+++ b/src/view/providers/mod.rs
@@ -14,7 +14,7 @@ pub mod mutations;
 mod object_storage_queue;
 pub mod part_log;
 mod queries;
-mod query_patterns;
+pub mod query_patterns;
 pub mod query_patterns_metrics;
 mod replicas;
 mod replicated_fetches;

--- a/src/view/providers/mod.rs
+++ b/src/view/providers/mod.rs
@@ -15,6 +15,7 @@ mod object_storage_queue;
 pub mod part_log;
 mod queries;
 mod query_patterns;
+pub mod query_patterns_metrics;
 mod replicas;
 mod replicated_fetches;
 mod replication_queue;

--- a/src/view/providers/query_patterns.rs
+++ b/src/view/providers/query_patterns.rs
@@ -2,7 +2,7 @@ use crate::{
     interpreter::{ContextArc, options::ChDigViews},
     view::{
         self, Navigation, ViewProvider,
-        providers::query_patterns_metrics::{METRICS, Metric},
+        providers::query_patterns_metrics::{self, METRICS, Metric},
     },
 };
 use cursive::{
@@ -10,7 +10,7 @@ use cursive::{
     event::Event,
     theme::{BaseColor, Color},
     view::{Nameable, Resizable},
-    views::{Dialog, OnEventView, SelectView},
+    views::OnEventView,
 };
 use std::collections::HashMap;
 
@@ -154,7 +154,10 @@ fn cycle_metric(siv: &mut Cursive) {
     let next = {
         let ctx = context.lock().unwrap();
         let mut current = ctx.query_patterns_metric.lock().unwrap();
-        let idx = METRICS.iter().position(|m| m.key == current.key).unwrap_or(0);
+        let idx = METRICS
+            .iter()
+            .position(|m| m.key == current.key)
+            .unwrap_or(0);
         let next = &METRICS[(idx + 1) % METRICS.len()];
         *current = next;
         next
@@ -164,47 +167,43 @@ fn cycle_metric(siv: &mut Cursive) {
 }
 
 fn apply_metric_change(siv: &mut Cursive, context: ContextArc) {
-    let metric = *context.lock().unwrap().query_patterns_metric.lock().unwrap();
+    let metric = *context
+        .lock()
+        .unwrap()
+        .query_patterns_metric
+        .lock()
+        .unwrap();
     let query = build_query(&context, metric);
-    siv.call_on_name(VIEW_NAME, |v: &mut cursive::views::OnEventView<view::SQLQueryView>| {
-        let v = v.get_inner_mut();
-        v.set_query(query);
-        v.set_column_title("heatmap", &format!("{} heatmap", metric.label));
-        v.set_column_title("total", metric.label);
-    });
+    siv.call_on_name(
+        VIEW_NAME,
+        |v: &mut cursive::views::OnEventView<view::SQLQueryView>| {
+            let v = v.get_inner_mut();
+            v.set_query(query);
+            v.set_column_title("heatmap", &format!("{} heatmap", metric.label));
+            v.set_column_title("total", metric.label);
+        },
+    );
     context.lock().unwrap().trigger_view_refresh();
 }
 
 fn show_metric_picker(siv: &mut Cursive) {
-    if siv.find_name::<SelectView<&'static Metric>>("metric_picker").is_some() {
-        return;
-    }
-
-    let context = siv.user_data::<ContextArc>().unwrap().clone();
-    let current_key = context.lock().unwrap().query_patterns_metric.lock().unwrap().key;
-
-    let mut select = SelectView::<&'static Metric>::new().autojump();
-    let mut selected_idx = 0;
-    for (i, m) in METRICS.iter().enumerate() {
-        select.add_item(m.label, m);
-        if m.key == current_key {
-            selected_idx = i;
-        }
-    }
-    select.set_selection(selected_idx);
-
-    select.set_on_submit(move |siv, metric: &&'static Metric| {
+    let items: Vec<(String, String)> = METRICS
+        .iter()
+        .map(|m| (m.label.to_string(), m.key.to_string()))
+        .collect();
+    crate::utils::fuzzy_select_strings(siv, "Select metric", items, |siv, key| {
+        let Some(metric) = query_patterns_metrics::find(&key) else {
+            return;
+        };
         let context = siv.user_data::<ContextArc>().unwrap().clone();
-        *context.lock().unwrap().query_patterns_metric.lock().unwrap() = *metric;
-        siv.pop_layer();
+        *context
+            .lock()
+            .unwrap()
+            .query_patterns_metric
+            .lock()
+            .unwrap() = metric;
         apply_metric_change(siv, context);
     });
-
-    siv.add_layer(
-        Dialog::around(select.with_name("metric_picker"))
-            .title("Select metric")
-            .dismiss_button("Cancel"),
-    );
 }
 
 fn show_query_patterns(siv: &mut Cursive, context: ContextArc) {
@@ -216,7 +215,12 @@ fn show_query_patterns(siv: &mut Cursive, context: ContextArc) {
 }
 
 fn build_and_install(siv: &mut Cursive, context: ContextArc) {
-    let metric = *context.lock().unwrap().query_patterns_metric.lock().unwrap();
+    let metric = *context
+        .lock()
+        .unwrap()
+        .query_patterns_metric
+        .lock()
+        .unwrap();
 
     let query = build_query(&context, metric);
     let columns = vec![
@@ -247,15 +251,12 @@ fn build_and_install(siv: &mut Cursive, context: ContextArc) {
         .set_on_submit(open_last_queries_for_hash);
     view.get_inner_mut()
         .set_heatmap_column("heatmap", "_heatmap");
-    view.get_inner_mut().set_column_width("heatmap", HEATMAP_BUCKETS);
+    view.get_inner_mut()
+        .set_column_width("heatmap", HEATMAP_BUCKETS);
     view.get_inner_mut()
         .set_column_title("heatmap", &format!("{} heatmap", metric.label));
     view.get_inner_mut().set_column_title("total", metric.label);
-    let total_width = METRICS
-        .iter()
-        .map(|m| m.label.len())
-        .max()
-        .unwrap_or(5);
+    let total_width = METRICS.iter().map(|m| m.label.len()).max().unwrap_or(5);
     view.get_inner_mut().set_column_width("total", total_width);
     view.get_inner_mut().set_title("Query patterns");
     view.get_inner_mut().set_color_log_scale(

--- a/src/view/providers/query_patterns.rs
+++ b/src/view/providers/query_patterns.rs
@@ -36,7 +36,7 @@ impl ViewProvider for QueryPatternsViewProvider {
     }
 }
 
-fn build_query(context: &ContextArc, metric: &Metric) -> String {
+fn build_query(context: &ContextArc) -> String {
     let (view_options, limit, dbtable, clickhouse, selected_host) = {
         let ctx = context.lock().unwrap();
         (
@@ -57,6 +57,44 @@ fn build_query(context: &ContextArc, metric: &Metric) -> String {
         .to_sql_datetime_64()
         .unwrap_or_else(|| "now()".to_string());
 
+    // Every metric is computed in this single grouped scan; the view switches
+    // between them client-side. Inner subquery emits per-metric `_total_<key>`
+    // (sortable) and `_hm_<key>` (per-bucket heatmap string); the outer SELECT
+    // adds the placeholder `total`/`heatmap` columns the view sources from them.
+    let cols = query_patterns_metrics::metric_columns();
+    let inner_totals = METRICS
+        .iter()
+        .zip(cols)
+        .map(|(m, (_, total_col, _))| format!("{} AS {}", m.agg_expr, total_col))
+        .collect::<Vec<_>>()
+        .join(",\n                ");
+    let inner_heatmaps = METRICS
+        .iter()
+        .zip(cols)
+        .map(|(m, (_, _, hm_col))| {
+            format!(
+                r#"arrayStringConcat(
+                    arrayMap(v -> toString(v),
+                        {bucket_agg}Resample(0, {buckets}, 1)(
+                            {bucket_value},
+                            toUInt16(least({buckets} - 1,
+                                intDiv(toUInt64(toUInt32(event_time) - start_ts) * {buckets}, span_)))
+                        )),
+                    ',') AS {hm_col}"#,
+                bucket_agg = m.bucket_agg,
+                bucket_value = m.bucket_value,
+                buckets = HEATMAP_BUCKETS,
+                hm_col = hm_col,
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(",\n                ");
+    let outer_passthrough = cols
+        .iter()
+        .map(|(_, total_col, hm_col)| format!("{},\n            {}", total_col, hm_col))
+        .collect::<Vec<_>>()
+        .join(",\n            ");
+
     format!(
         r#"
         WITH
@@ -70,14 +108,14 @@ fn build_query(context: &ContextArc, metric: &Metric) -> String {
             p50,
             p90,
             stddev,
-            total,
+            0 AS total,
             arrayStringConcat(
                 arrayMap(
                     h -> ['▁','▂','▃','▄','▅','▆','▇','█'][toUInt32(least(8, greatest(1, ceil(h / arrayMax(heights_) * 8))))],
                     heights_),
                 '') AS dist,
             '' AS heatmap,
-            _heatmap,
+            {outer_passthrough},
             normalized_query
         FROM
         (
@@ -87,16 +125,9 @@ fn build_query(context: &ContextArc, metric: &Metric) -> String {
                 quantile(0.5)(query_duration_ms)/1e3 AS p50,
                 quantile(0.9)(query_duration_ms)/1e3 AS p90,
                 stddevPop(query_duration_ms)/1e3 AS stddev,
-                {total_expr} AS total,
                 arrayMap(t -> t.3, histogram(16)(query_duration_ms)) AS heights_,
-                arrayStringConcat(
-                    arrayMap(v -> toString(v),
-                        {bucket_agg}Resample(0, {buckets}, 1)(
-                            {bucket_value},
-                            toUInt16(least({buckets} - 1,
-                                intDiv(toUInt64(toUInt32(event_time) - start_ts) * {buckets}, span_)))
-                        )),
-                    ',') AS _heatmap,
+                {inner_totals},
+                {inner_heatmaps},
                 any(normalizeQuery(query)) AS normalized_query
             FROM {dbtable}
             WHERE
@@ -107,7 +138,7 @@ fn build_query(context: &ContextArc, metric: &Metric) -> String {
                 {internal}
                 {host_filter}
             GROUP BY normalized_query_hash
-            ORDER BY total DESC
+            ORDER BY cnt DESC
             LIMIT {limit}
         )
         "#,
@@ -117,10 +148,9 @@ fn build_query(context: &ContextArc, metric: &Metric) -> String {
         internal = clickhouse.get_internal_filter_clause(),
         host_filter = clickhouse.get_log_host_filter_clause(selected_host.as_ref()),
         limit = limit,
-        buckets = HEATMAP_BUCKETS,
-        total_expr = metric.agg_expr,
-        bucket_value = metric.bucket_value,
-        bucket_agg = metric.bucket_agg,
+        inner_totals = inner_totals,
+        inner_heatmaps = inner_heatmaps,
+        outer_passthrough = outer_passthrough,
     )
 }
 
@@ -165,20 +195,29 @@ fn cycle_metric(siv: &mut Cursive) {
     apply_metric_change(siv, context);
 }
 
+// Point the displayed `total`/`heatmap` columns at the metric's data and set
+// its unit and titles. Shared by initial build and the runtime switch.
+fn configure_metric(v: &mut view::SQLQueryView, metric: &Metric) {
+    let (total_col, hm_col) = query_patterns_metrics::cols_for(metric.key);
+    v.set_value_source("total", total_col);
+    v.set_value_unit("total", metric.unit);
+    v.set_heatmap_column("heatmap", hm_col);
+    v.set_column_title("heatmap", &format!("{} heatmap", metric.label));
+    v.set_column_title("total", metric.label);
+}
+
 fn apply_metric_change(siv: &mut Cursive, context: ContextArc) {
     let metric = context.lock().unwrap().query_patterns_metric;
-    let query = build_query(&context, metric);
+    // All metrics are already in the result set: re-source and re-derive
+    // client-side instead of re-querying.
     siv.call_on_name(
         VIEW_NAME,
         |v: &mut cursive::views::OnEventView<view::SQLQueryView>| {
             let v = v.get_inner_mut();
-            v.set_query(query);
-            v.set_value_unit("total", metric.unit);
-            v.set_column_title("heatmap", &format!("{} heatmap", metric.label));
-            v.set_column_title("total", metric.label);
+            configure_metric(v, metric);
+            v.recompute_derived();
         },
     );
-    context.lock().unwrap().trigger_view_refresh();
 }
 
 fn show_metric_picker(siv: &mut Cursive) {
@@ -207,8 +246,10 @@ fn show_query_patterns(siv: &mut Cursive, context: ContextArc) {
 fn build_and_install(siv: &mut Cursive, context: ContextArc) {
     let metric = context.lock().unwrap().query_patterns_metric;
 
-    let query = build_query(&context, metric);
-    let columns = vec![
+    let query = build_query(&context);
+    // Visible columns, followed by the hidden per-metric `_total_*`/`_hm_*`
+    // columns the view sources `total`/`heatmap` from on a metric switch.
+    let mut columns = vec![
         "hash",
         "cnt",
         "p50",
@@ -217,9 +258,12 @@ fn build_and_install(siv: &mut Cursive, context: ContextArc) {
         "total",
         "dist",
         "heatmap",
-        "_heatmap",
         "normalized_query",
     ];
+    for (_, total_col, hm_col) in query_patterns_metrics::metric_columns() {
+        columns.push(total_col);
+        columns.push(hm_col);
+    }
     let columns_to_compare = vec!["normalized_query"];
 
     let mut view = view::SQLQueryView::new(
@@ -235,13 +279,8 @@ fn build_and_install(siv: &mut Cursive, context: ContextArc) {
     view.get_inner_mut()
         .set_on_submit(open_last_queries_for_hash);
     view.get_inner_mut()
-        .set_heatmap_column("heatmap", "_heatmap");
-    view.get_inner_mut()
         .set_column_width("heatmap", HEATMAP_BUCKETS);
-    view.get_inner_mut()
-        .set_column_title("heatmap", &format!("{} heatmap", metric.label));
-    view.get_inner_mut().set_column_title("total", metric.label);
-    view.get_inner_mut().set_value_unit("total", metric.unit);
+    configure_metric(view.get_inner_mut(), metric);
     let total_width = METRICS.iter().map(|m| m.label.len()).max().unwrap_or(5);
     view.get_inner_mut().set_column_width("total", total_width);
     view.get_inner_mut().set_title("Query patterns");

--- a/src/view/providers/query_patterns.rs
+++ b/src/view/providers/query_patterns.rs
@@ -57,6 +57,28 @@ fn build_query(context: &ContextArc) -> String {
         .to_sql_datetime_64()
         .unwrap_or_else(|| "now()".to_string());
 
+    query_patterns_sql(
+        &start_sql,
+        &end_sql,
+        &dbtable,
+        &clickhouse.get_internal_filter_clause(),
+        &clickhouse.get_log_host_filter_clause(selected_host.as_ref()),
+        limit,
+    )
+}
+
+/// Builds the fat "Query patterns" SQL: one grouped `query_log` scan that
+/// computes every metric at once (per-metric `_total_<key>` + `_hm_<key>`).
+/// Pure (no Context) so integration tests can run it against a real server.
+/// `internal_filter` / `host_filter` are extra `AND ...` WHERE clauses (or "").
+pub fn query_patterns_sql(
+    start_sql: &str,
+    end_sql: &str,
+    dbtable: &str,
+    internal_filter: &str,
+    host_filter: &str,
+    limit: u64,
+) -> String {
     // Every metric is computed in this single grouped scan; the view switches
     // between them client-side. Inner subquery emits per-metric `_total_<key>`
     // (sortable) and `_hm_<key>` (per-bucket heatmap string); the outer SELECT
@@ -145,8 +167,8 @@ fn build_query(context: &ContextArc) -> String {
         start = start_sql,
         end = end_sql,
         dbtable = dbtable,
-        internal = clickhouse.get_internal_filter_clause(),
-        host_filter = clickhouse.get_log_host_filter_clause(selected_host.as_ref()),
+        internal = internal_filter,
+        host_filter = host_filter,
         limit = limit,
         inner_totals = inner_totals,
         inner_heatmaps = inner_heatmaps,

--- a/src/view/providers/query_patterns.rs
+++ b/src/view/providers/query_patterns.rs
@@ -1,17 +1,24 @@
 use crate::{
     interpreter::{ContextArc, options::ChDigViews},
-    view::{self, Navigation, ViewProvider},
+    view::{
+        self, Navigation, ViewProvider,
+        providers::query_patterns_metrics::{METRICS, Metric},
+    },
 };
 use cursive::{
     Cursive,
+    event::Event,
     theme::{BaseColor, Color},
     view::{Nameable, Resizable},
+    views::{Dialog, OnEventView, SelectView},
 };
 use std::collections::HashMap;
 
-// Must match the max_width=20 MinMax clamp in SQLQueryView::new(), so that the
-// "heatmap" column width resolves to exactly this many cells.
-const HEATMAP_BUCKETS: usize = 20;
+// "heatmap" column is pinned to this width via set_column_width() below, so
+// the bucket count and the rendered column width line up exactly.
+const HEATMAP_BUCKETS: usize = 40;
+
+const VIEW_NAME: &str = "query_patterns";
 
 pub struct QueryPatternsViewProvider;
 
@@ -29,7 +36,7 @@ impl ViewProvider for QueryPatternsViewProvider {
     }
 }
 
-fn build_query(context: &ContextArc) -> String {
+fn build_query(context: &ContextArc, metric: &Metric) -> String {
     let (view_options, limit, dbtable, clickhouse, selected_host) = {
         let ctx = context.lock().unwrap();
         (
@@ -80,12 +87,12 @@ fn build_query(context: &ContextArc) -> String {
                 quantile(0.5)(query_duration_ms)/1e3 AS p50,
                 quantile(0.9)(query_duration_ms)/1e3 AS p90,
                 stddevPop(query_duration_ms)/1e3 AS stddev,
-                sum(query_duration_ms)/1e3 AS total,
+                {total_expr} AS total,
                 arrayMap(t -> t.3, histogram(16)(query_duration_ms)) AS heights_,
                 arrayStringConcat(
                     arrayMap(v -> toString(v),
-                        sumResample(0, {buckets}, 1)(
-                            memory_usage,
+                        {bucket_agg}Resample(0, {buckets}, 1)(
+                            {bucket_value},
                             toUInt16(least({buckets} - 1,
                                 intDiv(toUInt64(toUInt32(event_time) - start_ts) * {buckets}, span_)))
                         )),
@@ -111,6 +118,9 @@ fn build_query(context: &ContextArc) -> String {
         host_filter = clickhouse.get_log_host_filter_clause(selected_host.as_ref()),
         limit = limit,
         buckets = HEATMAP_BUCKETS,
+        total_expr = metric.agg_expr,
+        bucket_value = metric.bucket_value,
+        bucket_agg = metric.bucket_agg,
     )
 }
 
@@ -139,14 +149,76 @@ fn open_last_queries_for_hash(
     context.lock().unwrap().trigger_view_refresh();
 }
 
-fn show_query_patterns(siv: &mut Cursive, context: ContextArc) {
-    let view_name = "query_patterns";
+fn cycle_metric(siv: &mut Cursive) {
+    let context = siv.user_data::<ContextArc>().unwrap().clone();
+    let next = {
+        let ctx = context.lock().unwrap();
+        let mut current = ctx.query_patterns_metric.lock().unwrap();
+        let idx = METRICS.iter().position(|m| m.key == current.key).unwrap_or(0);
+        let next = &METRICS[(idx + 1) % METRICS.len()];
+        *current = next;
+        next
+    };
+    log::trace!("Query patterns metric switched to {}", next.key);
+    apply_metric_change(siv, context);
+}
 
-    if siv.has_view(view_name) {
+fn apply_metric_change(siv: &mut Cursive, context: ContextArc) {
+    let metric = *context.lock().unwrap().query_patterns_metric.lock().unwrap();
+    let query = build_query(&context, metric);
+    siv.call_on_name(VIEW_NAME, |v: &mut cursive::views::OnEventView<view::SQLQueryView>| {
+        let v = v.get_inner_mut();
+        v.set_query(query);
+        v.set_column_title("heatmap", &format!("{} heatmap", metric.label));
+        v.set_column_title("total", metric.label);
+    });
+    context.lock().unwrap().trigger_view_refresh();
+}
+
+fn show_metric_picker(siv: &mut Cursive) {
+    if siv.find_name::<SelectView<&'static Metric>>("metric_picker").is_some() {
         return;
     }
 
-    let query = build_query(&context);
+    let context = siv.user_data::<ContextArc>().unwrap().clone();
+    let current_key = context.lock().unwrap().query_patterns_metric.lock().unwrap().key;
+
+    let mut select = SelectView::<&'static Metric>::new().autojump();
+    let mut selected_idx = 0;
+    for (i, m) in METRICS.iter().enumerate() {
+        select.add_item(m.label, m);
+        if m.key == current_key {
+            selected_idx = i;
+        }
+    }
+    select.set_selection(selected_idx);
+
+    select.set_on_submit(move |siv, metric: &&'static Metric| {
+        let context = siv.user_data::<ContextArc>().unwrap().clone();
+        *context.lock().unwrap().query_patterns_metric.lock().unwrap() = *metric;
+        siv.pop_layer();
+        apply_metric_change(siv, context);
+    });
+
+    siv.add_layer(
+        Dialog::around(select.with_name("metric_picker"))
+            .title("Select metric")
+            .dismiss_button("Cancel"),
+    );
+}
+
+fn show_query_patterns(siv: &mut Cursive, context: ContextArc) {
+    if siv.has_view(VIEW_NAME) {
+        return;
+    }
+    siv.drop_main_view();
+    build_and_install(siv, context);
+}
+
+fn build_and_install(siv: &mut Cursive, context: ContextArc) {
+    let metric = *context.lock().unwrap().query_patterns_metric.lock().unwrap();
+
+    let query = build_query(&context, metric);
     let columns = vec![
         "hash",
         "cnt",
@@ -163,20 +235,28 @@ fn show_query_patterns(siv: &mut Cursive, context: ContextArc) {
 
     let mut view = view::SQLQueryView::new(
         context.clone(),
-        view_name,
+        VIEW_NAME,
         "total",
         columns,
         columns_to_compare,
         query,
     )
-    .unwrap_or_else(|_| panic!("Cannot create {}", view_name));
+    .unwrap_or_else(|_| panic!("Cannot create {}", VIEW_NAME));
 
     view.get_inner_mut()
         .set_on_submit(open_last_queries_for_hash);
     view.get_inner_mut()
         .set_heatmap_column("heatmap", "_heatmap");
+    view.get_inner_mut().set_column_width("heatmap", HEATMAP_BUCKETS);
     view.get_inner_mut()
-        .set_column_title("heatmap", "mem heatmap");
+        .set_column_title("heatmap", &format!("{} heatmap", metric.label));
+    view.get_inner_mut().set_column_title("total", metric.label);
+    let total_width = METRICS
+        .iter()
+        .map(|m| m.label.len())
+        .max()
+        .unwrap_or(5);
+    view.get_inner_mut().set_column_width("total", total_width);
     view.get_inner_mut().set_title("Query patterns");
     view.get_inner_mut().set_color_log_scale(
         "p90",
@@ -188,7 +268,10 @@ fn show_query_patterns(siv: &mut Cursive, context: ContextArc) {
         ],
     );
 
-    siv.drop_main_view();
-    siv.set_main_view(view.with_name(view_name).full_screen());
-    siv.focus_name(view_name).unwrap();
+    let wrapped = OnEventView::new(view.with_name(VIEW_NAME).full_screen())
+        .on_event(Event::Char('m'), show_metric_picker)
+        .on_event(Event::Char(' '), cycle_metric);
+
+    siv.set_main_view(wrapped);
+    siv.focus_name(VIEW_NAME).unwrap();
 }

--- a/src/view/providers/query_patterns.rs
+++ b/src/view/providers/query_patterns.rs
@@ -152,14 +152,13 @@ fn open_last_queries_for_hash(
 fn cycle_metric(siv: &mut Cursive) {
     let context = siv.user_data::<ContextArc>().unwrap().clone();
     let next = {
-        let ctx = context.lock().unwrap();
-        let mut current = ctx.query_patterns_metric.lock().unwrap();
+        let mut ctx = context.lock().unwrap();
         let idx = METRICS
             .iter()
-            .position(|m| m.key == current.key)
+            .position(|m| m.key == ctx.query_patterns_metric.key)
             .unwrap_or(0);
         let next = &METRICS[(idx + 1) % METRICS.len()];
-        *current = next;
+        ctx.query_patterns_metric = next;
         next
     };
     log::trace!("Query patterns metric switched to {}", next.key);
@@ -167,18 +166,14 @@ fn cycle_metric(siv: &mut Cursive) {
 }
 
 fn apply_metric_change(siv: &mut Cursive, context: ContextArc) {
-    let metric = *context
-        .lock()
-        .unwrap()
-        .query_patterns_metric
-        .lock()
-        .unwrap();
+    let metric = context.lock().unwrap().query_patterns_metric;
     let query = build_query(&context, metric);
     siv.call_on_name(
         VIEW_NAME,
         |v: &mut cursive::views::OnEventView<view::SQLQueryView>| {
             let v = v.get_inner_mut();
             v.set_query(query);
+            v.set_value_unit("total", metric.unit);
             v.set_column_title("heatmap", &format!("{} heatmap", metric.label));
             v.set_column_title("total", metric.label);
         },
@@ -196,12 +191,7 @@ fn show_metric_picker(siv: &mut Cursive) {
             return;
         };
         let context = siv.user_data::<ContextArc>().unwrap().clone();
-        *context
-            .lock()
-            .unwrap()
-            .query_patterns_metric
-            .lock()
-            .unwrap() = metric;
+        context.lock().unwrap().query_patterns_metric = metric;
         apply_metric_change(siv, context);
     });
 }
@@ -215,12 +205,7 @@ fn show_query_patterns(siv: &mut Cursive, context: ContextArc) {
 }
 
 fn build_and_install(siv: &mut Cursive, context: ContextArc) {
-    let metric = *context
-        .lock()
-        .unwrap()
-        .query_patterns_metric
-        .lock()
-        .unwrap();
+    let metric = context.lock().unwrap().query_patterns_metric;
 
     let query = build_query(&context, metric);
     let columns = vec![
@@ -256,6 +241,7 @@ fn build_and_install(siv: &mut Cursive, context: ContextArc) {
     view.get_inner_mut()
         .set_column_title("heatmap", &format!("{} heatmap", metric.label));
     view.get_inner_mut().set_column_title("total", metric.label);
+    view.get_inner_mut().set_value_unit("total", metric.unit);
     let total_width = METRICS.iter().map(|m| m.label.len()).max().unwrap_or(5);
     view.get_inner_mut().set_column_width("total", total_width);
     view.get_inner_mut().set_title("Query patterns");

--- a/src/view/providers/query_patterns_metrics.rs
+++ b/src/view/providers/query_patterns_metrics.rs
@@ -7,6 +7,7 @@
 // unit       — how the "total" value is rendered (counts must not be byte-formatted).
 
 use crate::view::Unit;
+use std::sync::OnceLock;
 
 pub struct Metric {
     pub key: &'static str,
@@ -240,6 +241,35 @@ pub const DEFAULT_METRIC_KEY: &str = "memory";
 
 pub fn find(key: &str) -> Option<&'static Metric> {
     METRICS.iter().find(|m| m.key == key)
+}
+
+/// Per-metric hidden column names `(key, total_col, heatmap_col)` for the fat
+/// "Query patterns" query, where every metric is computed at once and the view
+/// switches between them client-side. Names must be `&'static str` (the view
+/// keys columns by static name) yet are derived from `key`, so they are leaked
+/// once for the whole process (bounded by METRICS.len(), independent of how
+/// many times the view is opened).
+pub fn metric_columns() -> &'static [(&'static str, &'static str, &'static str)] {
+    static CELL: OnceLock<Vec<(&'static str, &'static str, &'static str)>> = OnceLock::new();
+    CELL.get_or_init(|| {
+        METRICS
+            .iter()
+            .map(|m| {
+                let total: &'static str = Box::leak(format!("_total_{}", m.key).into_boxed_str());
+                let hm: &'static str = Box::leak(format!("_hm_{}", m.key).into_boxed_str());
+                (m.key, total, hm)
+            })
+            .collect()
+    })
+}
+
+/// `(total_col, heatmap_col)` for the given metric key.
+pub fn cols_for(key: &str) -> (&'static str, &'static str) {
+    let cols = metric_columns()
+        .iter()
+        .find(|c| c.0 == key)
+        .unwrap_or(&metric_columns()[0]);
+    (cols.1, cols.2)
 }
 
 pub fn default_metric() -> &'static Metric {

--- a/src/view/providers/query_patterns_metrics.rs
+++ b/src/view/providers/query_patterns_metrics.rs
@@ -4,6 +4,9 @@
 // agg_expr   — final aggregate over the grouped rows (e.g. "sum(memory_usage)").
 // bucket_value/bucket_agg — per-row expression and aggregation function used by
 //                          `{bucket_agg}Resample(...)` to build the heatmap.
+// unit       — how the "total" value is rendered (counts must not be byte-formatted).
+
+use crate::view::Unit;
 
 pub struct Metric {
     pub key: &'static str,
@@ -11,6 +14,7 @@ pub struct Metric {
     pub agg_expr: &'static str,
     pub bucket_value: &'static str,
     pub bucket_agg: &'static str,
+    pub unit: Unit,
 }
 
 pub const METRICS: &[Metric] = &[
@@ -20,6 +24,7 @@ pub const METRICS: &[Metric] = &[
         agg_expr: "count()",
         bucket_value: "1",
         bucket_agg: "sum",
+        unit: Unit::Count,
     },
     Metric {
         key: "avg_duration",
@@ -27,6 +32,7 @@ pub const METRICS: &[Metric] = &[
         agg_expr: "avg(query_duration_ms)",
         bucket_value: "query_duration_ms",
         bucket_agg: "avg",
+        unit: Unit::Milliseconds,
     },
     Metric {
         key: "max_duration",
@@ -34,6 +40,7 @@ pub const METRICS: &[Metric] = &[
         agg_expr: "max(query_duration_ms)",
         bucket_value: "query_duration_ms",
         bucket_agg: "max",
+        unit: Unit::Milliseconds,
     },
     Metric {
         key: "total_duration",
@@ -41,6 +48,7 @@ pub const METRICS: &[Metric] = &[
         agg_expr: "sum(query_duration_ms)",
         bucket_value: "query_duration_ms",
         bucket_agg: "sum",
+        unit: Unit::Milliseconds,
     },
     Metric {
         key: "cpu_time",
@@ -48,6 +56,7 @@ pub const METRICS: &[Metric] = &[
         agg_expr: "sum(ProfileEvents['UserTimeMicroseconds']+ProfileEvents['SystemTimeMicroseconds'])",
         bucket_value: "ProfileEvents['UserTimeMicroseconds']+ProfileEvents['SystemTimeMicroseconds']",
         bucket_agg: "sum",
+        unit: Unit::Microseconds,
     },
     Metric {
         key: "read_bytes",
@@ -55,6 +64,7 @@ pub const METRICS: &[Metric] = &[
         agg_expr: "sum(read_bytes)",
         bucket_value: "read_bytes",
         bucket_agg: "sum",
+        unit: Unit::Bytes,
     },
     Metric {
         key: "written_bytes",
@@ -62,6 +72,7 @@ pub const METRICS: &[Metric] = &[
         agg_expr: "sum(written_bytes)",
         bucket_value: "written_bytes",
         bucket_agg: "sum",
+        unit: Unit::Bytes,
     },
     Metric {
         key: "avg_written_rows",
@@ -69,6 +80,7 @@ pub const METRICS: &[Metric] = &[
         agg_expr: "avg(written_rows)",
         bucket_value: "written_rows",
         bucket_agg: "avg",
+        unit: Unit::Count,
     },
     Metric {
         key: "result_bytes",
@@ -76,6 +88,7 @@ pub const METRICS: &[Metric] = &[
         agg_expr: "sum(result_bytes)",
         bucket_value: "result_bytes",
         bucket_agg: "sum",
+        unit: Unit::Bytes,
     },
     Metric {
         key: "network_bytes",
@@ -83,6 +96,7 @@ pub const METRICS: &[Metric] = &[
         agg_expr: "sum(ProfileEvents['NetworkReceiveBytes']+ProfileEvents['NetworkSendBytes'])",
         bucket_value: "ProfileEvents['NetworkReceiveBytes']+ProfileEvents['NetworkSendBytes']",
         bucket_agg: "sum",
+        unit: Unit::Bytes,
     },
     Metric {
         key: "memory",
@@ -90,6 +104,7 @@ pub const METRICS: &[Metric] = &[
         agg_expr: "sum(memory_usage)",
         bucket_value: "memory_usage",
         bucket_agg: "sum",
+        unit: Unit::Bytes,
     },
     Metric {
         key: "max_memory",
@@ -97,27 +112,31 @@ pub const METRICS: &[Metric] = &[
         agg_expr: "max(memory_usage)",
         bucket_value: "memory_usage",
         bucket_agg: "max",
+        unit: Unit::Bytes,
     },
     Metric {
         key: "network_wait",
         label: "network wait",
-        agg_expr: "sum(ProfileEvents['NetworkSendElapsedMicroseconds']+ProfileEvents['NetworkReceiveElapsedMicroseconds'])/1e6",
+        agg_expr: "sum(ProfileEvents['NetworkSendElapsedMicroseconds']+ProfileEvents['NetworkReceiveElapsedMicroseconds'])",
         bucket_value: "ProfileEvents['NetworkSendElapsedMicroseconds']+ProfileEvents['NetworkReceiveElapsedMicroseconds']",
         bucket_agg: "sum",
+        unit: Unit::Microseconds,
     },
     Metric {
         key: "io_time",
         label: "io time",
-        agg_expr: "sum(ProfileEvents['DiskReadElapsedMicroseconds']+ProfileEvents['DiskWriteElapsedMicroseconds'])/1e6",
+        agg_expr: "sum(ProfileEvents['DiskReadElapsedMicroseconds']+ProfileEvents['DiskWriteElapsedMicroseconds'])",
         bucket_value: "ProfileEvents['DiskReadElapsedMicroseconds']+ProfileEvents['DiskWriteElapsedMicroseconds']",
         bucket_agg: "sum",
+        unit: Unit::Microseconds,
     },
     Metric {
         key: "io_wait",
         label: "io wait",
-        agg_expr: "sum(ProfileEvents['OSIOWaitMicroseconds'])/1e6",
+        agg_expr: "sum(ProfileEvents['OSIOWaitMicroseconds'])",
         bucket_value: "ProfileEvents['OSIOWaitMicroseconds']",
         bucket_agg: "sum",
+        unit: Unit::Microseconds,
     },
     Metric {
         key: "zk_txns",
@@ -125,6 +144,7 @@ pub const METRICS: &[Metric] = &[
         agg_expr: "sum(ProfileEvents['ZooKeeperTransactions'])",
         bucket_value: "ProfileEvents['ZooKeeperTransactions']",
         bucket_agg: "sum",
+        unit: Unit::Count,
     },
     Metric {
         key: "parts_inserted",
@@ -132,6 +152,7 @@ pub const METRICS: &[Metric] = &[
         agg_expr: "sum(ProfileEvents['InsertedCompactParts']+ProfileEvents['InsertedWideParts'])",
         bucket_value: "ProfileEvents['InsertedCompactParts']+ProfileEvents['InsertedWideParts']",
         bucket_agg: "sum",
+        unit: Unit::Count,
     },
     Metric {
         key: "parts_inserted_avg",
@@ -139,6 +160,7 @@ pub const METRICS: &[Metric] = &[
         agg_expr: "avg(ProfileEvents['InsertedCompactParts']+ProfileEvents['InsertedWideParts'])",
         bucket_value: "ProfileEvents['InsertedCompactParts']+ProfileEvents['InsertedWideParts']",
         bucket_agg: "avg",
+        unit: Unit::Count,
     },
     Metric {
         key: "marks_load_time",
@@ -146,6 +168,7 @@ pub const METRICS: &[Metric] = &[
         agg_expr: "sum(ProfileEvents['WaitMarksLoadMicroseconds'])",
         bucket_value: "ProfileEvents['WaitMarksLoadMicroseconds']",
         bucket_agg: "sum",
+        unit: Unit::Microseconds,
     },
     Metric {
         key: "selected_parts",
@@ -153,6 +176,7 @@ pub const METRICS: &[Metric] = &[
         agg_expr: "sum(ProfileEvents['SelectedParts'])",
         bucket_value: "ProfileEvents['SelectedParts']",
         bucket_agg: "sum",
+        unit: Unit::Count,
     },
     Metric {
         key: "selected_ranges",
@@ -160,6 +184,7 @@ pub const METRICS: &[Metric] = &[
         agg_expr: "sum(ProfileEvents['SelectedRanges'])",
         bucket_value: "ProfileEvents['SelectedRanges']",
         bucket_agg: "sum",
+        unit: Unit::Count,
     },
     Metric {
         key: "selected_marks",
@@ -167,6 +192,7 @@ pub const METRICS: &[Metric] = &[
         agg_expr: "sum(ProfileEvents['SelectedMarks'])",
         bucket_value: "ProfileEvents['SelectedMarks']",
         bucket_agg: "sum",
+        unit: Unit::Count,
     },
     Metric {
         key: "exceptions",
@@ -174,6 +200,7 @@ pub const METRICS: &[Metric] = &[
         agg_expr: "sum(exception_code!=0)",
         bucket_value: "exception_code!=0",
         bucket_agg: "sum",
+        unit: Unit::Count,
     },
     Metric {
         key: "open_files",
@@ -181,6 +208,7 @@ pub const METRICS: &[Metric] = &[
         agg_expr: "sum(ProfileEvents['FileOpen'])",
         bucket_value: "ProfileEvents['FileOpen']",
         bucket_agg: "sum",
+        unit: Unit::Count,
     },
     Metric {
         key: "external_processing_files",
@@ -188,6 +216,7 @@ pub const METRICS: &[Metric] = &[
         agg_expr: "sum(ProfileEvents['ExternalProcessingFilesTotal'])",
         bucket_value: "ProfileEvents['ExternalProcessingFilesTotal']",
         bucket_agg: "sum",
+        unit: Unit::Count,
     },
     Metric {
         key: "threads_peak",
@@ -195,6 +224,7 @@ pub const METRICS: &[Metric] = &[
         agg_expr: "max(peak_threads_usage)",
         bucket_value: "peak_threads_usage",
         bucket_agg: "max",
+        unit: Unit::Count,
     },
     Metric {
         key: "threads_total",
@@ -202,6 +232,7 @@ pub const METRICS: &[Metric] = &[
         agg_expr: "max(length(thread_ids))",
         bucket_value: "length(thread_ids)",
         bucket_agg: "max",
+        unit: Unit::Count,
     },
 ];
 

--- a/src/view/providers/query_patterns_metrics.rs
+++ b/src/view/providers/query_patterns_metrics.rs
@@ -1,0 +1,216 @@
+// Metrics available for the "Query patterns" view. Each metric drives both the
+// sortable "total" column and the per-bucket heatmap on the right.
+//
+// agg_expr   — final aggregate over the grouped rows (e.g. "sum(memory_usage)").
+// bucket_value/bucket_agg — per-row expression and aggregation function used by
+//                          `{bucket_agg}Resample(...)` to build the heatmap.
+
+pub struct Metric {
+    pub key: &'static str,
+    pub label: &'static str,
+    pub agg_expr: &'static str,
+    pub bucket_value: &'static str,
+    pub bucket_agg: &'static str,
+}
+
+pub const METRICS: &[Metric] = &[
+    Metric {
+        key: "count",
+        label: "count",
+        agg_expr: "count()",
+        bucket_value: "1",
+        bucket_agg: "sum",
+    },
+    Metric {
+        key: "avg_duration",
+        label: "avg duration",
+        agg_expr: "avg(query_duration_ms)",
+        bucket_value: "query_duration_ms",
+        bucket_agg: "avg",
+    },
+    Metric {
+        key: "max_duration",
+        label: "max duration",
+        agg_expr: "max(query_duration_ms)",
+        bucket_value: "query_duration_ms",
+        bucket_agg: "max",
+    },
+    Metric {
+        key: "total_duration",
+        label: "total duration",
+        agg_expr: "sum(query_duration_ms)",
+        bucket_value: "query_duration_ms",
+        bucket_agg: "sum",
+    },
+    Metric {
+        key: "cpu_time",
+        label: "cpu time",
+        agg_expr: "sum(ProfileEvents['UserTimeMicroseconds']+ProfileEvents['SystemTimeMicroseconds'])",
+        bucket_value: "ProfileEvents['UserTimeMicroseconds']+ProfileEvents['SystemTimeMicroseconds']",
+        bucket_agg: "sum",
+    },
+    Metric {
+        key: "read_bytes",
+        label: "read bytes",
+        agg_expr: "sum(read_bytes)",
+        bucket_value: "read_bytes",
+        bucket_agg: "sum",
+    },
+    Metric {
+        key: "written_bytes",
+        label: "written bytes",
+        agg_expr: "sum(written_bytes)",
+        bucket_value: "written_bytes",
+        bucket_agg: "sum",
+    },
+    Metric {
+        key: "avg_written_rows",
+        label: "avg written rows",
+        agg_expr: "avg(written_rows)",
+        bucket_value: "written_rows",
+        bucket_agg: "avg",
+    },
+    Metric {
+        key: "result_bytes",
+        label: "result bytes",
+        agg_expr: "sum(result_bytes)",
+        bucket_value: "result_bytes",
+        bucket_agg: "sum",
+    },
+    Metric {
+        key: "network_bytes",
+        label: "network bytes",
+        agg_expr: "sum(ProfileEvents['NetworkReceiveBytes']+ProfileEvents['NetworkSendBytes'])",
+        bucket_value: "ProfileEvents['NetworkReceiveBytes']+ProfileEvents['NetworkSendBytes']",
+        bucket_agg: "sum",
+    },
+    Metric {
+        key: "memory",
+        label: "memory",
+        agg_expr: "sum(memory_usage)",
+        bucket_value: "memory_usage",
+        bucket_agg: "sum",
+    },
+    Metric {
+        key: "max_memory",
+        label: "max memory",
+        agg_expr: "max(memory_usage)",
+        bucket_value: "memory_usage",
+        bucket_agg: "max",
+    },
+    Metric {
+        key: "network_wait",
+        label: "network wait",
+        agg_expr: "sum(ProfileEvents['NetworkSendElapsedMicroseconds']+ProfileEvents['NetworkReceiveElapsedMicroseconds'])/1e6",
+        bucket_value: "ProfileEvents['NetworkSendElapsedMicroseconds']+ProfileEvents['NetworkReceiveElapsedMicroseconds']",
+        bucket_agg: "sum",
+    },
+    Metric {
+        key: "io_time",
+        label: "io time",
+        agg_expr: "sum(ProfileEvents['DiskReadElapsedMicroseconds']+ProfileEvents['DiskWriteElapsedMicroseconds'])/1e6",
+        bucket_value: "ProfileEvents['DiskReadElapsedMicroseconds']+ProfileEvents['DiskWriteElapsedMicroseconds']",
+        bucket_agg: "sum",
+    },
+    Metric {
+        key: "io_wait",
+        label: "io wait",
+        agg_expr: "sum(ProfileEvents['OSIOWaitMicroseconds'])/1e6",
+        bucket_value: "ProfileEvents['OSIOWaitMicroseconds']",
+        bucket_agg: "sum",
+    },
+    Metric {
+        key: "zk_txns",
+        label: "zk txns",
+        agg_expr: "sum(ProfileEvents['ZooKeeperTransactions'])",
+        bucket_value: "ProfileEvents['ZooKeeperTransactions']",
+        bucket_agg: "sum",
+    },
+    Metric {
+        key: "parts_inserted",
+        label: "parts inserted",
+        agg_expr: "sum(ProfileEvents['InsertedCompactParts']+ProfileEvents['InsertedWideParts'])",
+        bucket_value: "ProfileEvents['InsertedCompactParts']+ProfileEvents['InsertedWideParts']",
+        bucket_agg: "sum",
+    },
+    Metric {
+        key: "parts_inserted_avg",
+        label: "parts inserted avg",
+        agg_expr: "avg(ProfileEvents['InsertedCompactParts']+ProfileEvents['InsertedWideParts'])",
+        bucket_value: "ProfileEvents['InsertedCompactParts']+ProfileEvents['InsertedWideParts']",
+        bucket_agg: "avg",
+    },
+    Metric {
+        key: "marks_load_time",
+        label: "marks load time",
+        agg_expr: "sum(ProfileEvents['WaitMarksLoadMicroseconds'])",
+        bucket_value: "ProfileEvents['WaitMarksLoadMicroseconds']",
+        bucket_agg: "sum",
+    },
+    Metric {
+        key: "selected_parts",
+        label: "selected parts",
+        agg_expr: "sum(ProfileEvents['SelectedParts'])",
+        bucket_value: "ProfileEvents['SelectedParts']",
+        bucket_agg: "sum",
+    },
+    Metric {
+        key: "selected_ranges",
+        label: "selected ranges",
+        agg_expr: "sum(ProfileEvents['SelectedRanges'])",
+        bucket_value: "ProfileEvents['SelectedRanges']",
+        bucket_agg: "sum",
+    },
+    Metric {
+        key: "selected_marks",
+        label: "selected marks",
+        agg_expr: "sum(ProfileEvents['SelectedMarks'])",
+        bucket_value: "ProfileEvents['SelectedMarks']",
+        bucket_agg: "sum",
+    },
+    Metric {
+        key: "exceptions",
+        label: "exceptions",
+        agg_expr: "sum(exception_code!=0)",
+        bucket_value: "exception_code!=0",
+        bucket_agg: "sum",
+    },
+    Metric {
+        key: "open_files",
+        label: "open files",
+        agg_expr: "sum(ProfileEvents['FileOpen'])",
+        bucket_value: "ProfileEvents['FileOpen']",
+        bucket_agg: "sum",
+    },
+    Metric {
+        key: "external_processing_files",
+        label: "spill files",
+        agg_expr: "sum(ProfileEvents['ExternalProcessingFilesTotal'])",
+        bucket_value: "ProfileEvents['ExternalProcessingFilesTotal']",
+        bucket_agg: "sum",
+    },
+    Metric {
+        key: "threads_peak",
+        label: "threads (peak)",
+        agg_expr: "max(peak_threads_usage)",
+        bucket_value: "peak_threads_usage",
+        bucket_agg: "max",
+    },
+    Metric {
+        key: "threads_total",
+        label: "threads (total)",
+        agg_expr: "max(length(thread_ids))",
+        bucket_value: "length(thread_ids)",
+        bucket_agg: "max",
+    },
+];
+
+pub const DEFAULT_METRIC_KEY: &str = "memory";
+
+pub fn find(key: &str) -> Option<&'static Metric> {
+    METRICS.iter().find(|m| m.key == key)
+}
+
+pub fn default_metric() -> &'static Metric {
+    find(DEFAULT_METRIC_KEY).unwrap_or(&METRICS[0])
+}

--- a/src/view/sql_query_view.rs
+++ b/src/view/sql_query_view.rs
@@ -20,6 +20,61 @@ use cursive::utils::markup::StyledString;
 use cursive::view::ViewWrapper;
 use cursive::views::OnEventView;
 
+/// Physical meaning of a numeric column, used to format its value for display
+/// without losing the underlying number for sorting (see Field::Quantity).
+#[derive(Clone, Copy, Debug, PartialEq, PartialOrd)]
+pub enum Unit {
+    Count,
+    Bytes,
+    Microseconds,
+    Milliseconds,
+    Seconds,
+}
+
+impl Unit {
+    fn format(self, v: f64) -> String {
+        match self {
+            Unit::Count => format_count(v),
+            Unit::Bytes => SizeFormatter::new()
+                .with_base(Base::Base2)
+                .with_style(Style::Abbreviated)
+                .format(v as i64),
+            Unit::Microseconds => format_duration_ms(v / 1000.0),
+            Unit::Milliseconds => format_duration_ms(v),
+            Unit::Seconds => format_duration_ms(v * 1000.0),
+        }
+    }
+}
+
+fn format_count(v: f64) -> String {
+    if v.abs() < 1000.0 {
+        return format!("{}", v.round() as i64);
+    }
+    const UNITS: [&str; 5] = ["", "K", "M", "B", "T"];
+    let mut x = v;
+    let mut i = 0;
+    while x.abs() >= 1000.0 && i < UNITS.len() - 1 {
+        x /= 1000.0;
+        i += 1;
+    }
+    format!("{:.2}{}", x, UNITS[i])
+}
+
+fn format_duration_ms(ms: f64) -> String {
+    if ms < 1000.0 {
+        return format!("{:.0}ms", ms);
+    }
+    let s = ms / 1000.0;
+    if s < 60.0 {
+        return format!("{:.2}s", s);
+    }
+    let m = s / 60.0;
+    if m < 60.0 {
+        return format!("{:.1}m", m);
+    }
+    format!("{:.1}h", m / 60.0)
+}
+
 #[derive(Clone, Debug, PartialEq, PartialOrd)]
 pub enum Field {
     String(String),
@@ -34,6 +89,8 @@ pub enum Field {
     Int16(i16),
     Int8(i8),
     DateTime(DateTime<Local>),
+    // Numeric value rendered through Unit::format(); ordering stays numeric.
+    Quantity(f64, Unit),
     // TODO: support more types
 }
 
@@ -81,6 +138,7 @@ impl std::fmt::Display for Field {
             Self::Int16(ref value) => write!(f, "{}", value),
             Self::Int8(ref value) => write!(f, "{}", value),
             Self::DateTime(ref value) => write!(f, "{}", value),
+            Self::Quantity(value, unit) => write!(f, "{}", unit.format(value)),
         }
     }
 }
@@ -191,6 +249,7 @@ fn field_to_f64(field: &Field) -> f64 {
         Field::Int8(v) => v as f64,
         Field::Float64(v) => v,
         Field::Float32(v) => v as f64,
+        Field::Quantity(v, _) => v,
         _ => 0.0,
     }
 }
@@ -211,6 +270,7 @@ pub struct SQLQueryView {
     bar_columns: Vec<BarColumnConfig>,
     color_scale: Option<ColorScaleConfig>,
     heatmap_column: Option<HeatmapColumnConfig>,
+    value_units: Vec<(&'static str, Unit)>,
 
     query: Arc<Mutex<String>>,
 
@@ -265,6 +325,7 @@ impl SQLQueryView {
 
         // Store all items, compute bars/colors/heatmaps, and apply filtering
         self.all_items = items;
+        self.apply_units();
         self.compute_bars();
         self.compute_colors();
         self.compute_heatmaps();
@@ -305,6 +366,27 @@ impl SQLQueryView {
 
     pub fn set_heatmap_column(&mut self, heatmap: &'static str, values: &'static str) {
         self.heatmap_column = Some((heatmap, values));
+    }
+
+    /// Tags a numeric column with a physical unit so its value is rendered via
+    /// Unit::format() (sorting stays numeric). Re-tagging the same column
+    /// overrides the previous unit (used when the column's meaning changes, e.g.
+    /// the metric switch in the Query patterns view).
+    pub fn set_value_unit(&mut self, column: &'static str, unit: Unit) {
+        self.value_units.retain(|(c, _)| *c != column);
+        self.value_units.push((column, unit));
+    }
+
+    fn apply_units(&mut self) {
+        for &(column, unit) in &self.value_units {
+            let Some(idx) = self.columns.iter().position(|c| *c == column) else {
+                continue;
+            };
+            for row in &mut self.all_items {
+                let v = field_to_f64(&row.0[idx]);
+                row.0[idx] = Field::Quantity(v, unit);
+            }
+        }
     }
 
     /// Overrides the displayed header of a column (column names come from the
@@ -553,6 +635,7 @@ impl SQLQueryView {
             bar_columns: Vec::new(),
             color_scale: None,
             heatmap_column: None,
+            value_units: Vec::new(),
             query,
             bg_runner,
         };

--- a/src/view/sql_query_view.rs
+++ b/src/view/sql_query_view.rs
@@ -212,6 +212,8 @@ pub struct SQLQueryView {
     color_scale: Option<ColorScaleConfig>,
     heatmap_column: Option<HeatmapColumnConfig>,
 
+    query: Arc<Mutex<String>>,
+
     #[allow(unused)]
     bg_runner: BackgroundRunner,
 }
@@ -219,6 +221,10 @@ pub struct SQLQueryView {
 impl SQLQueryView {
     pub fn set_title<S: Into<String>>(&mut self, title: S) {
         self.table.set_title(title);
+    }
+
+    pub fn set_query(&mut self, query: String) {
+        *self.query.lock().unwrap() = query;
     }
 
     pub fn update(&mut self, block: Columns) -> Result<()> {
@@ -306,6 +312,14 @@ impl SQLQueryView {
     pub fn set_column_title(&mut self, column: &'static str, title: &str) {
         if let Some(idx) = self.columns.iter().position(|c| *c == column) {
             self.table.set_column_title(idx as u8, title.to_string());
+        }
+    }
+
+    /// Pins a column to a fixed width so it stops auto-resizing when content
+    /// changes (useful for columns whose values can vary across modes).
+    pub fn set_column_width(&mut self, column: &'static str, width: usize) {
+        if let Some(idx) = self.columns.iter().position(|c| *c == column) {
+            self.table.set_column_width(idx as u8, width);
         }
     }
 
@@ -454,13 +468,17 @@ impl SQLQueryView {
     ) -> Result<OnEventView<Self>> {
         let delay = context.lock().unwrap().options.view.delay_interval;
 
+        let query = Arc::new(Mutex::new(query));
+
         let update_callback_context = context.clone();
+        let update_callback_query = query.clone();
         let update_callback = move |force: bool| {
+            let q = update_callback_query.lock().unwrap().clone();
             update_callback_context
                 .lock()
                 .unwrap()
                 .worker
-                .send(force, WorkerEvent::SQLQuery(view_name, query.clone()));
+                .send(force, WorkerEvent::SQLQuery(view_name, q));
         };
 
         let columns = parse_columns(&columns);
@@ -535,6 +553,7 @@ impl SQLQueryView {
             bar_columns: Vec::new(),
             color_scale: None,
             heatmap_column: None,
+            query,
             bg_runner,
         };
 

--- a/src/view/sql_query_view.rs
+++ b/src/view/sql_query_view.rs
@@ -271,8 +271,7 @@ pub struct SQLQueryView {
     color_scale: Option<ColorScaleConfig>,
     heatmap_column: Option<HeatmapColumnConfig>,
     value_units: Vec<(&'static str, Unit)>,
-
-    query: Arc<Mutex<String>>,
+    value_sources: Vec<(&'static str, &'static str)>,
 
     #[allow(unused)]
     bg_runner: BackgroundRunner,
@@ -281,10 +280,6 @@ pub struct SQLQueryView {
 impl SQLQueryView {
     pub fn set_title<S: Into<String>>(&mut self, title: S) {
         self.table.set_title(title);
-    }
-
-    pub fn set_query(&mut self, query: String) {
-        *self.query.lock().unwrap() = query;
     }
 
     pub fn update(&mut self, block: Columns) -> Result<()> {
@@ -323,15 +318,24 @@ impl SQLQueryView {
             items.push(row);
         }
 
-        // Store all items, compute bars/colors/heatmaps, and apply filtering
+        // Store all items, then derive the displayed columns and apply filtering.
         self.all_items = items;
+        self.recompute_derived();
+
+        return Ok(());
+    }
+
+    /// Recomputes everything derived from `all_items` (value sources, units,
+    /// bars, colors, heatmaps) and re-applies the filter. Re-runnable without a
+    /// new result block, so views can switch what a column shows client-side
+    /// (e.g. the Query patterns metric switch) without re-querying.
+    pub fn recompute_derived(&mut self) {
+        self.apply_value_sources();
         self.apply_units();
         self.compute_bars();
         self.compute_colors();
         self.compute_heatmaps();
         self.apply_filter();
-
-        return Ok(());
     }
 
     fn apply_filter(&mut self) {
@@ -375,6 +379,30 @@ impl SQLQueryView {
     pub fn set_value_unit(&mut self, column: &'static str, unit: Unit) {
         self.value_units.retain(|(c, _)| *c != column);
         self.value_units.push((column, unit));
+    }
+
+    /// Populates a displayed column from another (typically hidden) source
+    /// column. Re-pointing the destination overrides the previous source; the
+    /// source column itself is never mutated, so switches are idempotent. Used
+    /// to flip the Query patterns "total" column between per-metric columns
+    /// without re-querying.
+    pub fn set_value_source(&mut self, dst: &'static str, src: &'static str) {
+        self.value_sources.retain(|(d, _)| *d != dst);
+        self.value_sources.push((dst, src));
+    }
+
+    fn apply_value_sources(&mut self) {
+        for &(dst, src) in &self.value_sources {
+            let (Some(dst_idx), Some(src_idx)) = (
+                self.columns.iter().position(|c| *c == dst),
+                self.columns.iter().position(|c| *c == src),
+            ) else {
+                continue;
+            };
+            for row in &mut self.all_items {
+                row.0[dst_idx] = row.0[src_idx].clone();
+            }
+        }
     }
 
     fn apply_units(&mut self) {
@@ -550,17 +578,13 @@ impl SQLQueryView {
     ) -> Result<OnEventView<Self>> {
         let delay = context.lock().unwrap().options.view.delay_interval;
 
-        let query = Arc::new(Mutex::new(query));
-
         let update_callback_context = context.clone();
-        let update_callback_query = query.clone();
         let update_callback = move |force: bool| {
-            let q = update_callback_query.lock().unwrap().clone();
             update_callback_context
                 .lock()
                 .unwrap()
                 .worker
-                .send(force, WorkerEvent::SQLQuery(view_name, q));
+                .send(force, WorkerEvent::SQLQuery(view_name, query.clone()));
         };
 
         let columns = parse_columns(&columns);
@@ -636,7 +660,7 @@ impl SQLQueryView {
             color_scale: None,
             heatmap_column: None,
             value_units: Vec::new(),
-            query,
+            value_sources: Vec::new(),
             bg_runner,
         };
 

--- a/src/view/table_view.rs
+++ b/src/view/table_view.rs
@@ -628,6 +628,16 @@ where
         }
     }
 
+    /// Pins an existing column to a fixed (absolute) width so it does not
+    /// rescale when content changes.
+    pub fn set_column_width(&mut self, column: H, width: usize) {
+        if let Some(&i) = self.column_indicies.get(&column) {
+            self.columns[i].requested_width = Some(TableColumnWidth::Absolute(width));
+            self.columns[i].width = width;
+            self.needs_relayout = true;
+        }
+    }
+
     /// Sets the title displayed above the table header (chainable).
     pub fn title<S: Into<String>>(mut self, title: S) -> Self {
         self.title = Some(title.into());

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -143,6 +143,66 @@ async fn test_last_query_log_normalized_query() {
     );
 }
 
+// The "Query patterns" view builds one fat query that computes all ~30 metrics
+// (per-metric _total_<key> + _hm_<key> heatmap) in a single grouped scan. That
+// generated SQL is easy to break (large format string, many aggregates), so run
+// it against a real server and check the aggregation and heatmap shape.
+async fn test_query_patterns() {
+    let Some(server) = common::server() else {
+        return;
+    };
+    // Three executions of the same normalized query -> one pattern, cnt=3.
+    for (i, duration) in [100u64, 200, 300].into_iter().enumerate() {
+        server.insert_query_log(
+            &format!("it-qp-{i}"),
+            "it_user_qp",
+            duration,
+            "SELECT 1 FROM it_qp",
+        );
+    }
+
+    // internal_filter isolates this scenario's rows on the shared server.
+    let sql = chdig::query_patterns_sql(
+        "now() - INTERVAL 10 MINUTE",
+        "now()",
+        "system.query_log",
+        "AND user = 'it_user_qp'",
+        "",
+        1000,
+    );
+
+    // Full (un-pruned) top-level query, so every metric expression is evaluated.
+    let out = server.query(&format!("{sql}\nFORMAT TSVWithNames"));
+    let mut lines = out.lines();
+    let header: Vec<&str> = lines.next().unwrap().split('\t').collect();
+    let row: Vec<&str> = lines.next().expect("one pattern row").split('\t').collect();
+    assert!(lines.next().is_none(), "expected exactly one pattern");
+    let col = |name: &str| -> &str {
+        let i = header
+            .iter()
+            .position(|h| *h == name)
+            .unwrap_or_else(|| panic!("missing column {name}: {header:?}"));
+        row[i]
+    };
+
+    assert_eq!(col("cnt"), "3");
+    // `total`/`heatmap` are placeholders the view sources from the metric columns.
+    assert_eq!(col("total"), "0");
+    assert_eq!(col("heatmap"), "");
+    assert_eq!(col("_total_count"), "3");
+    assert_eq!(col("_total_memory"), "3145728"); // 3 * 1 MiB
+    assert_eq!(col("_total_total_duration"), "600"); // sum(query_duration_ms)
+    assert_eq!(col("_total_max_duration"), "300");
+
+    // One heatmap value per time bucket, summing to the row count.
+    let hm: Vec<i64> = col("_hm_count")
+        .split(',')
+        .map(|v| v.parse().unwrap())
+        .collect();
+    assert_eq!(hm.len(), 40, "heatmap bucket count");
+    assert_eq!(hm.iter().sum::<i64>(), 3);
+}
+
 async fn test_slow_query_log() {
     let Some(server) = common::server() else {
         return;
@@ -1151,6 +1211,7 @@ common::integration_tests!(
     test_summary,
     test_last_query_log,
     test_last_query_log_normalized_query,
+    test_query_patterns,
     test_slow_query_log,
     test_query_log_out_of_window,
     test_processlist_and_kill_query,


### PR DESCRIPTION

Bindings inside the view:
- Space   cycle to next metric
- m       open picker dialog (SelectView of metric labels)

SQLQueryView gains set_query() and a new TableView::set_column_width() so metric switches refresh in place via trigger_view_refresh() instead of tearing the view down (preserves rows via set_items_stable, no left-shift while the new query runs).

The total column is pinned to the longest metric label so it does not rescale on switch, and the heatmap column is widened to 40 buckets.

https://asciinema.org/a/5DL7E6BdKuWofXJs