### PR TITLE
Compatibility for additional_table_filters not supported inside IN subqueries

### DIFF
--- a/src/interpreter/clickhouse.rs
+++ b/src/interpreter/clickhouse.rs
@@ -377,28 +377,57 @@ impl ClickHouse {
     ) -> Result<Columns> {
         let dbtable = self.get_log_table_name("query_log");
         let host_filter = self.get_log_host_filter_clause(selected_host);
+        // NOTE: this is split into two separate top-level queries instead of a
+        // WITH ... GLOBAL IN subquery, since ClickHouse does not apply
+        // additional_table_filters to tables read from within a subquery
+        // (this is not the case for all ClickHouse versions).
+        let ids_columns = self
+            .execute(
+                format!(
+                    r#"
+                    WITH
+                        {start} AS start_,
+                        {end}   AS end_
+                    SELECT DISTINCT initial_query_id
+                    FROM {db_table}
+                    WHERE
+                        event_date BETWEEN toDate(start_) AND toDate(end_) AND
+                        event_time BETWEEN toDateTime(start_) AND toDateTime(end_) AND
+                        is_initial_query AND
+                        /* To make query faster */
+                        query_duration_ms > 1e3
+                        {filter}
+                        {internal}
+                        {host_filter}
+                    ORDER BY query_duration_ms DESC
+                    LIMIT {limit}
+                "#,
+                    start = start.to_sql_datetime_64().ok_or(Error::msg("Invalid start"))?,
+                    end = end.to_sql_datetime_64().ok_or(Error::msg("Invalid end"))?,
+                    db_table = dbtable,
+                    internal = self.get_internal_filter_clause(),
+                    filter = if !filter.is_empty() {
+                        format!("AND (client_hostname LIKE '{0}' OR log_comment LIKE '{0}' OR os_user LIKE '{0}' OR user LIKE '{0}' OR initial_user LIKE '{0}' OR client_name LIKE '{0}' OR query_id LIKE '{0}' OR query LIKE '{0}' OR current_database LIKE '{0}' OR toString(normalized_query_hash) LIKE '{0}')", &filter)
+                    } else {
+                        "".to_string()
+                    },
+                    host_filter = host_filter,
+                )
+                .as_str(),
+            )
+            .await?;
+        let mut ids = Vec::with_capacity(ids_columns.row_count());
+        for i in 0..ids_columns.row_count() {
+            ids.push(ids_columns.get::<String, _>(i, "initial_query_id")?);
+        }
+
         return self
             .execute(
                 format!(
                     r#"
                     WITH
                         {start} AS start_,
-                        {end}   AS end_,
-                        slow_queries_ids AS (
-                            SELECT DISTINCT initial_query_id
-                            FROM {db_table}
-                            WHERE
-                                event_date BETWEEN toDate(start_) AND toDate(end_) AND
-                                event_time BETWEEN toDateTime(start_) AND toDateTime(end_) AND
-                                is_initial_query AND
-                                /* To make query faster */
-                                query_duration_ms > 1e3
-                                {filter}
-                                {internal}
-                                {host_filter}
-                            ORDER BY query_duration_ms DESC
-                            LIMIT {limit}
-                        )
+                        {end}   AS end_
                     SELECT
                         mapKeys(ProfileEvents)   AS `ProfileEvents.Names`,
                         mapValues(ProfileEvents) AS `ProfileEvents.Values`,
@@ -427,7 +456,7 @@ impl ClickHouse {
                         event_date BETWEEN toDate(start_) AND toDate(end_) AND
                         event_time BETWEEN toDateTime(start_) AND toDateTime(end_) AND
                         type != 'QueryStart' AND
-                        initial_query_id GLOBAL IN slow_queries_ids
+                        initial_query_id IN ('{ids}')
                 "#,
                     start = start.to_sql_datetime_64().ok_or(Error::msg("Invalid start"))?,
                     end = end.to_sql_datetime_64().ok_or(Error::msg("Invalid end"))?,
@@ -437,13 +466,7 @@ impl ClickHouse {
                     } else {
                         "length(thread_ids)"
                     },
-                    internal = self.get_internal_filter_clause(),
-                    filter = if !filter.is_empty() {
-                        format!("AND (client_hostname LIKE '{0}' OR log_comment LIKE '{0}' OR os_user LIKE '{0}' OR user LIKE '{0}' OR initial_user LIKE '{0}' OR client_name LIKE '{0}' OR query_id LIKE '{0}' OR query LIKE '{0}' OR current_database LIKE '{0}' OR toString(normalized_query_hash) LIKE '{0}')", &filter)
-                    } else {
-                        "".to_string()
-                    },
-                    host_filter = host_filter,
+                    ids = ids.join("','"),
                 )
                 .as_str(),
             )
@@ -463,26 +486,55 @@ impl ClickHouse {
         // - distributed_group_by_no_merge=2 is broken for this query with WINDOW function
         let dbtable = self.get_log_table_name("query_log");
         let host_filter = self.get_log_host_filter_clause(selected_host);
+        // NOTE: this is split into two separate top-level queries instead of a
+        // WITH ... GLOBAL IN subquery, since ClickHouse does not apply
+        // additional_table_filters to tables read from within a subquery
+        // (this is not the case for all ClickHouse versions).
+        let ids_columns = self
+            .execute(
+                format!(
+                    r#"
+                    WITH
+                        {start} AS start_,
+                        {end}   AS end_
+                    SELECT DISTINCT initial_query_id
+                    FROM {db_table}
+                    WHERE
+                        event_date BETWEEN toDate(start_) AND toDate(end_) AND
+                        event_time BETWEEN toDateTime(start_) AND toDateTime(end_) AND
+                        is_initial_query
+                        {filter}
+                        {internal}
+                        {host_filter}
+                    ORDER BY event_date DESC, event_time DESC
+                    LIMIT {limit}
+                "#,
+                    start = start.to_sql_datetime_64().ok_or(Error::msg("Invalid start"))?,
+                    end = end.to_sql_datetime_64().ok_or(Error::msg("Invalid end"))?,
+                    db_table = dbtable,
+                    internal = self.get_internal_filter_clause(),
+                    filter = if !filter.is_empty() {
+                        format!("AND (client_hostname LIKE '{0}' OR log_comment LIKE '{0}' OR os_user LIKE '{0}' OR user LIKE '{0}' OR initial_user LIKE '{0}' OR client_name LIKE '{0}' OR query_id LIKE '{0}' OR query LIKE '{0}' OR current_database LIKE '{0}' OR toString(normalized_query_hash) LIKE '{0}')", &filter)
+                    } else {
+                        "".to_string()
+                    },
+                    host_filter = host_filter,
+                )
+                .as_str(),
+            )
+            .await?;
+        let mut ids = Vec::with_capacity(ids_columns.row_count());
+        for i in 0..ids_columns.row_count() {
+            ids.push(ids_columns.get::<String, _>(i, "initial_query_id")?);
+        }
+
         return self
             .execute(
                 format!(
                     r#"
                     WITH
                         {start} AS start_,
-                        {end}   AS end_,
-                        last_queries_ids AS (
-                            SELECT DISTINCT initial_query_id
-                            FROM {db_table}
-                            WHERE
-                                event_date BETWEEN toDate(start_) AND toDate(end_) AND
-                                event_time BETWEEN toDateTime(start_) AND toDateTime(end_) AND
-                                is_initial_query
-                                {filter}
-                                {internal}
-                                {host_filter}
-                            ORDER BY event_date DESC, event_time DESC
-                            LIMIT {limit}
-                        )
+                        {end}   AS end_
                     SELECT
                         mapKeys(ProfileEvents)   AS `ProfileEvents.Names`,
                         mapValues(ProfileEvents) AS `ProfileEvents.Values`,
@@ -511,7 +563,7 @@ impl ClickHouse {
                         event_date BETWEEN toDate(start_) AND toDate(end_) AND
                         event_time BETWEEN toDateTime(start_) AND toDateTime(end_) AND
                         type != 'QueryStart' AND
-                        initial_query_id GLOBAL IN last_queries_ids
+                        initial_query_id IN ('{ids}')
                 "#,
                     start = start.to_sql_datetime_64().ok_or(Error::msg("Invalid start"))?,
                     end = end.to_sql_datetime_64().ok_or(Error::msg("Invalid end"))?,
@@ -521,13 +573,7 @@ impl ClickHouse {
                     } else {
                         "length(thread_ids)"
                     },
-                    internal = self.get_internal_filter_clause(),
-                    filter = if !filter.is_empty() {
-                        format!("AND (client_hostname LIKE '{0}' OR log_comment LIKE '{0}' OR os_user LIKE '{0}' OR user LIKE '{0}' OR initial_user LIKE '{0}' OR client_name LIKE '{0}' OR query_id LIKE '{0}' OR query LIKE '{0}' OR current_database LIKE '{0}' OR toString(normalized_query_hash) LIKE '{0}')", &filter)
-                    } else {
-                        "".to_string()
-                    },
-                    host_filter = host_filter,
+                    ids = ids.join("','"),
                 )
                 .as_str(),
             )

--- a/src/interpreter/clickhouse.rs
+++ b/src/interpreter/clickhouse.rs
@@ -377,49 +377,80 @@ impl ClickHouse {
     ) -> Result<Columns> {
         let dbtable = self.get_log_table_name("query_log");
         let host_filter = self.get_log_host_filter_clause(selected_host);
-        // NOTE: this is split into two separate top-level queries instead of a
-        // WITH ... GLOBAL IN subquery, since ClickHouse does not apply
-        // additional_table_filters to tables read from within a subquery
-        // (this is not the case for all ClickHouse versions).
-        let ids_columns = self
-            .execute(
-                format!(
-                    r#"
-                    WITH
-                        {start} AS start_,
-                        {end}   AS end_
-                    SELECT DISTINCT initial_query_id
-                    FROM {db_table}
-                    WHERE
-                        event_date BETWEEN toDate(start_) AND toDate(end_) AND
-                        event_time BETWEEN toDateTime(start_) AND toDateTime(end_) AND
-                        is_initial_query AND
-                        /* To make query faster */
-                        query_duration_ms > 1e3
-                        {filter}
-                        {internal}
-                        {host_filter}
-                    ORDER BY query_duration_ms DESC
-                    LIMIT {limit}
-                "#,
-                    start = start.to_sql_datetime_64().ok_or(Error::msg("Invalid start"))?,
-                    end = end.to_sql_datetime_64().ok_or(Error::msg("Invalid end"))?,
-                    db_table = dbtable,
-                    internal = self.get_internal_filter_clause(),
-                    filter = if !filter.is_empty() {
-                        format!("AND (client_hostname LIKE '{0}' OR log_comment LIKE '{0}' OR os_user LIKE '{0}' OR user LIKE '{0}' OR initial_user LIKE '{0}' OR client_name LIKE '{0}' OR query_id LIKE '{0}' OR query LIKE '{0}' OR current_database LIKE '{0}' OR toString(normalized_query_hash) LIKE '{0}')", &filter)
-                    } else {
-                        "".to_string()
-                    },
-                    host_filter = host_filter,
+        let filter_clause = if !filter.is_empty() {
+            format!("AND (client_hostname LIKE '{0}' OR log_comment LIKE '{0}' OR os_user LIKE '{0}' OR user LIKE '{0}' OR initial_user LIKE '{0}' OR client_name LIKE '{0}' OR query_id LIKE '{0}' OR query LIKE '{0}' OR current_database LIKE '{0}' OR toString(normalized_query_hash) LIKE '{0}')", &filter)
+        } else {
+            "".to_string()
+        };
+        let peak_threads_usage = if self.quirks.has(ClickHouseAvailableQuirks::QueryLogPeakThreadsUsage) {
+            "peak_threads_usage"
+        } else {
+            "length(thread_ids)"
+        };
+        let internal = self.get_internal_filter_clause();
+
+        let (id_condition, ids_cte) = if self.quirks.has(ClickHouseAvailableQuirks::AdditionalTableFiltersInSubquery) {
+            let ids_cte = format!(
+                r#",
+                        slow_queries_ids AS (
+                            SELECT DISTINCT initial_query_id
+                            FROM {db_table}
+                            WHERE
+                                event_date BETWEEN toDate(start_) AND toDate(end_) AND
+                                event_time BETWEEN toDateTime(start_) AND toDateTime(end_) AND
+                                is_initial_query AND
+                                /* To make query faster */
+                                query_duration_ms > 1e3
+                                {filter}
+                                {internal}
+                                {host_filter}
+                            ORDER BY query_duration_ms DESC
+                            LIMIT {limit}
+                        )"#,
+                db_table = dbtable,
+                filter = filter_clause,
+                internal = internal,
+                host_filter = host_filter,
+            );
+            ("initial_query_id GLOBAL IN slow_queries_ids".to_string(), ids_cte)
+        } else {
+            let ids_columns = self
+                .execute(
+                    format!(
+                        r#"
+                        WITH
+                            {start} AS start_,
+                            {end}   AS end_
+                        SELECT DISTINCT initial_query_id
+                        FROM {db_table}
+                        WHERE
+                            event_date BETWEEN toDate(start_) AND toDate(end_) AND
+                            event_time BETWEEN toDateTime(start_) AND toDateTime(end_) AND
+                            is_initial_query AND
+                            /* To make query faster */
+                            query_duration_ms > 1e3
+                            {filter}
+                            {internal}
+                            {host_filter}
+                        ORDER BY query_duration_ms DESC
+                        LIMIT {limit}
+                    "#,
+                        start = start.to_sql_datetime_64().ok_or(Error::msg("Invalid start"))?,
+                        end = end.to_sql_datetime_64().ok_or(Error::msg("Invalid end"))?,
+                        db_table = dbtable,
+                        internal = internal,
+                        filter = filter_clause,
+                        host_filter = host_filter,
+                    )
+                    .as_str(),
                 )
-                .as_str(),
-            )
-            .await?;
-        let mut ids = Vec::with_capacity(ids_columns.row_count());
-        for i in 0..ids_columns.row_count() {
-            ids.push(ids_columns.get::<String, _>(i, "initial_query_id")?);
-        }
+                .await?;
+            let mut ids = Vec::with_capacity(ids_columns.row_count());
+            for i in 0..ids_columns.row_count() {
+                ids.push(ids_columns.get::<String, _>(i, "initial_query_id")?);
+            }
+            (format!("initial_query_id IN ('{}')", ids.join("','")), "".to_string())
+        };
 
         return self
             .execute(
@@ -427,7 +458,7 @@ impl ClickHouse {
                     r#"
                     WITH
                         {start} AS start_,
-                        {end}   AS end_
+                        {end}   AS end_{ids_cte}
                     SELECT
                         mapKeys(ProfileEvents)   AS `ProfileEvents.Names`,
                         mapValues(ProfileEvents) AS `ProfileEvents.Values`,
@@ -456,17 +487,14 @@ impl ClickHouse {
                         event_date BETWEEN toDate(start_) AND toDate(end_) AND
                         event_time BETWEEN toDateTime(start_) AND toDateTime(end_) AND
                         type != 'QueryStart' AND
-                        initial_query_id IN ('{ids}')
+                        {id_condition}
                 "#,
                     start = start.to_sql_datetime_64().ok_or(Error::msg("Invalid start"))?,
                     end = end.to_sql_datetime_64().ok_or(Error::msg("Invalid end"))?,
                     db_table = dbtable,
-                    peak_threads_usage = if self.quirks.has(ClickHouseAvailableQuirks::QueryLogPeakThreadsUsage) {
-                        "peak_threads_usage"
-                    } else {
-                        "length(thread_ids)"
-                    },
-                    ids = ids.join("','"),
+                    peak_threads_usage = peak_threads_usage,
+                    ids_cte = ids_cte,
+                    id_condition = id_condition,
                 )
                 .as_str(),
             )
@@ -486,47 +514,76 @@ impl ClickHouse {
         // - distributed_group_by_no_merge=2 is broken for this query with WINDOW function
         let dbtable = self.get_log_table_name("query_log");
         let host_filter = self.get_log_host_filter_clause(selected_host);
-        // NOTE: this is split into two separate top-level queries instead of a
-        // WITH ... GLOBAL IN subquery, since ClickHouse does not apply
-        // additional_table_filters to tables read from within a subquery
-        // (this is not the case for all ClickHouse versions).
-        let ids_columns = self
-            .execute(
-                format!(
-                    r#"
-                    WITH
-                        {start} AS start_,
-                        {end}   AS end_
-                    SELECT DISTINCT initial_query_id
-                    FROM {db_table}
-                    WHERE
-                        event_date BETWEEN toDate(start_) AND toDate(end_) AND
-                        event_time BETWEEN toDateTime(start_) AND toDateTime(end_) AND
-                        is_initial_query
-                        {filter}
-                        {internal}
-                        {host_filter}
-                    ORDER BY event_date DESC, event_time DESC
-                    LIMIT {limit}
-                "#,
-                    start = start.to_sql_datetime_64().ok_or(Error::msg("Invalid start"))?,
-                    end = end.to_sql_datetime_64().ok_or(Error::msg("Invalid end"))?,
-                    db_table = dbtable,
-                    internal = self.get_internal_filter_clause(),
-                    filter = if !filter.is_empty() {
-                        format!("AND (client_hostname LIKE '{0}' OR log_comment LIKE '{0}' OR os_user LIKE '{0}' OR user LIKE '{0}' OR initial_user LIKE '{0}' OR client_name LIKE '{0}' OR query_id LIKE '{0}' OR query LIKE '{0}' OR current_database LIKE '{0}' OR toString(normalized_query_hash) LIKE '{0}')", &filter)
-                    } else {
-                        "".to_string()
-                    },
-                    host_filter = host_filter,
+        let filter_clause = if !filter.is_empty() {
+            format!("AND (client_hostname LIKE '{0}' OR log_comment LIKE '{0}' OR os_user LIKE '{0}' OR user LIKE '{0}' OR initial_user LIKE '{0}' OR client_name LIKE '{0}' OR query_id LIKE '{0}' OR query LIKE '{0}' OR current_database LIKE '{0}' OR toString(normalized_query_hash) LIKE '{0}')", &filter)
+        } else {
+            "".to_string()
+        };
+        let peak_threads_usage = if self.quirks.has(ClickHouseAvailableQuirks::QueryLogPeakThreadsUsage) {
+            "peak_threads_usage"
+        } else {
+            "length(thread_ids)"
+        };
+        let internal = self.get_internal_filter_clause();
+
+        let (id_condition, ids_cte) = if self.quirks.has(ClickHouseAvailableQuirks::AdditionalTableFiltersInSubquery) {
+            let ids_cte = format!(
+                r#",
+                        last_queries_ids AS (
+                            SELECT DISTINCT initial_query_id
+                            FROM {db_table}
+                            WHERE
+                                event_date BETWEEN toDate(start_) AND toDate(end_) AND
+                                event_time BETWEEN toDateTime(start_) AND toDateTime(end_) AND
+                                is_initial_query
+                                {filter}
+                                {internal}
+                                {host_filter}
+                            ORDER BY event_date DESC, event_time DESC
+                            LIMIT {limit}
+                        )"#,
+                db_table = dbtable,
+                filter = filter_clause,
+                internal = internal,
+                host_filter = host_filter,
+            );
+            ("initial_query_id GLOBAL IN last_queries_ids".to_string(), ids_cte)
+        } else {
+            let ids_columns = self
+                .execute(
+                    format!(
+                        r#"
+                        WITH
+                            {start} AS start_,
+                            {end}   AS end_
+                        SELECT DISTINCT initial_query_id
+                        FROM {db_table}
+                        WHERE
+                            event_date BETWEEN toDate(start_) AND toDate(end_) AND
+                            event_time BETWEEN toDateTime(start_) AND toDateTime(end_) AND
+                            is_initial_query
+                            {filter}
+                            {internal}
+                            {host_filter}
+                        ORDER BY event_date DESC, event_time DESC
+                        LIMIT {limit}
+                    "#,
+                        start = start.to_sql_datetime_64().ok_or(Error::msg("Invalid start"))?,
+                        end = end.to_sql_datetime_64().ok_or(Error::msg("Invalid end"))?,
+                        db_table = dbtable,
+                        internal = internal,
+                        filter = filter_clause,
+                        host_filter = host_filter,
+                    )
+                    .as_str(),
                 )
-                .as_str(),
-            )
-            .await?;
-        let mut ids = Vec::with_capacity(ids_columns.row_count());
-        for i in 0..ids_columns.row_count() {
-            ids.push(ids_columns.get::<String, _>(i, "initial_query_id")?);
-        }
+                .await?;
+            let mut ids = Vec::with_capacity(ids_columns.row_count());
+            for i in 0..ids_columns.row_count() {
+                ids.push(ids_columns.get::<String, _>(i, "initial_query_id")?);
+            }
+            (format!("initial_query_id IN ('{}')", ids.join("','")), "".to_string())
+        };
 
         return self
             .execute(
@@ -534,7 +591,7 @@ impl ClickHouse {
                     r#"
                     WITH
                         {start} AS start_,
-                        {end}   AS end_
+                        {end}   AS end_{ids_cte}
                     SELECT
                         mapKeys(ProfileEvents)   AS `ProfileEvents.Names`,
                         mapValues(ProfileEvents) AS `ProfileEvents.Values`,
@@ -563,17 +620,14 @@ impl ClickHouse {
                         event_date BETWEEN toDate(start_) AND toDate(end_) AND
                         event_time BETWEEN toDateTime(start_) AND toDateTime(end_) AND
                         type != 'QueryStart' AND
-                        initial_query_id IN ('{ids}')
+                        {id_condition}
                 "#,
                     start = start.to_sql_datetime_64().ok_or(Error::msg("Invalid start"))?,
                     end = end.to_sql_datetime_64().ok_or(Error::msg("Invalid end"))?,
                     db_table = dbtable,
-                    peak_threads_usage = if self.quirks.has(ClickHouseAvailableQuirks::QueryLogPeakThreadsUsage) {
-                        "peak_threads_usage"
-                    } else {
-                        "length(thread_ids)"
-                    },
-                    ids = ids.join("','"),
+                    peak_threads_usage = peak_threads_usage,
+                    ids_cte = ids_cte,
+                    id_condition = id_condition,
                 )
                 .as_str(),
             )

--- a/src/interpreter/clickhouse_quirks.rs
+++ b/src/interpreter/clickhouse_quirks.rs
@@ -10,10 +10,11 @@ pub enum ClickHouseAvailableQuirks {
     QueryLogPeakThreadsUsage = 16,
     ProcessesPeakThreadsUsage = 32,
     SystemBackgroundSchedulePool = 64,
+    AdditionalTableFiltersInSubquery = 128,
 }
 
 // List of quirks (that requires workaround) or new features.
-const QUIRKS: [(&str, ClickHouseAvailableQuirks); 8] = [
+const QUIRKS: [(&str, ClickHouseAvailableQuirks); 9] = [
     // https://github.com/ClickHouse/ClickHouse/pull/46047
     //
     // NOTE: I use here 22.13 because I have such version in production, which is more or less the
@@ -45,6 +46,16 @@ const QUIRKS: [(&str, ClickHouseAvailableQuirks); 8] = [
     (
         ">=25.12",
         ClickHouseAvailableQuirks::SystemBackgroundSchedulePool,
+    ),
+    // ClickHouse before 26.3 did not applied additional_table_filters to tables read from within a
+    // subquery, so on such versions the initial_query_id selection is run as its own top-level
+    // query first, and its result is spliced into the main query as a literal IN (...) list instead
+    // of a WITH ... GLOBAL IN subquery.
+    //
+    // Fixed in: https://github.com/ClickHouse/ClickHouse/pull/99436
+    (
+        ">=26.3",
+        ClickHouseAvailableQuirks::AdditionalTableFiltersInSubquery,
     ),
 ];
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -6,7 +6,7 @@ use chdig::interpreter::clickhouse::{
 };
 use chdig::interpreter::options::ClickHouseOptions;
 use chdig::interpreter::perfetto::PerfettoTraceBuilder;
-use chdig::interpreter::{ClickHouse, TextLogArguments};
+use chdig::interpreter::{ClickHouse, ClickHouseQuirks, TextLogArguments};
 use chrono::{DateTime, Local, TimeDelta};
 use perfetto_protos::trace::Trace;
 use perfetto_protos::trace_packet::trace_packet::Data;
@@ -225,6 +225,51 @@ async fn test_slow_query_log() {
     assert_eq!(block.row_count(), 1);
     assert_eq!(block.get::<String, _>(0, "query_id").unwrap(), "it-slow-1");
     assert_eq!(block.get::<f64, _>(0, "elapsed").unwrap(), 5.0);
+}
+
+// get_last_query_log/get_slow_query_log resolve initial_query_id differently depending on
+// whether the server has https://github.com/ClickHouse/ClickHouse/pull/99436 (26.3+): older
+// servers get a two-query workaround (initial_query_id IN a literal list), 26.3+ a single
+// WITH ... GLOBAL IN subquery. Force both branches against the same real server and check both
+// produce the same result, regardless of which one the server under test actually is.
+async fn test_query_log_additional_table_filters_quirk_variations() {
+    let Some(server) = common::server() else {
+        return;
+    };
+    server.insert_query_log("it-quirk-1", "it_user_quirk", 5000, "SELECT 1 FROM it_quirk");
+    server.insert_query_log("it-quirk-2", "it_user_quirk", 100, "SELECT 2 FROM it_quirk");
+
+    let mut chdig = server.chdig().await;
+    for version in ["26.2.1.1-stable", "26.3.1.1-stable"] {
+        chdig.quirks = ClickHouseQuirks::new(version.to_string());
+
+        let (start, end) = window();
+        let last = chdig
+            .get_last_query_log(&"it-quirk-%".to_string(), start, end, 100, None)
+            .await
+            .unwrap();
+        let mut last_ids: Vec<String> = (0..last.row_count())
+            .map(|i| last.get::<String, _>(i, "query_id").unwrap())
+            .collect();
+        last_ids.sort();
+        assert_eq!(
+            last_ids,
+            vec!["it-quirk-1".to_string(), "it-quirk-2".to_string()],
+            "get_last_query_log mismatch for quirks version {version}"
+        );
+
+        let (start, end) = window();
+        let slow = chdig
+            .get_slow_query_log(&"it-quirk-%".to_string(), start, end, 100, None)
+            .await
+            .unwrap();
+        assert_eq!(
+            slow.row_count(),
+            1,
+            "get_slow_query_log mismatch for quirks version {version}"
+        );
+        assert_eq!(slow.get::<String, _>(0, "query_id").unwrap(), "it-quirk-1");
+    }
 }
 
 async fn test_query_log_out_of_window() {
@@ -1366,6 +1411,7 @@ common::integration_tests!(
     test_last_query_log_normalized_query,
     test_query_patterns,
     test_slow_query_log,
+    test_query_log_additional_table_filters_quirk_variations,
     test_query_log_out_of_window,
     test_processlist_and_kill_query,
     test_execute_query,


### PR DESCRIPTION
Split query that uses GLOBAL IN with 2 queries if it is not supported