### PR TITLE
Compress content shared to pastila with gzip (on by default)

### DIFF
--- a/src/interpreter/flamegraph.rs
+++ b/src/interpreter/flamegraph.rs
@@ -90,16 +90,11 @@ pub fn show_diff(title: &'static str, before: String, after: String) -> AppResul
     run_flamelens(App::with_flamegraph(title, after_fg))
 }
 
-pub async fn share(
-    data: String,
-    pastila_clickhouse_host: &str,
-    pastila_url: &str,
-) -> Result<String> {
+pub async fn share(data: String, pastila: &pastila::PastilaConfig) -> Result<String> {
     if data.trim().is_empty() {
         return Err(Error::msg("Flamegraph is empty"));
     }
 
-    let pastila_url =
-        pastila::upload_encrypted(&data, pastila_clickhouse_host, pastila_url).await?;
+    let pastila_url = pastila::upload_encrypted(&data, pastila, "").await?;
     return Ok(format!("https://whodidit.you/#profileURL={}", pastila_url));
 }

--- a/src/interpreter/options.rs
+++ b/src/interpreter/options.rs
@@ -457,6 +457,11 @@ pub struct ServiceOptions {
     #[arg(long, default_value = "https://pastila.nl/")]
     /// pastila.nl URL (only to show direct link to pastila in logs)
     pub pastila_url: String,
+    #[arg(long, action = ArgAction::SetTrue, default_value_t = true, overrides_with = "no_pastila_compression")]
+    /// Compress (gzip) content before encrypting when sharing to pastila (adds .gz to the URL)
+    pub pastila_compression: bool,
+    #[arg(long, action = ArgAction::SetTrue, overrides_with = "pastila_compression")]
+    no_pastila_compression: bool,
     /// Path to chdig config file (YAML)
     #[arg(long, env = "CHDIG_CONFIG")]
     pub chdig_config: Option<String>,
@@ -564,6 +569,7 @@ struct ChDigServiceConfig {
     log: Option<String>,
     pastila_clickhouse_host: Option<String>,
     pastila_url: Option<String>,
+    pastila_compression: Option<bool>,
 }
 
 fn read_yaml_clickhouse_client_config(path: &str) -> Result<ClickHouseClientConfig> {
@@ -808,6 +814,9 @@ fn apply_chdig_config(options: &mut ChDigOptions, config: &ChDigConfig) {
     }
     if let Some(ref url) = svc.pastila_url {
         options.service.pastila_url = url.clone();
+    }
+    if let Some(compression) = svc.pastila_compression {
+        options.service.pastila_compression = compression;
     }
 
     // perfetto section
@@ -1169,6 +1178,10 @@ fn adjust_defaults(options: &mut ChDigOptions) -> Result<()> {
     // FIXME: overrides_with works before default_value_if, hence --no-group-by never works
     if options.view.no_group_by {
         options.view.group_by = false;
+    }
+    // overrides_with resets the paired flag to its default (true), so collapse manually
+    if options.service.no_pastila_compression {
+        options.service.pastila_compression = false;
     }
 
     return Ok(());

--- a/src/interpreter/worker.rs
+++ b/src/interpreter/worker.rs
@@ -1285,7 +1285,17 @@ async fn process_event(context: ContextArc, event: Event, need_clear: &mut bool)
                 .map_err(|_| anyhow!("Cannot send message to UI"))?;
         }
         Event::ShareLogs(content) => {
-            let url = pastila::upload_encrypted(&content, &pastila, "").await?;
+            let url = pastila::upload_encrypted(&content, &pastila, "").await;
+            if url.is_err() {
+                // Pop the "Uploading logs..." dialog: the caller only stacks the error
+                // dialog on top, and this pop is queued before it.
+                cb_sink
+                    .send(Box::new(|siv: &mut cursive::Cursive| {
+                        siv.pop_layer();
+                    }))
+                    .unwrap_or_default();
+            }
+            let url = url?;
 
             let url_clone = url.clone();
             cb_sink

--- a/src/interpreter/worker.rs
+++ b/src/interpreter/worker.rs
@@ -338,8 +338,7 @@ async fn render_or_share_flamegraph(
     cb_sink: cursive::CbSink,
     title: &'static str,
     data: String,
-    pastila_clickhouse_host: String,
-    pastila_url: String,
+    pastila: pastila::PastilaConfig,
 ) -> Result<()> {
     if tui {
         cb_sink
@@ -353,7 +352,7 @@ async fn render_or_share_flamegraph(
             }))
             .map_err(|_| anyhow!("Cannot send message to UI"))?;
     } else {
-        let url = flamegraph::share(data, &pastila_clickhouse_host, &pastila_url).await?;
+        let url = flamegraph::share(data, &pastila).await?;
 
         let url_clone = url.clone();
         cb_sink
@@ -792,14 +791,15 @@ fn serve_perfetto_trace(
 async fn process_event(context: ContextArc, event: Event, need_clear: &mut bool) -> Result<()> {
     let cb_sink = context.lock().unwrap().cb_sink.clone();
     let clickhouse = context.lock().unwrap().clickhouse.clone();
-    let pastila_clickhouse_host = context
-        .lock()
-        .unwrap()
-        .options
-        .service
-        .pastila_clickhouse_host
-        .clone();
-    let pastila_url = context.lock().unwrap().options.service.pastila_url.clone();
+    let pastila = {
+        let context = context.lock().unwrap();
+        let service = &context.options.service;
+        pastila::PastilaConfig {
+            clickhouse_host: service.pastila_clickhouse_host.clone(),
+            url: service.pastila_url.clone(),
+            compress: service.pastila_compression,
+        }
+    };
     let selected_host = context.lock().unwrap().selected_host.clone();
 
     match event {
@@ -902,8 +902,7 @@ async fn process_event(context: ContextArc, event: Event, need_clear: &mut bool)
                 cb_sink,
                 "Server",
                 flamegraph::block_to_folded(&flamegraph_block),
-                pastila_clickhouse_host,
-                pastila_url,
+                pastila.clone(),
             )
             .await?;
             *need_clear = true;
@@ -917,8 +916,7 @@ async fn process_event(context: ContextArc, event: Event, need_clear: &mut bool)
                 cb_sink,
                 "jemalloc",
                 flamegraph::block_to_folded(&flamegraph_block),
-                pastila_clickhouse_host,
-                pastila_url,
+                pastila.clone(),
             )
             .await?;
             *need_clear = true;
@@ -938,8 +936,7 @@ async fn process_event(context: ContextArc, event: Event, need_clear: &mut bool)
                 cb_sink,
                 "Query",
                 flamegraph::block_to_folded(&flamegraph_block),
-                pastila_clickhouse_host,
-                pastila_url,
+                pastila.clone(),
             )
             .await?;
             *need_clear = true;
@@ -984,8 +981,7 @@ async fn process_event(context: ContextArc, event: Event, need_clear: &mut bool)
                 cb_sink,
                 "Query (live)",
                 flamegraph::block_to_folded(&flamegraph_block),
-                pastila_clickhouse_host,
-                pastila_url,
+                pastila.clone(),
             )
             .await?;
             *need_clear = true;
@@ -1089,7 +1085,7 @@ async fn process_event(context: ContextArc, event: Event, need_clear: &mut bool)
                 .join("\n");
 
             // Upload graph to pastila and open in browser
-            match share_graph(pipeline, &pastila_clickhouse_host, &pastila_url).await {
+            match share_graph(pipeline, &pastila).await {
                 Ok(_) => {}
                 Err(err) => {
                     let error_msg = err.to_string();
@@ -1289,8 +1285,7 @@ async fn process_event(context: ContextArc, event: Event, need_clear: &mut bool)
                 .map_err(|_| anyhow!("Cannot send message to UI"))?;
         }
         Event::ShareLogs(content) => {
-            let url =
-                pastila::upload_encrypted(&content, &pastila_clickhouse_host, &pastila_url).await?;
+            let url = pastila::upload_encrypted(&content, &pastila, "").await?;
 
             let url_clone = url.clone();
             cb_sink

--- a/src/pastila.rs
+++ b/src/pastila.rs
@@ -5,10 +5,19 @@ use aes_gcm::{
 use anyhow::{Result, anyhow};
 use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
 use clickhouse_rs::{Block, Options, Pool};
+use flate2::{Compression, write::GzEncoder};
 use rand::RngCore;
 use regex::Regex;
+use std::io::Write;
 use std::str::FromStr;
 use url::Url;
+
+#[derive(Clone)]
+pub struct PastilaConfig {
+    pub clickhouse_host: String,
+    pub url: String,
+    pub compress: bool,
+}
 
 /// ClickHouse's SipHash-2-4 implementation (128-bit version)
 /// See https://github.com/ClickHouse/ClickHouse/pull/46065 for details
@@ -130,12 +139,12 @@ pub fn get_fingerprint(text: &str) -> String {
     full_hash[..8].to_string()
 }
 
-fn encrypt_content(content: &str, key: &[u8; 16]) -> Result<String> {
+fn encrypt_content(content: &[u8], key: &[u8; 16]) -> Result<String> {
     let cipher = Aes128Gcm::new(GenericArray::from_slice(key));
     let nonce = Nonce::from_slice(&key[..12]);
 
     let ciphertext = cipher
-        .encrypt(nonce, content.as_bytes())
+        .encrypt(nonce, content)
         .map_err(|e| anyhow!("Encryption failed: {}", e))?;
 
     Ok(BASE64.encode(&ciphertext))
@@ -172,40 +181,64 @@ async fn get_pastila_client(pastila_clickhouse_host: &str) -> Result<clickhouse_
     Ok(client)
 }
 
+/// Uploads the content compressed (unless disabled) and encrypted.
+///
+/// `extension` is the pastila rendering type (e.g. ".html"), it is reflected in the
+/// URL and does not affect the stored content; ".gz" is appended after it since
+/// decompression happens before rendering.
 pub async fn upload_encrypted(
     content: &str,
-    pastila_clickhouse_host: &str,
-    pastila_url: &str,
+    config: &PastilaConfig,
+    extension: &str,
 ) -> Result<String> {
     let mut key = [0u8; 16];
     rand::thread_rng().fill_bytes(&mut key);
-    let encrypted = encrypt_content(content, &key)?;
+
+    let compressed = if config.compress {
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(content.as_bytes())?;
+        Some(encoder.finish()?)
+    } else {
+        None
+    };
+    let payload = compressed.as_deref().unwrap_or(content.as_bytes());
+    let encrypted = encrypt_content(payload, &key)?;
+
+    let sizes = if let Some(ref compressed) = compressed {
+        format!(
+            "{} bytes uncompressed, {} compressed, {} encrypted",
+            content.len(),
+            compressed.len(),
+            encrypted.len()
+        )
+    } else {
+        format!("{} bytes, {} encrypted", content.len(), encrypted.len())
+    };
 
     let fingerprint_hex = get_fingerprint(&encrypted);
     let hash_hex = calculate_hash(&encrypted);
 
-    log::info!(
-        "Uploading {} bytes ({} bytes encrypted) to {}",
-        content.len(),
-        encrypted.len(),
-        pastila_clickhouse_host
-    );
+    log::info!("Uploading {} to {}", sizes, config.clickhouse_host);
 
     {
-        let mut client = get_pastila_client(pastila_clickhouse_host).await?;
+        let mut client = get_pastila_client(&config.clickhouse_host).await?;
         let block = Block::new()
             .column("fingerprint_hex", vec![fingerprint_hex.as_str()])
             .column("hash_hex", vec![hash_hex.as_str()])
             .column("content", vec![encrypted.as_str()])
             .column("is_encrypted", vec![1_u8]);
-        client.insert("paste.data", block).await?;
+        client
+            .insert("paste.data", block)
+            .await
+            .map_err(|e| anyhow!("Upload to pastila failed ({}):\n\n{}", sizes, e))?;
     }
 
-    let pastila_url = pastila_url.trim_end_matches('/');
+    let pastila_url = config.url.trim_end_matches('/');
+    let gz = if config.compress { ".gz" } else { "" };
     let key_fragment = format!("#{}", BASE64.encode(key));
     let pastila_page_url = format!(
-        "{}/?{}/{}{}GCM",
-        pastila_url, fingerprint_hex, hash_hex, key_fragment
+        "{}/?{}/{}{}{}{}GCM",
+        pastila_url, fingerprint_hex, hash_hex, extension, gz, key_fragment
     );
 
     Ok(pastila_page_url)

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -297,11 +297,7 @@ pub fn open_url_command(url: &str) -> Command {
     cmd
 }
 
-pub async fn share_graph(
-    graph: String,
-    pastila_clickhouse_host: &str,
-    pastila_url: &str,
-) -> Result<()> {
+pub async fn share_graph(graph: String, pastila: &crate::pastila::PastilaConfig) -> Result<()> {
     if graph.is_empty() {
         return Err(Error::msg("Graph is empty"));
     }
@@ -339,11 +335,7 @@ pub async fn share_graph(
     );
 
     // Upload HTML to pastila with end-to-end encryption
-    let mut url = pastila::upload_encrypted(&html, pastila_clickhouse_host, pastila_url).await?;
-
-    if let Some(anchor_pos) = url.find('#') {
-        url.insert_str(anchor_pos, ".html");
-    }
+    let url = pastila::upload_encrypted(&html, pastila, ".html").await?;
 
     // Open the URL in the browser
     open_url_command(&url).status()?;

--- a/src/view/settings_view.rs
+++ b/src/view/settings_view.rs
@@ -273,7 +273,7 @@ struct SearchTarget {
 }
 
 struct SearchableLayout {
-    layout: LinearLayout,
+    columns: Vec<LinearLayout>,
     sections: Vec<String>,
     targets: Vec<SearchTarget>,
 }
@@ -281,10 +281,30 @@ struct SearchableLayout {
 impl SearchableLayout {
     fn new() -> Self {
         Self {
-            layout: LinearLayout::vertical(),
+            columns: vec![LinearLayout::vertical()],
             sections: Vec::new(),
             targets: Vec::new(),
         }
+    }
+
+    /// Subsequent sections go into a new column (columns are laid out side by side)
+    fn column(&mut self) {
+        self.columns.push(LinearLayout::vertical());
+    }
+
+    fn layout(&mut self) -> &mut LinearLayout {
+        self.columns.last_mut().unwrap()
+    }
+
+    fn into_layout(self) -> (LinearLayout, Vec<String>, Vec<SearchTarget>) {
+        let mut layout = LinearLayout::horizontal();
+        for (i, column) in self.columns.into_iter().enumerate() {
+            if i > 0 {
+                layout.add_child(DummyView.fixed_width(3));
+            }
+            layout.add_child(column);
+        }
+        (layout, self.sections, self.targets)
     }
 
     fn target(&mut self, label: &str, focus_name: &str) {
@@ -297,43 +317,41 @@ impl SearchableLayout {
 
     fn section(&mut self, title: &str) {
         self.sections.push(title.trim_end_matches(':').to_string());
-        self.layout
-            .add_child(TextView::new(StyledString::styled(title, Effect::Bold)));
+        let title = TextView::new(StyledString::styled(title, Effect::Bold));
+        self.layout().add_child(title);
     }
 
     fn separator(&mut self) {
-        self.layout.add_child(DummyView);
+        self.layout().add_child(DummyView);
     }
 
     fn text(&mut self, label: &str, value: impl std::fmt::Display) {
         // Named so that the search can focus (and thus scroll to) read-only rows
         let name = format!("settings_row_{}", self.targets.len());
-        self.layout
-            .add_child(TextView::new(format!("  {}: {}", label, value)).with_name(&name));
+        let row = TextView::new(format!("  {}: {}", label, value)).with_name(&name);
+        self.layout().add_child(row);
         self.target(label, &name);
     }
 
     fn checkbox(&mut self, label: &str, name: &str, checked: bool) {
-        self.layout.add_child(
-            LinearLayout::horizontal()
-                .child(DummyView.fixed_width(2))
-                .child(Checkbox::new().with_checked(checked).with_name(name))
-                .child(TextView::new(format!(" {}", label))),
-        );
+        let row = LinearLayout::horizontal()
+            .child(DummyView.fixed_width(2))
+            .child(Checkbox::new().with_checked(checked).with_name(name))
+            .child(TextView::new(format!(" {}", label)));
+        self.layout().add_child(row);
         self.target(label, name);
     }
 
     fn edit(&mut self, label: &str, name: &str, value: &str, width: usize) {
-        self.layout.add_child(
-            LinearLayout::horizontal()
-                .child(TextView::new(format!("  {}: ", label)))
-                .child(
-                    EditView::new()
-                        .content(value)
-                        .with_name(name)
-                        .fixed_width(width),
-                ),
-        );
+        let row = LinearLayout::horizontal()
+            .child(TextView::new(format!("  {}: ", label)))
+            .child(
+                EditView::new()
+                    .content(value)
+                    .with_name(name)
+                    .fixed_width(width),
+            );
+        self.layout().add_child(row);
         self.target(label, name);
     }
 }
@@ -477,17 +495,6 @@ pub fn show_settings_dialog(siv: &mut Cursive) {
     layout.edit("end", "set_end", &opts.view.end.to_editable_string(), 22);
     layout.separator();
 
-    layout.section("Queries columns:");
-    for &col in AVAILABLE_QUERY_COLUMNS {
-        let Some(label) = query_column_id(col) else {
-            continue;
-        };
-        let visible = opts.view.query_columns.iter().any(|h| h == label);
-        let name = format!("set_qcol_{}", label);
-        layout.checkbox(label, &name, visible);
-    }
-    layout.separator();
-
     layout.section("Service:");
     layout.text("log", opts.service.log.as_deref().unwrap_or("(none)"));
     layout.text(
@@ -498,13 +505,13 @@ pub fn show_settings_dialog(siv: &mut Cursive) {
         "pastila_clickhouse_host",
         "set_pastila_clickhouse_host",
         &opts.service.pastila_clickhouse_host,
-        50,
+        35,
     );
     layout.edit(
         "pastila_url",
         "set_pastila_url",
         &opts.service.pastila_url,
-        50,
+        35,
     );
     layout.checkbox(
         "pastila_compression",
@@ -513,6 +520,25 @@ pub fn show_settings_dialog(siv: &mut Cursive) {
     );
     layout.separator();
 
+    layout.section("Runtime:");
+    layout.text("selected_host", selected_host.as_deref().unwrap_or("(all)"));
+    layout.text(
+        "current_view",
+        format!("{:?}", current_view.unwrap_or(ChDigViews::Queries)),
+    );
+
+    layout.column();
+    layout.section("Queries columns:");
+    for &col in AVAILABLE_QUERY_COLUMNS {
+        let Some(label) = query_column_id(col) else {
+            continue;
+        };
+        let visible = opts.view.query_columns.iter().any(|h| h == label);
+        let name = format!("set_qcol_{}", label);
+        layout.checkbox(label, &name, visible);
+    }
+
+    layout.column();
     layout.section("Perfetto (query):");
     layout.checkbox(
         "opentelemetry_span_log",
@@ -588,20 +614,8 @@ pub fn show_settings_dialog(siv: &mut Cursive) {
 
     layout.section("Perfetto (export):");
     layout.checkbox("compress", "set_compress", opts.perfetto.compress);
-    layout.separator();
 
-    layout.section("Runtime:");
-    layout.text("selected_host", selected_host.as_deref().unwrap_or("(all)"));
-    layout.text(
-        "current_view",
-        format!("{:?}", current_view.unwrap_or(ChDigViews::Queries)),
-    );
-
-    let SearchableLayout {
-        layout,
-        sections,
-        targets,
-    } = layout;
+    let (layout, sections, targets) = layout.into_layout();
     let search = Arc::new(SettingsSearch {
         sections,
         targets,
@@ -611,9 +625,11 @@ pub fn show_settings_dialog(siv: &mut Cursive) {
     let context_for_apply = context.clone();
     let context_for_enter = context;
 
-    let content = crate::view::submit_on_enter(ScrollView::new(layout), move |siv| {
-        apply_settings(siv, &context_for_enter);
-    });
+    // Columns can exceed narrow terminals, so allow horizontal scrolling too
+    let content =
+        crate::view::submit_on_enter(ScrollView::new(layout).scroll_x(true), move |siv| {
+            apply_settings(siv, &context_for_enter);
+        });
 
     let dialog = Dialog::new()
         .title("Settings")

--- a/src/view/settings_view.rs
+++ b/src/view/settings_view.rs
@@ -130,6 +130,20 @@ fn apply_settings(siv: &mut Cursive, context: &ContextArc) {
         .call_on_name("set_compress", |v: &mut Checkbox| v.is_checked())
         .unwrap();
 
+    let pastila_clickhouse_host = siv
+        .call_on_name("set_pastila_clickhouse_host", |v: &mut EditView| {
+            (*v.get_content()).clone()
+        })
+        .unwrap();
+    let pastila_url = siv
+        .call_on_name("set_pastila_url", |v: &mut EditView| {
+            (*v.get_content()).clone()
+        })
+        .unwrap();
+    let pastila_compression = siv
+        .call_on_name("set_pastila_compression", |v: &mut Checkbox| v.is_checked())
+        .unwrap();
+
     let limit: u64 = match limit_str.parse() {
         Ok(v) => v,
         Err(_) => {
@@ -225,6 +239,10 @@ fn apply_settings(siv: &mut Cursive, context: &ContextArc) {
         ctx.options.perfetto.session_log = session_log;
         ctx.options.perfetto.aggregated_zookeeper_log = zk_log;
         ctx.options.perfetto.compress = compress;
+
+        ctx.options.service.pastila_clickhouse_host = pastila_clickhouse_host;
+        ctx.options.service.pastila_url = pastila_url;
+        ctx.options.service.pastila_compression = pastila_compression;
 
         ctx.trigger_view_refresh();
     }
@@ -475,6 +493,23 @@ pub fn show_settings_dialog(siv: &mut Cursive) {
     layout.text(
         "chdig_config",
         opts.service.chdig_config.as_deref().unwrap_or("(none)"),
+    );
+    layout.edit(
+        "pastila_clickhouse_host",
+        "set_pastila_clickhouse_host",
+        &opts.service.pastila_clickhouse_host,
+        50,
+    );
+    layout.edit(
+        "pastila_url",
+        "set_pastila_url",
+        &opts.service.pastila_url,
+        50,
+    );
+    layout.checkbox(
+        "pastila_compression",
+        "set_pastila_compression",
+        opts.service.pastila_compression,
     );
     layout.separator();
 


### PR DESCRIPTION
pastila's 50MiB length constraint applies to the base64 ciphertext, rejecting large flamegraphs. Compress before encrypting; a .gz URL extension after the rendering type tells pastila to decompress after decrypting. pastila.nl must deploy .gz support first; whodidit.you already auto-detects gzip via pako.

Refs:
- Render compressed pastilas - https://github.com/ClickHouse/pastila/pull/54