### PR TITLE
Initial Panes Implementation (similar to tmux)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -809,7 +809,7 @@ dependencies = [
 [[package]]
 name = "cursive-multiplex"
 version = "0.7.0"
-source = "git+https://github.com/azat-rust/cursive-multiplex?branch=chdig#fb182512dcf6ac067742c541725a2f63c2ef48b2"
+source = "git+https://github.com/azat-rust/cursive-multiplex?branch=chdig#a653f941cd6168514a8544054f060f02fb44fce7"
 dependencies = [
  "cursive_core",
  "indextree",
@@ -2301,7 +2301,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -809,7 +809,7 @@ dependencies = [
 [[package]]
 name = "cursive-multiplex"
 version = "0.7.0"
-source = "git+https://github.com/azat-rust/cursive-multiplex?branch=chdig#3afd3b65722badcb5a10b2c5a85413988cd3a64f"
+source = "git+https://github.com/azat-rust/cursive-multiplex?branch=chdig#340a20a4b805758307dca945771e853d4cf2db99"
 dependencies = [
  "cursive_core",
  "indextree",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -809,7 +809,7 @@ dependencies = [
 [[package]]
 name = "cursive-multiplex"
 version = "0.7.0"
-source = "git+https://github.com/azat-rust/cursive-multiplex?branch=chdig#a653f941cd6168514a8544054f060f02fb44fce7"
+source = "git+https://github.com/azat-rust/cursive-multiplex?branch=chdig#5ad320144f2b78e5a7f91e5778d8f083e79a0f28"
 dependencies = [
  "cursive_core",
  "indextree",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -350,6 +350,7 @@ dependencies = [
  "crossterm 0.28.1",
  "cursive",
  "cursive-flexi-logger-view",
+ "cursive-multiplex",
  "cursive-syntect",
  "flamelens",
  "flate2",
@@ -803,6 +804,17 @@ version = "0.1.0"
 source = "git+https://github.com/azat-rust/cursive?branch=chdig-next#77a14e5d5a67a231a098abe5cdfe26bbfbe3548f"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "cursive-multiplex"
+version = "0.7.0"
+source = "git+https://github.com/azat-rust/cursive-multiplex?branch=chdig#fb182512dcf6ac067742c541725a2f63c2ef48b2"
+dependencies = [
+ "cursive_core",
+ "indextree",
+ "log",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1614,6 +1626,30 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
+]
+
+[[package]]
+name = "indextree"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cee462cd93b03891663339b59a21246cc5fc2cc95060d0bb5059e25cd50edc4"
+dependencies = [
+ "indextree-macros",
+]
+
+[[package]]
+name = "indextree-macros"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f85dac6c239acc85fd61934c572292d93adfd2de459d9c032aa22b553506e915"
+dependencies = [
+ "either",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "strum 0.27.2",
+ "syn",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2471,7 +2507,7 @@ dependencies = [
  "itertools 0.13.0",
  "lru",
  "paste",
- "strum",
+ "strum 0.26.3",
  "unicode-segmentation",
  "unicode-truncate",
  "unicode-width 0.2.0",
@@ -2829,7 +2865,16 @@ version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.26.4",
+]
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros 0.27.2",
 ]
 
 [[package]]
@@ -2842,6 +2887,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
+ "syn",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
  "syn",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -809,7 +809,7 @@ dependencies = [
 [[package]]
 name = "cursive-multiplex"
 version = "0.7.0"
-source = "git+https://github.com/azat-rust/cursive-multiplex?branch=chdig#5ad320144f2b78e5a7f91e5778d8f083e79a0f28"
+source = "git+https://github.com/azat-rust/cursive-multiplex?branch=chdig#3afd3b65722badcb5a10b2c5a85413988cd3a64f"
 dependencies = [
  "cursive_core",
  "indextree",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ cursive = { version = "*", default-features = false, features = ["crossterm-back
 cursive-syntect = { version = "*", default-features = true }
 unicode-width = "0.1"
 cursive-flexi-logger-view = { git = "https://github.com/azat-rust/cursive-flexi-logger-view", branch = "next", default-features = false }
+cursive-multiplex = { git = "https://github.com/azat-rust/cursive-multiplex", branch = "chdig" }
 syntect = { version = "*", default-features = false, features = ["default-syntaxes", "default-themes"] }
 arboard = { version = "*", default-features = false }
 clickhouse-rs = { git = "https://github.com/azat-rust/clickhouse-rs", branch = "next", default-features = false, features = ["tokio_io"] }

--- a/Documentation/Actions.md
+++ b/Documentation/Actions.md
@@ -72,8 +72,13 @@ Here is a list of available shortcuts
 |                 | **G**/**g**   | Move to the end/Move to the beginning         |
 |                 | **PageDown**/**PageUp**| Move to the end/Move to the beginning|
 |                 | **Home**      | Reset selection/follow item in table          |
-| chdig controls  | **Esc**       | Back/Quit                                     |
-|                 | **q**         | Back/Quit                                     |
+| Panes           | **Alt+=**     | Split pane (right)                            |
+|                 | **Alt+-**     | Split pane (below)                            |
+|                 | **Alt+Arrows**| Move focus between panes                      |
+|                 | **Ctrl+Arrows**| Resize panes                                 |
+|                 | **Ctrl+x**    | Zoom the focused pane (fullscreen on/off)     |
+| chdig controls  | **Esc**       | Back/Close pane                               |
+|                 | **q**         | Back/Close pane/Quit                          |
 |                 | **Q**         | Quit forcefully                               |
 |                 | **Backspace** | Back                                          |
 |                 | **p**         | Toggle pause                                  |

--- a/Documentation/Actions.md
+++ b/Documentation/Actions.md
@@ -75,7 +75,7 @@ Here is a list of available shortcuts
 | Panes           | **Alt+=**     | Split pane (right)                            |
 |                 | **Alt+-**     | Split pane (below)                            |
 |                 | **Alt+Arrows**| Move focus between panes                      |
-|                 | **Ctrl+Arrows**| Resize panes                                 |
+|                 | **Ctrl+Arrows**| Resize panes (or drag the separator)         |
 |                 | **Ctrl+x**    | Zoom the focused pane (fullscreen on/off)     |
 | chdig controls  | **Esc**       | Back/Close pane                               |
 |                 | **q**         | Back/Close pane/Quit                          |

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ introspection, like `top` for Linux.
 - Share flamegraphs (using [pastila.nl](https://pastila.nl/) and [speedscope](https://www.speedscope.app/))
 - Share logs via [pastila.nl](https://pastila.nl/)
 - Share query pipelines (using [viz.js](https://github.com/mdaines/viz-js) and [pastila.nl](https://pastila.nl/))
+- Split panes (tmux-like) - multiple views side by side, with zoom (thanks to [cursive-multiplex](https://github.com/deinstapel/cursive-multiplex))
 - Cluster support (`--cluster`) - aggregate data from all hosts in the cluster
 - Historical support (`--history`) - includes rotated `system.*_log_*` tables
 - `clickhouse-client` compatibility (including `--connection`) for options and configuration files

--- a/src/interpreter/context.rs
+++ b/src/interpreter/context.rs
@@ -21,6 +21,9 @@ pub struct GlobalAction {
 type ViewActionCallback =
     Arc<Box<dyn Fn(&mut dyn View) -> Result<Option<EventResult>> + Send + Sync>>;
 pub struct ViewAction {
+    /// Name of the view the action belongs to (actions of several live views
+    /// can coexist, each view drops only its own).
+    pub owner: &'static str,
     pub description: ActionDescription,
     pub callback: ViewActionCallback,
 }
@@ -185,6 +188,7 @@ impl Context {
     pub fn add_view_action<F, E, V>(
         &mut self,
         view: &mut OnEventView<V>,
+        owner: &'static str,
         text: &'static str,
         event: E,
         cb: F,
@@ -195,6 +199,7 @@ impl Context {
     {
         let event = event.into();
         let action = ViewAction {
+            owner,
             description: ActionDescription { text, event },
             callback: Arc::new(Box::new(cb)),
         };
@@ -217,13 +222,14 @@ impl Context {
     pub fn add_view_action_without_shortcut<F, V>(
         &mut self,
         view: &mut OnEventView<V>,
+        owner: &'static str,
         text: &'static str,
         cb: F,
     ) where
         F: Fn(&mut dyn View) -> Result<Option<EventResult>> + Send + Sync + Copy + 'static,
         V: View,
     {
-        return self.add_view_action(view, text, Event::Unknown(Vec::from([0u8])), cb);
+        return self.add_view_action(view, owner, text, Event::Unknown(Vec::from([0u8])), cb);
     }
 
     pub fn get_or_start_perfetto_server(&mut self) -> Arc<PerfettoServer> {

--- a/src/interpreter/options.rs
+++ b/src/interpreter/options.rs
@@ -412,6 +412,10 @@ pub struct ViewOptions {
     #[arg(long, action = ArgAction::SetTrue)]
     pub wrap: bool,
 
+    /// Open logs (query logs, table logs, ...) in a dialog instead of a split pane
+    #[arg(long, action = ArgAction::SetTrue)]
+    pub logs_in_dialog: bool,
+
     /// Disable stripping common hostname prefix and suffix in queries and logs views
     #[arg(long, action = ArgAction::SetTrue)]
     pub no_strip_hostname_suffix: bool,

--- a/src/interpreter/worker.rs
+++ b/src/interpreter/worker.rs
@@ -113,7 +113,9 @@ impl Event {
             Event::ProcessList(..) => "ProcessList".to_string(),
             Event::SlowQueryLog(..) => "SlowQueryLog".to_string(),
             Event::LastQueryLog(..) => "LastQueryLog".to_string(),
-            Event::TextLog(..) => "TextLog".to_string(),
+            // Per-view key: log views in several panes update concurrently,
+            // one shared capacity-1 channel would drop their updates.
+            Event::TextLog(view_name, ..) => format!("TextLog({})", view_name),
             Event::ServerFlameGraph(..) => "ServerFlameGraph".to_string(),
             Event::JemallocFlameGraph(..) => "JemallocFlameGraph".to_string(),
             Event::QueryFlameGraph(..) => "QueryFlameGraph".to_string(),

--- a/src/view/log_view.rs
+++ b/src/view/log_view.rs
@@ -1475,6 +1475,15 @@ impl LogView {
 }
 
 impl View for LogViewBase {
+    // The default is CannotFocus, and everything above (the pane's layout,
+    // Mux click-to-focus and add-follows-focus) refuses focus with it.
+    fn take_focus(
+        &mut self,
+        _source: cursive::direction::Direction,
+    ) -> Result<EventResult, cursive::view::CannotFocus> {
+        Ok(EventResult::consumed())
+    }
+
     fn draw(&self, printer: &Printer<'_, '_>) {
         if self.visible_log_count() == 0 {
             let text = if self.loading {

--- a/src/view/navigation.rs
+++ b/src/view/navigation.rs
@@ -19,6 +19,32 @@ use cursive::{
 use cursive_flexi_logger_view::toggle_flexi_logger_debug_console;
 use cursive_multiplex::Mux;
 
+/// Placeholder content of a freshly split pane. TextView itself refuses
+/// focus, but the pane must be focusable so that the view selected in the
+/// views menu replaces this pane (present_view targets the focused pane).
+struct PaneStub {
+    inner: TextView,
+}
+
+impl PaneStub {
+    fn new() -> Self {
+        Self {
+            inner: TextView::new("Press F2 to choose a view").center(),
+        }
+    }
+}
+
+impl cursive::view::ViewWrapper for PaneStub {
+    cursive::wrap_impl!(self.inner: TextView);
+
+    fn wrap_take_focus(
+        &mut self,
+        _source: cursive::direction::Direction,
+    ) -> Result<EventResult, cursive::view::CannotFocus> {
+        Ok(EventResult::consumed())
+    }
+}
+
 fn toggle_debug_metrics(siv: &mut Cursive) {
     let ctx = siv.user_data::<ContextArc>().unwrap().clone();
     let metrics = ctx.lock().unwrap().debug_metrics.clone();
@@ -57,7 +83,12 @@ pub trait Navigation {
     fn make_theme_from_therminal(&mut self) -> Theme;
     /// Closes the left menu or the top layer. Returns false if there was
     /// nothing to close (i.e. only the main view is shown).
-    fn pop_ui(&mut self, exit: bool) -> bool;
+    fn pop_ui(&mut self) -> bool;
+    /// Adds a new pane next to (or below) the focused one and opens the views
+    /// menu to fill it.
+    fn split_pane(&mut self, below: bool);
+    /// Closes the focused pane. Returns false if it is the only one.
+    fn close_pane(&mut self) -> bool;
     fn toggle_pause_updates(&mut self, reason: Option<&str>);
     fn refresh_view(&mut self);
     fn seek_time_frame(&mut self, is_sub: bool);
@@ -111,7 +142,7 @@ impl Navigation for Cursive {
         return theme;
     }
 
-    fn pop_ui(&mut self, exit: bool) -> bool {
+    fn pop_ui(&mut self) -> bool {
         // Close left menu
         let mut has_left_menu = false;
         self.call_on_name("left_menu", |left_menu_view: &mut LinearLayout| {
@@ -129,10 +160,6 @@ impl Navigation for Cursive {
         }
 
         if self.screen_mut().len() == 1 {
-            if exit {
-                self.quit();
-                return true;
-            }
             return false;
         }
 
@@ -334,11 +361,13 @@ impl Navigation for Cursive {
             );
         }
         context.add_global_action(self, "Toggle debug metrics", '!', toggle_debug_metrics);
-        context.add_global_action(self, "Back/Quit", Key::Esc, |siv| { siv.pop_ui(false); });
-        context.add_global_action(self, "Back/Quit", 'q', |siv| { siv.pop_ui(true); });
+        context.add_global_action(self, "Back/Close pane", Key::Esc, |siv| { if !siv.pop_ui() { siv.close_pane(); } });
+        context.add_global_action(self, "Back/Close pane/Quit", 'q', |siv| { if !siv.pop_ui() && !siv.close_pane() { siv.quit(); } });
+        context.add_global_action(self, "Split pane (right)", Event::AltChar('='), |siv| siv.split_pane(false));
+        context.add_global_action(self, "Split pane (below)", Event::AltChar('-'), |siv| siv.split_pane(true));
         context.add_global_action(self, "Quit forcefully", 'Q', |siv| siv.quit());
         context.add_global_action(self, "Back", Key::Backspace, |siv| {
-            if !siv.pop_ui(false) {
+            if !siv.pop_ui() {
                 siv.show_previous_view();
             }
         });
@@ -415,6 +444,21 @@ impl Navigation for Cursive {
         text.append_styled("\nExtended navigation:\n\n", Effect::Bold);
         text.append_styled(
             format!("{:>10} - reset selection/follow item in table\n", "Home"),
+            Effect::Bold,
+        );
+        text.append_styled(
+            format!("{:>10} - move focus between panes\n", "Alt+Arrows"),
+            Effect::Bold,
+        );
+        text.append_styled(
+            format!("{:>10} - resize panes\n", "Ctrl+Arrows"),
+            Effect::Bold,
+        );
+        text.append_styled(
+            format!(
+                "{:>10} - zoom the focused pane (fullscreen on/off)\n",
+                "Ctrl+x"
+            ),
             Effect::Bold,
         );
 
@@ -854,6 +898,35 @@ impl Navigation for Cursive {
             }
         });
         self.focus_name(focus).unwrap();
+    }
+
+    fn split_pane(&mut self, below: bool) {
+        let added = self
+            .call_on_name("panes", |mux: &mut Mux| {
+                let focused = mux.focus();
+                // Nothing to split while the first view is not shown yet
+                if mux.active_view().is_none() {
+                    return false;
+                }
+                if below {
+                    mux.add_below(PaneStub::new(), focused).unwrap();
+                } else {
+                    mux.add_right_of(PaneStub::new(), focused).unwrap();
+                }
+                true
+            })
+            .unwrap_or(false);
+        if added {
+            self.show_views();
+        }
+    }
+
+    fn close_pane(&mut self) -> bool {
+        self.call_on_name("panes", |mux: &mut Mux| {
+            let focused = mux.focus();
+            mux.remove_id(focused).is_ok()
+        })
+        .unwrap_or(false)
     }
 
     fn set_statusbar_version(&mut self, main_content: impl Into<SpannedString<Style>>) {

--- a/src/view/navigation.rs
+++ b/src/view/navigation.rs
@@ -11,13 +11,14 @@ use cursive::{
     event::{Event, EventResult, Key},
     theme::{BaseColor, Color, ColorStyle, Effect, PaletteColor, Style, Theme},
     utils::{markup::StyledString, span::SpannedString},
-    view::{IntoBoxedView, Nameable, Resizable, View},
+    view::{IntoBoxedView, Nameable, Resizable, Selector, View},
     views::{
         BoxedView, Dialog, DummyView, EditView, LinearLayout, OnEventView, SelectView, TextView,
     },
 };
 use cursive_flexi_logger_view::toggle_flexi_logger_debug_console;
 use cursive_multiplex::Mux;
+use std::collections::HashSet;
 
 /// Placeholder content of a freshly split pane. TextView itself refuses
 /// focus, but the pane must be focusable so that the view selected in the
@@ -43,6 +44,33 @@ impl cursive::view::ViewWrapper for PaneStub {
     ) -> Result<EventResult, cursive::view::CannotFocus> {
         Ok(EventResult::consumed())
     }
+}
+
+/// Whether the focused pane subtree contains a view named `name`.
+fn focused_pane_contains(siv: &mut Cursive, name: &str) -> bool {
+    siv.call_on_name("panes", |mux: &mut Mux| {
+        let mut found = false;
+        if let Some(v) = mux.active_view_mut() {
+            v.call_on_any(&Selector::Name(name), &mut |_| found = true);
+        }
+        found
+    })
+    .unwrap_or(false)
+}
+
+/// Owners of view actions that live in the focused pane. Actions of views in
+/// other panes are hidden until those panes are focused (their key bindings
+/// only fire there anyway, since events follow the focus path).
+fn focused_action_owners(siv: &mut Cursive) -> HashSet<&'static str> {
+    let context = siv.user_data::<ContextArc>().unwrap().clone();
+    let owners: HashSet<&'static str> = {
+        let ctx = context.lock().unwrap();
+        ctx.view_actions.iter().map(|a| a.owner).collect()
+    };
+    owners
+        .into_iter()
+        .filter(|o| focused_pane_contains(siv, o))
+        .collect()
 }
 
 fn toggle_debug_metrics(siv: &mut Cursive) {
@@ -428,6 +456,7 @@ impl Navigation for Cursive {
         );
 
         {
+            let owners = focused_action_owners(self);
             let context = self.user_data::<ContextArc>().unwrap().lock().unwrap();
 
             text.append_styled("\nGlobal shortcuts:\n\n", Effect::Bold);
@@ -436,7 +465,11 @@ impl Navigation for Cursive {
             }
 
             text.append_styled("\nActions:\n\n", Effect::Bold);
-            for shortcut in context.view_actions.iter() {
+            for shortcut in context
+                .view_actions
+                .iter()
+                .filter(|a| owners.contains(a.owner))
+            {
                 text.append(shortcut.description.preview_styled());
             }
         }
@@ -545,6 +578,7 @@ impl Navigation for Cursive {
 
     fn show_actions(&mut self) {
         let mut has_actions = false;
+        let owners = focused_action_owners(self);
         let context = self.user_data::<ContextArc>().unwrap().clone();
         self.call_on_name("left_menu", |left_menu_view: &mut LinearLayout| {
             if !left_menu_view.is_empty() {
@@ -560,11 +594,15 @@ impl Navigation for Cursive {
 
                         siv.focus_name("main").unwrap();
                         {
+                            let owners = focused_action_owners(siv);
                             let mut context = context.lock().unwrap();
                             let action_callback = context
                                 .view_actions
                                 .iter()
-                                .find(|x| x.description.text == selected_action)
+                                .find(|x| {
+                                    x.description.text == selected_action
+                                        && owners.contains(x.owner)
+                                })
                                 .unwrap()
                                 .callback
                                 .clone();
@@ -583,10 +621,16 @@ impl Navigation for Cursive {
                 {
                     let context = context.clone();
                     let context = context.lock().unwrap();
-                    for action in context.view_actions.iter() {
+                    let mut has_any = false;
+                    for action in context
+                        .view_actions
+                        .iter()
+                        .filter(|a| owners.contains(a.owner))
+                    {
                         select.add_item_str(action.description.text);
+                        has_any = true;
                     }
-                    if context.view_actions.is_empty() {
+                    if !has_any {
                         return;
                     }
                 }
@@ -616,6 +660,7 @@ impl Navigation for Cursive {
     }
 
     fn show_fuzzy_actions(&mut self) {
+        let owners = focused_action_owners(self);
         let context = self.user_data::<ContextArc>().unwrap().clone();
         let all_actions = {
             let context = context.lock().unwrap();
@@ -623,7 +668,13 @@ impl Navigation for Cursive {
                 .global_actions
                 .iter()
                 .map(|x| &x.description)
-                .chain(context.view_actions.iter().map(|x| &x.description))
+                .chain(
+                    context
+                        .view_actions
+                        .iter()
+                        .filter(|x| owners.contains(x.owner))
+                        .map(|x| &x.description),
+                )
                 .chain(context.views_menu_actions.iter().map(|x| &x.description))
                 .cloned()
                 .collect()
@@ -648,11 +699,12 @@ impl Navigation for Cursive {
 
             // View callbacks
             {
+                let owners = focused_action_owners(siv);
                 let mut context = context.lock().unwrap();
                 if let Some(action) = context
                     .view_actions
                     .iter()
-                    .find(|x| x.description.text == action_text)
+                    .find(|x| x.description.text == action_text && owners.contains(x.owner))
                 {
                     context.pending_view_callback = Some(action.callback.clone());
                     // The pending_view_callback handling is binded to Event::Refresh event, but it
@@ -845,6 +897,17 @@ impl Navigation for Cursive {
                                     .view_registry
                                     .get_by_view_type(current_view);
 
+                                // Other panes keep queries built with the old
+                                // host filter: collapse to a single pane.
+                                siv.call_on_name("panes", |mux: &mut Mux| {
+                                    let focused = mux.focus();
+                                    for id in mux.panes() {
+                                        if id != focused {
+                                            mux.remove_id(id).unwrap();
+                                        }
+                                    }
+                                    mux.set_focus(focused);
+                                });
                                 siv.drop_main_view();
                                 provider.show(siv, context_arc.clone());
 

--- a/src/view/navigation.rs
+++ b/src/view/navigation.rs
@@ -12,9 +12,12 @@ use cursive::{
     theme::{BaseColor, Color, ColorStyle, Effect, PaletteColor, Style, Theme},
     utils::{markup::StyledString, span::SpannedString},
     view::{IntoBoxedView, Nameable, Resizable, View},
-    views::{Dialog, DummyView, EditView, LinearLayout, OnEventView, SelectView, TextView},
+    views::{
+        BoxedView, Dialog, DummyView, EditView, LinearLayout, OnEventView, SelectView, TextView,
+    },
 };
 use cursive_flexi_logger_view::toggle_flexi_logger_debug_console;
+use cursive_multiplex::Mux;
 
 fn toggle_debug_metrics(siv: &mut Cursive) {
     let ctx = siv.user_data::<ContextArc>().unwrap().clone();
@@ -77,8 +80,7 @@ pub trait Navigation {
     fn show_previous_view(&mut self);
 
     fn drop_main_view(&mut self);
-    fn set_main_view<V: IntoBoxedView + 'static>(&mut self, view: V);
-    /// Replaces the main view with `view` and focuses `focus` in it.
+    /// Replaces the focused pane content with `view` and focuses `focus` in it.
     fn present_view<V: IntoBoxedView + 'static>(&mut self, focus: &str, view: V);
 
     fn set_statusbar_version(&mut self, main_content: impl Into<SpannedString<Style>>);
@@ -267,6 +269,7 @@ impl Navigation for Cursive {
                                 .child(TextView::new("").with_name("version")),
                         )
                         .child(view::SummaryView::new(context.clone()).with_name("summary"))
+                        .child(Mux::new().with_name("panes"))
                         .with_name("main"),
                 ),
         );
@@ -824,27 +827,32 @@ impl Navigation for Cursive {
             self.pop_layer();
         }
 
-        self.call_on_name("main", |main_view: &mut LinearLayout| {
-            // Views that should not be touched:
-            // - top bar (menu text + is_paused + status)
-            // - summary
-            if main_view.len() > 2 {
-                main_view
-                    .remove_child(main_view.len() - 1)
-                    .expect("No child view to remove");
+        // The lone pane cannot be removed from the Mux, so "dropping" is
+        // replacing the pane content with a placeholder (removal is
+        // add-new-then-remove-old, as in present_view).
+        self.call_on_name("panes", |mux: &mut Mux| {
+            let old = mux.focus();
+            if mux.active_view().is_some() {
+                mux.add_right_of(DummyView, old).unwrap();
+                mux.remove_id(old).unwrap();
             }
         });
     }
 
-    fn set_main_view<V: IntoBoxedView + 'static>(&mut self, view: V) {
-        self.call_on_name("main", |main_view: &mut LinearLayout| {
-            main_view.add_child(view);
-        });
-    }
-
     fn present_view<V: IntoBoxedView + 'static>(&mut self, focus: &str, view: V) {
-        self.drop_main_view();
-        self.set_main_view(view);
+        while self.screen_mut().len() > 1 {
+            self.pop_layer();
+        }
+
+        self.call_on_name("panes", |mux: &mut Mux| {
+            let old = mux.focus();
+            let replace = mux.active_view().is_some();
+            mux.add_right_of(BoxedView::new(view.into_boxed_view()), old)
+                .unwrap();
+            if replace {
+                mux.remove_id(old).unwrap();
+            }
+        });
         self.focus_name(focus).unwrap();
     }
 

--- a/src/view/navigation.rs
+++ b/src/view/navigation.rs
@@ -141,6 +141,14 @@ pub trait Navigation {
     fn drop_main_view(&mut self);
     /// Replaces the focused pane content with `view` and focuses `focus` in it.
     fn present_view<V: IntoBoxedView + 'static>(&mut self, focus: &str, view: V);
+    /// Shows a log view in a new pane to the right (default) or in a dialog
+    /// (--logs-in-dialog). `view` must contain a view named `view_name`.
+    fn present_logs<V: IntoBoxedView + 'static>(
+        &mut self,
+        view_name: &'static str,
+        title: &str,
+        view: V,
+    );
 
     fn set_statusbar_version(&mut self, main_content: impl Into<SpannedString<Style>>);
     fn set_statusbar_content(&mut self, content: impl Into<SpannedString<Style>>);
@@ -961,6 +969,39 @@ impl Navigation for Cursive {
             }
         });
         self.focus_name(focus).unwrap();
+    }
+
+    fn present_logs<V: IntoBoxedView + 'static>(
+        &mut self,
+        view_name: &'static str,
+        title: &str,
+        view: V,
+    ) {
+        let in_dialog = {
+            let ctx = self.user_data::<ContextArc>().unwrap().lock().unwrap();
+            ctx.options.view.logs_in_dialog
+        };
+
+        let content = LinearLayout::vertical()
+            .child(TextView::new(title).center())
+            .child(DummyView.fixed_height(1))
+            .child(view);
+
+        if in_dialog {
+            self.add_layer(Dialog::around(content));
+            self.focus_name(view_name).unwrap();
+        } else if self.has_view(view_name) {
+            // Two views with one name would both receive the worker updates:
+            // replace the existing one in place (has_view focused its pane).
+            self.present_view(view_name, content);
+        } else {
+            self.call_on_name("panes", |mux: &mut Mux| {
+                let focused = mux.focus();
+                mux.add_right_of(BoxedView::new(content.into_boxed_view()), focused)
+                    .unwrap();
+            });
+            self.focus_name(view_name).unwrap();
+        }
     }
 
     fn split_pane(&mut self, below: bool) {

--- a/src/view/navigation.rs
+++ b/src/view/navigation.rs
@@ -78,6 +78,8 @@ pub trait Navigation {
 
     fn drop_main_view(&mut self);
     fn set_main_view<V: IntoBoxedView + 'static>(&mut self, view: V);
+    /// Replaces the main view with `view` and focuses `focus` in it.
+    fn present_view<V: IntoBoxedView + 'static>(&mut self, focus: &str, view: V);
 
     fn set_statusbar_version(&mut self, main_content: impl Into<SpannedString<Style>>);
     fn set_statusbar_content(&mut self, content: impl Into<SpannedString<Style>>);
@@ -838,6 +840,12 @@ impl Navigation for Cursive {
         self.call_on_name("main", |main_view: &mut LinearLayout| {
             main_view.add_child(view);
         });
+    }
+
+    fn present_view<V: IntoBoxedView + 'static>(&mut self, focus: &str, view: V) {
+        self.drop_main_view();
+        self.set_main_view(view);
+        self.focus_name(focus).unwrap();
     }
 
     fn set_statusbar_version(&mut self, main_content: impl Into<SpannedString<Style>>) {

--- a/src/view/providers/asynchronous_inserts.rs
+++ b/src/view/providers/asynchronous_inserts.rs
@@ -155,9 +155,7 @@ pub fn show_asynchronous_inserts(
 
     view.get_inner_mut().set_title(filters.build_title(false));
 
-    siv.drop_main_view();
-    siv.set_main_view(view.with_name(view_name).full_screen());
-    siv.focus_name(view_name).unwrap();
+    siv.present_view(view_name, view.with_name(view_name).full_screen());
 }
 
 pub fn show_asynchronous_inserts_dialog(

--- a/src/view/providers/asynchronous_metric_log.rs
+++ b/src/view/providers/asynchronous_metric_log.rs
@@ -133,7 +133,5 @@ fn show_asynchronous_metric_log(siv: &mut Cursive, context: ContextArc) {
     view.get_inner_mut().set_on_submit(show_chart);
     view.get_inner_mut().set_title("Asynchronous metric log");
 
-    siv.drop_main_view();
-    siv.set_main_view(view.with_name(view_name).full_screen());
-    siv.focus_name(view_name).unwrap();
+    siv.present_view(view_name, view.with_name(view_name).full_screen());
 }

--- a/src/view/providers/background_schedule_pool.rs
+++ b/src/view/providers/background_schedule_pool.rs
@@ -73,8 +73,6 @@ impl ViewProvider for BackgroundSchedulePoolViewProvider {
             where_clause,
         );
 
-        siv.drop_main_view();
-
         let mut view = view::SQLQueryView::new(
             context.clone(),
             "background_schedule_pool",
@@ -93,8 +91,10 @@ impl ViewProvider for BackgroundSchedulePoolViewProvider {
             .set_on_submit(background_schedule_pool_action_callback);
         view.get_inner_mut().set_title("Background Schedule Pool");
 
-        siv.set_main_view(view.with_name("background_schedule_pool").full_screen());
-        siv.focus_name("background_schedule_pool").unwrap();
+        siv.present_view(
+            "background_schedule_pool",
+            view.with_name("background_schedule_pool").full_screen(),
+        );
     }
 }
 

--- a/src/view/providers/background_schedule_pool_log.rs
+++ b/src/view/providers/background_schedule_pool_log.rs
@@ -241,9 +241,7 @@ pub fn show_background_schedule_pool_log(
 
     view.get_inner_mut().set_title(filters.build_title(false));
 
-    siv.drop_main_view();
-    siv.set_main_view(view.with_name(view_name).full_screen());
-    siv.focus_name(view_name).unwrap();
+    siv.present_view(view_name, view.with_name(view_name).full_screen());
 }
 
 pub fn show_background_schedule_pool_log_dialog(

--- a/src/view/providers/error_log.rs
+++ b/src/view/providers/error_log.rs
@@ -71,8 +71,6 @@ impl ViewProvider for ErrorLogViewProvider {
             host_filter = clickhouse.get_log_host_filter_clause(selected_host.as_ref()),
         );
 
-        siv.drop_main_view();
-
         let mut view = view::SQLQueryView::new(
             context.clone(),
             view_name,
@@ -87,7 +85,6 @@ impl ViewProvider for ErrorLogViewProvider {
         view.get_inner_mut().set_title(view_name);
         view.get_inner_mut().set_bar_columns(vec![("bar", "total")]);
 
-        siv.set_main_view(view.with_name(view_name).full_screen());
-        siv.focus_name(view_name).unwrap();
+        siv.present_view(view_name, view.with_name(view_name).full_screen());
     }
 }

--- a/src/view/providers/errors.rs
+++ b/src/view/providers/errors.rs
@@ -126,8 +126,6 @@ impl ViewProvider for ErrorsViewProvider {
             where_clause,
         );
 
-        siv.drop_main_view();
-
         let mut view = view::SQLQueryView::new(
             context.clone(),
             "errors",
@@ -141,7 +139,6 @@ impl ViewProvider for ErrorsViewProvider {
         view.get_inner_mut().set_title("errors");
         view.get_inner_mut().set_bar_columns(vec![("bar", "total")]);
 
-        siv.set_main_view(view.with_name("errors").full_screen());
-        siv.focus_name("errors").unwrap();
+        siv.present_view("errors", view.with_name("errors").full_screen());
     }
 }

--- a/src/view/providers/logger_names.rs
+++ b/src/view/providers/logger_names.rs
@@ -6,7 +6,7 @@ use chrono::{DateTime, Local};
 use cursive::{
     Cursive,
     view::{Nameable, Resizable},
-    views::{Dialog, DummyView, LinearLayout, NamedView, TextView},
+    views::NamedView,
 };
 use std::collections::HashMap;
 
@@ -70,28 +70,26 @@ impl ViewProvider for LoggerNamesViewProvider {
                 let context = siv.user_data::<ContextArc>().unwrap().clone();
                 let view_options = context.lock().unwrap().options.view.clone();
 
-                siv.add_layer(Dialog::around(
-                    LinearLayout::vertical()
-                        .child(TextView::new(format!("Logs for logger: {}", logger_name)).center())
-                        .child(DummyView.fixed_height(1))
-                        .child(NamedView::new(
+                siv.present_logs(
+                    "logger_logs",
+                    &format!("Logs for logger: {}", logger_name),
+                    NamedView::new(
+                        "logger_logs",
+                        TextLogView::new(
                             "logger_logs",
-                            TextLogView::new(
-                                "logger_logs",
-                                context,
-                                crate::interpreter::TextLogArguments {
-                                    query_ids: None,
-                                    logger_names: Some(vec![logger_name]),
-                                    hostname: None,
-                                    message_filter: None,
-                                    max_level: None,
-                                    start: DateTime::<Local>::from(view_options.start),
-                                    end: view_options.end,
-                                },
-                            ),
-                        )),
-                ));
-                siv.focus_name("logger_logs").unwrap();
+                            context,
+                            crate::interpreter::TextLogArguments {
+                                query_ids: None,
+                                logger_names: Some(vec![logger_name.clone()]),
+                                hostname: None,
+                                message_filter: None,
+                                max_level: None,
+                                start: DateTime::<Local>::from(view_options.start),
+                                end: view_options.end,
+                            },
+                        ),
+                    ),
+                );
             };
 
         // Build the query with time filtering

--- a/src/view/providers/logger_names.rs
+++ b/src/view/providers/logger_names.rs
@@ -145,8 +145,6 @@ impl ViewProvider for LoggerNamesViewProvider {
             limit,
         );
 
-        siv.drop_main_view();
-
         let mut view = view::SQLQueryView::new(
             context.clone(),
             "logger_names",
@@ -159,7 +157,6 @@ impl ViewProvider for LoggerNamesViewProvider {
         view.get_inner_mut().set_on_submit(logger_names_callback);
         view.get_inner_mut().set_title("Loggers");
 
-        siv.set_main_view(view.with_name("logger_names").full_screen());
-        siv.focus_name("logger_names").unwrap();
+        siv.present_view("logger_names", view.with_name("logger_names").full_screen());
     }
 }

--- a/src/view/providers/merges.rs
+++ b/src/view/providers/merges.rs
@@ -168,9 +168,7 @@ fn show_merges(
 
     view.get_inner_mut().set_title(filters.build_title(false));
 
-    siv.drop_main_view();
-    siv.set_main_view(view.with_name(view_name).full_screen());
-    siv.focus_name(view_name).unwrap();
+    siv.present_view(view_name, view.with_name(view_name).full_screen());
 }
 
 pub fn show_merges_dialog(

--- a/src/view/providers/metric_log.rs
+++ b/src/view/providers/metric_log.rs
@@ -144,7 +144,5 @@ fn show_metric_log(siv: &mut Cursive, context: ContextArc) {
     view.get_inner_mut().set_on_submit(show_chart);
     view.get_inner_mut().set_title("Metric log");
 
-    siv.drop_main_view();
-    siv.set_main_view(view.with_name(view_name).full_screen());
-    siv.focus_name(view_name).unwrap();
+    siv.present_view(view_name, view.with_name(view_name).full_screen());
 }

--- a/src/view/providers/mod.rs
+++ b/src/view/providers/mod.rs
@@ -376,8 +376,6 @@ pub fn render_from_clickhouse_query<F, T>(
         settings_str,
     );
 
-    siv.drop_main_view();
-
     let mut view = view::SQLQueryView::new(
         params.context.clone(),
         table_alias,
@@ -393,8 +391,7 @@ pub fn render_from_clickhouse_query<F, T>(
     view.get_inner_mut().set_title(table_alias);
     let view = view.with_name(table_alias).full_screen();
 
-    siv.set_main_view(view);
-    siv.focus_name(table_alias).unwrap();
+    siv.present_view(table_alias, view);
 }
 
 /// Shows a chart of `value_expr` aggregated over the view's time interval,

--- a/src/view/providers/mod.rs
+++ b/src/view/providers/mod.rs
@@ -55,7 +55,7 @@ use chrono::{DateTime, Local};
 use cursive::{
     Cursive,
     view::{Nameable, Resizable},
-    views::{Dialog, DummyView, LinearLayout, NamedView, TextView},
+    views::{Dialog, NamedView},
 };
 use std::collections::HashMap;
 
@@ -204,6 +204,8 @@ pub fn query_result_show_logs_for_row(
     logger_names_patterns: &[&'static str],
     view_name: &'static str,
 ) {
+    use crate::view::Navigation;
+
     let row = row.0;
 
     let mut map = HashMap::<String, String>::new();
@@ -225,28 +227,24 @@ pub fn query_result_show_logs_for_row(
         .map(|p| strfmt::strfmt(p, &map).unwrap())
         .collect::<Vec<_>>();
 
-    siv.add_layer(Dialog::around(
-        LinearLayout::vertical()
-            .child(TextView::new("Logs:").center())
-            .child(DummyView.fixed_height(1))
-            .child(NamedView::new(
-                view_name,
-                TextLogView::new(
-                    view_name,
-                    context,
-                    crate::interpreter::TextLogArguments {
-                        query_ids: None,
-                        logger_names: Some(logger_names),
-                        hostname: None,
-                        message_filter: None,
-                        max_level: None,
-                        start: DateTime::<Local>::from(view_options.start),
-                        end: view_options.end,
-                    },
-                ),
-            )),
-    ));
-    siv.focus_name(view_name).unwrap();
+    let log_view = NamedView::new(
+        view_name,
+        TextLogView::new(
+            view_name,
+            context,
+            crate::interpreter::TextLogArguments {
+                query_ids: None,
+                logger_names: Some(logger_names),
+                hostname: None,
+                message_filter: None,
+                max_level: None,
+                start: DateTime::<Local>::from(view_options.start),
+                end: view_options.end,
+            },
+        ),
+    );
+
+    siv.present_logs(view_name, "Logs:", log_view);
 }
 
 pub trait ClickHouseSettingValue {

--- a/src/view/providers/mutations.rs
+++ b/src/view/providers/mutations.rs
@@ -115,9 +115,7 @@ fn show_mutations(
 
     view.get_inner_mut().set_title(filters.build_title(false));
 
-    siv.drop_main_view();
-    siv.set_main_view(view.with_name(view_name).full_screen());
-    siv.focus_name(view_name).unwrap();
+    siv.present_view(view_name, view.with_name(view_name).full_screen());
 }
 
 pub fn show_mutations_dialog(

--- a/src/view/providers/part_log.rs
+++ b/src/view/providers/part_log.rs
@@ -326,9 +326,7 @@ pub fn show_part_log(
 
     view.get_inner_mut().set_title(filters.build_title(false));
 
-    siv.drop_main_view();
-    siv.set_main_view(view.with_name(view_name).full_screen());
-    siv.focus_name(view_name).unwrap();
+    siv.present_view(view_name, view.with_name(view_name).full_screen());
 }
 
 pub fn show_part_log_dialog(

--- a/src/view/providers/queries.rs
+++ b/src/view/providers/queries.rs
@@ -23,8 +23,8 @@ impl ViewProvider for ProcessesViewProvider {
             return;
         }
 
-        siv.drop_main_view();
-        siv.set_main_view(
+        siv.present_view(
+            "processes",
             view::QueriesView::new(
                 context.clone(),
                 ProcessesType::ProcessList,
@@ -34,7 +34,6 @@ impl ViewProvider for ProcessesViewProvider {
             .with_name("processes")
             .full_screen(),
         );
-        siv.focus_name("processes").unwrap();
     }
 }
 
@@ -54,8 +53,8 @@ impl ViewProvider for SlowQueryLogViewProvider {
             return;
         }
 
-        siv.drop_main_view();
-        siv.set_main_view(
+        siv.present_view(
+            "slow_query_log",
             view::QueriesView::new(
                 context.clone(),
                 ProcessesType::SlowQueryLog,
@@ -65,7 +64,6 @@ impl ViewProvider for SlowQueryLogViewProvider {
             .with_name("slow_query_log")
             .full_screen(),
         );
-        siv.focus_name("slow_query_log").unwrap();
     }
 }
 
@@ -85,8 +83,8 @@ impl ViewProvider for LastQueryLogViewProvider {
             return;
         }
 
-        siv.drop_main_view();
-        siv.set_main_view(
+        siv.present_view(
+            "last_query_log",
             view::QueriesView::new(
                 context.clone(),
                 ProcessesType::LastQueryLog,
@@ -96,6 +94,5 @@ impl ViewProvider for LastQueryLogViewProvider {
             .with_name("last_query_log")
             .full_screen(),
         );
-        siv.focus_name("last_query_log").unwrap();
     }
 }

--- a/src/view/providers/query_patterns.rs
+++ b/src/view/providers/query_patterns.rs
@@ -261,7 +261,6 @@ fn show_query_patterns(siv: &mut Cursive, context: ContextArc) {
     if siv.has_view(VIEW_NAME) {
         return;
     }
-    siv.drop_main_view();
     build_and_install(siv, context);
 }
 
@@ -320,6 +319,5 @@ fn build_and_install(siv: &mut Cursive, context: ContextArc) {
         .on_event(Event::Char('m'), show_metric_picker)
         .on_event(Event::Char(' '), cycle_metric);
 
-    siv.set_main_view(wrapped);
-    siv.focus_name(VIEW_NAME).unwrap();
+    siv.present_view(VIEW_NAME, wrapped);
 }

--- a/src/view/providers/replicas.rs
+++ b/src/view/providers/replicas.rs
@@ -76,8 +76,6 @@ impl ViewProvider for ReplicasViewProvider {
             where_clause,
         );
 
-        siv.drop_main_view();
-
         let mut view = view::SQLQueryView::new(
             context.clone(),
             "replicas",
@@ -106,7 +104,6 @@ impl ViewProvider for ReplicasViewProvider {
         view.get_inner_mut().set_on_submit(replicas_logs_callback);
         view.get_inner_mut().set_title("Replicas");
 
-        siv.set_main_view(view.with_name("replicas").full_screen());
-        siv.focus_name("replicas").unwrap();
+        siv.present_view("replicas", view.with_name("replicas").full_screen());
     }
 }

--- a/src/view/providers/server_logs.rs
+++ b/src/view/providers/server_logs.rs
@@ -30,8 +30,8 @@ impl ViewProvider for ServerLogsViewProvider {
             (ctx.options.view.clone(), ctx.selected_host.clone())
         };
 
-        siv.drop_main_view();
-        siv.set_main_view(
+        siv.present_view(
+            "server_logs",
             LinearLayout::vertical()
                 .child(TextView::new("Server logs:").center())
                 .child(DummyView.fixed_height(1))
@@ -53,6 +53,5 @@ impl ViewProvider for ServerLogsViewProvider {
                     .full_screen(),
                 ),
         );
-        siv.focus_name("server_logs").unwrap();
     }
 }

--- a/src/view/providers/table_parts.rs
+++ b/src/view/providers/table_parts.rs
@@ -249,9 +249,7 @@ pub fn show_table_parts(
 
     view.get_inner_mut().set_title(filters.build_title(false));
 
-    siv.drop_main_view();
-    siv.set_main_view(view.with_name(view_name).full_screen());
-    siv.focus_name(view_name).unwrap();
+    siv.present_view(view_name, view.with_name(view_name).full_screen());
 }
 
 pub fn show_table_parts_dialog(

--- a/src/view/providers/tables.rs
+++ b/src/view/providers/tables.rs
@@ -102,8 +102,6 @@ impl ViewProvider for TablesViewProvider {
             )
         };
 
-        siv.drop_main_view();
-
         let mut view = view::SQLQueryView::new(
             context.clone(),
             "tables",
@@ -122,8 +120,7 @@ impl ViewProvider for TablesViewProvider {
         view.get_inner_mut().set_on_submit(tables_action_callback);
         view.get_inner_mut().set_title("Tables");
 
-        siv.set_main_view(view.with_name("tables").full_screen());
-        siv.focus_name("tables").unwrap();
+        siv.present_view("tables", view.with_name("tables").full_screen());
     }
 }
 

--- a/src/view/queries_view.rs
+++ b/src/view/queries_view.rs
@@ -1279,13 +1279,14 @@ impl QueriesView {
                 .query_columns
                 .retain(|c| c != label);
         });
-        table.set_on_submit(|siv, _row, _index| {
+        table.set_on_submit(move |siv, _row, _index| {
             let context = siv.user_data::<ContextArc>().unwrap().clone();
             let query_actions = context
                 .lock()
                 .unwrap()
                 .view_actions
                 .iter()
+                .filter(|x| x.owner == view_name)
                 .map(|x| &x.description)
                 .cloned()
                 .collect();
@@ -1298,7 +1299,7 @@ impl QueriesView {
                     if let Some(action) = context
                         .view_actions
                         .iter()
-                        .find(|x| x.description.text == action_text)
+                        .find(|x| x.description.text == action_text && x.owner == view_name)
                     {
                         context.pending_view_callback = Some(action.callback.clone());
                     }

--- a/src/view/queries_view.rs
+++ b/src/view/queries_view.rs
@@ -19,6 +19,7 @@ use cursive::{
 use size::{Base, SizeFormatter, Style};
 
 use crate::common::RelativeDateTime;
+use crate::view::Navigation;
 use crate::view::show_bottom_prompt;
 use crate::{
     interpreter::{
@@ -679,28 +680,26 @@ impl QueriesView {
             .unwrap()
             .cb_sink
             .send(Box::new(move |siv: &mut cursive::Cursive| {
-                siv.add_layer(views::Dialog::around(
-                    views::LinearLayout::vertical()
-                        .child(views::TextView::new("Logs:").center())
-                        .child(views::DummyView.fixed_height(1))
-                        .child(views::NamedView::new(
+                siv.present_logs(
+                    "query_log",
+                    "Logs:",
+                    views::NamedView::new(
+                        "query_log",
+                        TextLogView::new(
                             "query_log",
-                            TextLogView::new(
-                                "query_log",
-                                context_copy,
-                                TextLogArguments {
-                                    query_ids: Some(query_ids),
-                                    logger_names: None,
-                                    hostname: None,
-                                    message_filter: None,
-                                    max_level: None,
-                                    start: min_query_start_microseconds,
-                                    end: RelativeDateTime::from(max_query_end_microseconds),
-                                },
-                            ),
-                        )),
-                ));
-                siv.focus_name("query_log").unwrap();
+                            context_copy,
+                            TextLogArguments {
+                                query_ids: Some(query_ids),
+                                logger_names: None,
+                                hostname: None,
+                                message_filter: None,
+                                max_level: None,
+                                start: min_query_start_microseconds,
+                                end: RelativeDateTime::from(max_query_end_microseconds),
+                            },
+                        ),
+                    ),
+                );
             }))
             .unwrap();
         Ok(Some(EventResult::consumed()))

--- a/src/view/queries_view.rs
+++ b/src/view/queries_view.rs
@@ -358,6 +358,7 @@ pub struct QueriesView {
     limit: Arc<Mutex<u64>>,
     // Keep clipboard alive so X11 clipboard manager can persist the data
     clipboard: Option<arboard::Clipboard>,
+    view_name: &'static str,
 
     #[allow(unused)]
     bg_runner: BackgroundRunner,
@@ -1183,25 +1184,25 @@ impl QueriesView {
         macro_rules! add_action {
             // With shortcut and method arguments
             ($ctx:expr, $view:expr, $desc:expr, $shortcut:expr, $method:ident($($args:expr),*)) => {
-                $ctx.add_view_action($view, $desc, $shortcut, |v| {
+                $ctx.add_view_action($view, view_name, $desc, $shortcut, |v| {
                     v.downcast_mut::<QueriesView>().unwrap().$method($($args),*)
                 })
             };
             // Without shortcut but with method arguments
             ($ctx:expr, $view:expr, $desc:expr, $method:ident($($args:expr),*)) => {
-                $ctx.add_view_action_without_shortcut($view, $desc, |v| {
+                $ctx.add_view_action_without_shortcut($view, view_name, $desc, |v| {
                     v.downcast_mut::<QueriesView>().unwrap().$method($($args),*)
                 })
             };
             // With shortcut (char or Event), no arguments
             ($ctx:expr, $view:expr, $desc:expr, $shortcut:expr, $method:ident) => {
-                $ctx.add_view_action($view, $desc, $shortcut, |v| {
+                $ctx.add_view_action($view, view_name, $desc, $shortcut, |v| {
                     v.downcast_mut::<QueriesView>().unwrap().$method()
                 })
             };
             // Without shortcut, no arguments
             ($ctx:expr, $view:expr, $desc:expr, $method:ident) => {
-                $ctx.add_view_action_without_shortcut($view, $desc, |v| {
+                $ctx.add_view_action_without_shortcut($view, view_name, $desc, |v| {
                     v.downcast_mut::<QueriesView>().unwrap().$method()
                 })
             };
@@ -1357,6 +1358,7 @@ impl QueriesView {
             filter,
             limit,
             clipboard: None,
+            view_name,
             bg_runner,
         };
 
@@ -1405,7 +1407,7 @@ impl QueriesView {
         add_action!(context, &mut event_view, "EXPLAIN SYNTAX", 's', action_explain_syntax);
         add_action!(context, &mut event_view, "EXPLAIN PLAN", 'e', action_explain_plan);
         add_action!(context, &mut event_view, "EXPLAIN PIPELINE", 'E', action_explain_pipeline);
-        context.add_view_action(&mut event_view, "Filter", '/', move |_v| {
+        context.add_view_action(&mut event_view, view_name, "Filter", '/', move |_v| {
             return Ok(Some(EventResult::Consumed(Some(Callback::from_fn(
                 move |siv: &mut Cursive| {
                     let filter_cb = move |siv: &mut Cursive, text: &str| {
@@ -1460,8 +1462,14 @@ impl QueriesView {
 
 impl Drop for QueriesView {
     fn drop(&mut self) {
-        log::debug!("Removing views actions");
-        self.context.lock().unwrap().view_actions.clear();
+        log::debug!("Removing {} view actions", self.view_name);
+        // Only own actions: with panes the replacement view is constructed
+        // (and registers its actions) before this view is dropped.
+        self.context
+            .lock()
+            .unwrap()
+            .view_actions
+            .retain(|a| a.owner != self.view_name);
     }
 }
 

--- a/src/view/settings_view.rs
+++ b/src/view/settings_view.rs
@@ -43,6 +43,9 @@ fn apply_settings(siv: &mut Cursive, context: &ContextArc) {
     let wrap = siv
         .call_on_name("set_wrap", |v: &mut Checkbox| v.is_checked())
         .unwrap();
+    let logs_in_dialog = siv
+        .call_on_name("set_logs_in_dialog", |v: &mut Checkbox| v.is_checked())
+        .unwrap();
     let no_strip = siv
         .call_on_name("set_no_strip_hostname_suffix", |v: &mut Checkbox| {
             v.is_checked()
@@ -212,6 +215,7 @@ fn apply_settings(siv: &mut Cursive, context: &ContextArc) {
         ctx.options.view.group_by = group_by;
         ctx.options.view.no_subqueries = no_subqueries;
         ctx.options.view.wrap = wrap;
+        ctx.options.view.logs_in_dialog = logs_in_dialog;
         ctx.options.view.no_strip_hostname_suffix = no_strip;
         ctx.options.view.no_color = no_color;
         *ctx.queries_filter.lock().unwrap() = queries_filter;
@@ -475,6 +479,11 @@ pub fn show_settings_dialog(siv: &mut Cursive) {
         opts.view.no_subqueries,
     );
     layout.checkbox("wrap", "set_wrap", opts.view.wrap);
+    layout.checkbox(
+        "logs_in_dialog",
+        "set_logs_in_dialog",
+        opts.view.logs_in_dialog,
+    );
     layout.checkbox(
         "no_strip_hostname_suffix",
         "set_no_strip_hostname_suffix",

--- a/src/view/table_view.rs
+++ b/src/view/table_view.rs
@@ -1209,16 +1209,17 @@ where
         let title_height = self.title_height();
 
         if let Some(title) = &self.title {
+            // Bright in the focused pane, dim otherwise (the pane indicator,
+            // together with the highlighted separators)
+            let title_color = if printer.focused {
+                Color::Light(BaseColor::Cyan)
+            } else {
+                Color::Dark(BaseColor::Cyan)
+            };
             let mut styled = StyledString::new();
             styled.append_plain("\u{2500}\u{2500}\u{2500} ");
-            styled.append_styled(
-                title,
-                Style::from(Color::Dark(BaseColor::Cyan)).combine(Effect::Bold),
-            );
-            styled.append_styled(
-                format!(" ({})", self.items.len()),
-                Style::from(Color::Dark(BaseColor::Cyan)),
-            );
+            styled.append_styled(title, Style::from(title_color).combine(Effect::Bold));
+            styled.append_styled(format!(" ({})", self.items.len()), Style::from(title_color));
             styled.append_plain(" \u{2500}\u{2500}\u{2500}");
             let width = printer.size.x;
             let text_width = styled.width();

--- a/tests/tui.rs
+++ b/tests/tui.rs
@@ -380,6 +380,32 @@ async fn test_pane_click_focus() {
         !screen.find_occurences("Logs:").is_empty()
             && screen.find_occurences("it-tui-click").is_empty()
     });
+    tui.send(Event::CtrlChar('x'));
+    tui.wait_for("unzoomed again", |screen| {
+        !screen.find_occurences("it-tui-click").is_empty()
+    });
+
+    // Drag the separator (screen column 90) to column 130
+    let separator_at = |screen: &ObservedScreen, x: usize| {
+        screen[Vec2::new(x, 20)]
+            .as_ref()
+            .and_then(|c| c.letter.as_option().cloned())
+            == Some("\u{2502}".to_string())
+    };
+    tui.send(click(90, 20));
+    tui.send(Event::Mouse {
+        offset: Vec2::zero(),
+        position: Vec2::new(130, 20),
+        event: cursive::event::MouseEvent::Hold(cursive::event::MouseButton::Left),
+    });
+    tui.send(Event::Mouse {
+        offset: Vec2::zero(),
+        position: Vec2::new(130, 20),
+        event: cursive::event::MouseEvent::Release(cursive::event::MouseButton::Left),
+    });
+    tui.wait_for("separator dragged to column 130", |screen| {
+        separator_at(screen, 130) && !separator_at(screen, 90)
+    });
 
     kill_query(server, "it-tui-click", &mut child);
     tui.quit();

--- a/tests/tui.rs
+++ b/tests/tui.rs
@@ -80,15 +80,15 @@ impl Tui {
         self.input.send(Some(event)).unwrap();
     }
 
-    /// Wait until the pattern shows up on the screen and return that frame.
-    fn wait_for_text(&self, pattern: &str) -> ObservedScreen {
+    /// Wait until the predicate holds for a frame and return that frame.
+    fn wait_for<F: Fn(&ObservedScreen) -> bool>(&self, what: &str, pred: F) -> ObservedScreen {
         let deadline = Instant::now() + Duration::from_secs(60);
         let mut last_screen = None;
         loop {
             // Force a redraw, so that a new frame is always emitted
             self.send(Event::Refresh);
             if let Ok(screen) = self.frames.recv_timeout(Duration::from_millis(200)) {
-                if !screen.find_occurences(pattern).is_empty() {
+                if pred(&screen) {
                     return screen;
                 }
                 last_screen = Some(screen);
@@ -97,9 +97,16 @@ impl Tui {
                 if let Some(screen) = &last_screen {
                     eprintln!("last screen:\n{}", screen_to_string(screen));
                 }
-                panic!("'{pattern}' did not appear on the screen");
+                panic!("{what} did not appear on the screen");
             }
         }
+    }
+
+    /// Wait until the pattern shows up on the screen and return that frame.
+    fn wait_for_text(&self, pattern: &str) -> ObservedScreen {
+        self.wait_for(&format!("'{pattern}'"), |screen| {
+            !screen.find_occurences(pattern).is_empty()
+        })
     }
 
     fn quit(mut self) {
@@ -204,10 +211,184 @@ async fn test_query_logs_view() {
     // The table has no selection until the first interaction
     tui.send(Event::Key(cursive::event::Key::Down));
     tui.send(Event::Char('l'));
-    tui.wait_for_text("tui marker log line");
+    // Only the prefix: the long log line is cropped at the logs pane width
+    tui.wait_for_text("tui marker");
 
     kill_query(server, "it-tui-logs", &mut child);
     tui.quit();
 }
 
-common::integration_tests!(test_queries_view, test_query_logs_view);
+// Split panes (#164): Alt+v adds a pane and opens the views menu, the chosen view
+// shows up next to the old one; Ctrl+x zooms the focused pane; q closes it.
+async fn test_panes() {
+    let Some(server) = common::server() else {
+        return;
+    };
+    let serial = serial_lock();
+    let mut child = server.spawn_query(
+        "it-tui-panes",
+        "SELECT sum(sleep(0.5)) AS tui_marker_panes FROM numbers(600) SETTINGS max_block_size=1",
+    );
+    wait_query_is_running(server, "it-tui-panes");
+
+    let tui = Tui::start(server, serial);
+    tui.wait_for_text("tui_marker_panes");
+
+    tui.send(Event::AltChar('='));
+    tui.wait_for_text("Press F2 to choose a view");
+    // Select the Tables view in the menu (autojump + submit); it replaces the stub
+    tui.send(Event::Char('T'));
+    tui.send(Event::Key(cursive::event::Key::Enter));
+    // Both panes at once: the queries view and the tables view ("engine" column).
+    // The query text is cropped in the halved pane, the query_id column is not.
+    tui.wait_for("queries and tables panes", |screen| {
+        !screen.find_occurences("it-tui-panes").is_empty()
+            && !screen.find_occurences("engine").is_empty()
+    });
+
+    // Zoom the focused (tables) pane: the queries pane is hidden, then back
+    tui.send(Event::CtrlChar('x'));
+    tui.wait_for("zoomed tables pane", |screen| {
+        screen.find_occurences("it-tui-panes").is_empty()
+            && !screen.find_occurences("engine").is_empty()
+    });
+    tui.send(Event::CtrlChar('x'));
+    tui.wait_for("unzoomed panes", |screen| {
+        !screen.find_occurences("it-tui-panes").is_empty()
+            && !screen.find_occurences("engine").is_empty()
+    });
+
+    // A mouse click into the left pane focuses it: zoom must now show the
+    // queries view (the click also selects the row under the cursor)
+    tui.send(Event::Mouse {
+        offset: Vec2::zero(),
+        position: Vec2::new(20, 10),
+        event: cursive::event::MouseEvent::Press(cursive::event::MouseButton::Left),
+    });
+    tui.send(Event::CtrlChar('x'));
+    tui.wait_for("zoomed queries pane", |screen| {
+        !screen.find_occurences("it-tui-panes").is_empty()
+            && screen.find_occurences("engine").is_empty()
+    });
+    tui.send(Event::CtrlChar('x'));
+    tui.wait_for("unzoomed panes", |screen| {
+        !screen.find_occurences("it-tui-panes").is_empty()
+            && !screen.find_occurences("engine").is_empty()
+    });
+
+    // 'l' on the selected query opens its logs in a pane (the default),
+    // Ctrl+x zooms it even though the log view is the focused one
+    tui.send(Event::Key(cursive::event::Key::Down));
+    tui.send(Event::Char('l'));
+    tui.wait_for("logs pane", |screen| {
+        !screen.find_occurences("Logs:").is_empty()
+            && !screen.find_occurences("it-tui-panes").is_empty()
+    });
+    tui.send(Event::CtrlChar('x'));
+    tui.wait_for("zoomed logs pane", |screen| {
+        !screen.find_occurences("Logs:").is_empty()
+            && screen.find_occurences("it-tui-panes").is_empty()
+    });
+    tui.send(Event::CtrlChar('x'));
+
+    // q closes the focused (logs) pane, then the tables pane
+    tui.send(Event::Char('q'));
+    tui.wait_for("queries and tables panes again", |screen| {
+        screen.find_occurences("Logs:").is_empty()
+            && !screen.find_occurences("it-tui-panes").is_empty()
+            && !screen.find_occurences("engine").is_empty()
+    });
+    tui.send(Event::Char('q'));
+    tui.wait_for("single pane", |screen| {
+        screen.find_occurences("engine").is_empty()
+            || screen.find_occurences("it-tui-panes").is_empty()
+    });
+
+    kill_query(server, "it-tui-panes", &mut child);
+    tui.quit();
+}
+
+// Logs pane after a view replacement: switching a view collapses the Mux tree
+// to a root leaf, adding the logs pane next to it must stay inside the tree
+// (used to end up detached: invisible, but querying).
+async fn test_table_logs_pane() {
+    let Some(server) = common::server() else {
+        return;
+    };
+    let serial = serial_lock();
+    let tui = Tui::start(server, serial);
+    tui.wait_for_text("Queries (");
+
+    // Switch the pane to the Tables view
+    tui.send(Event::Key(cursive::event::Key::F2));
+    tui.send(Event::Char('T'));
+    tui.send(Event::Key(cursive::event::Key::Enter));
+    tui.wait_for_text("MergeTree");
+
+    // Row submit opens the fuzzy actions dialog; Enter picks the first
+    // action ("Show table logs")
+    tui.send(Event::Key(cursive::event::Key::Down));
+    tui.send(Event::Key(cursive::event::Key::Enter));
+    tui.wait_for_text("Fuzzy search");
+    tui.send(Event::Key(cursive::event::Key::Enter));
+    tui.wait_for_text("Logs:");
+
+    tui.quit();
+}
+
+// Click-to-focus must work for a pane that lost focus (the logs pane content
+// used to refuse take_focus, making it impossible to focus it back).
+async fn test_pane_click_focus() {
+    let Some(server) = common::server() else {
+        return;
+    };
+    let serial = serial_lock();
+    let mut child = server.spawn_query(
+        "it-tui-click",
+        "SELECT sum(sleep(0.5)) AS tui_marker_click FROM numbers(600) SETTINGS max_block_size=1",
+    );
+    wait_query_is_running(server, "it-tui-click");
+
+    let tui = Tui::start(server, serial);
+    tui.wait_for_text("tui_marker_click");
+    tui.send(Event::Key(cursive::event::Key::Down));
+    tui.send(Event::Char('l'));
+    tui.wait_for_text("Logs:");
+
+    let click = |x: usize, y: usize| Event::Mouse {
+        offset: Vec2::zero(),
+        position: Vec2::new(x, y),
+        event: cursive::event::MouseEvent::Press(cursive::event::MouseButton::Left),
+    };
+
+    // Focus the left (queries) pane by click, verify via zoom
+    tui.send(click(20, 10));
+    tui.send(Event::CtrlChar('x'));
+    tui.wait_for("zoomed queries", |screen| {
+        screen.find_occurences("Logs:").is_empty()
+            && !screen.find_occurences("it-tui-click").is_empty()
+    });
+    tui.send(Event::CtrlChar('x'));
+    tui.wait_for("unzoomed", |screen| {
+        !screen.find_occurences("Logs:").is_empty()
+    });
+
+    // Focus the right (logs) pane by click, verify via zoom
+    tui.send(click(150, 10));
+    tui.send(Event::CtrlChar('x'));
+    tui.wait_for("zoomed logs", |screen| {
+        !screen.find_occurences("Logs:").is_empty()
+            && screen.find_occurences("it-tui-click").is_empty()
+    });
+
+    kill_query(server, "it-tui-click", &mut child);
+    tui.quit();
+}
+
+common::integration_tests!(
+    test_pane_click_focus,
+    test_queries_view,
+    test_query_logs_view,
+    test_panes,
+    test_table_logs_pane
+);


### PR DESCRIPTION
### Changes
- Every view can be opened in a pane
- Query logs will be opened in a new pane by default (old popup behavior under setting)

### Shortcuts
- `Alt`+Arrows - navigation
- `Alt`+`-`/`=`s split pane right/below
- `Ctrl`+Arrows - resize
- `Ctrl`-`x` - zoom

### Limitations
- Only unique views can be opened in parallel

Fixes: https://github.com/azat/chdig/issues/164