### PR TITLE
tests: truncate only MergeTree log tables (fixes integration tests)

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -460,19 +460,34 @@ fn cleanup_stale_dirs(target_tmpdir: &Path) {
 /// Shared server for the whole test binary. None (with a message) if there is no clickhouse
 /// binary around, so that plain `cargo test` still passes in environments without it.
 pub fn server() -> Option<&'static ClickHouseServer> {
-    static SERVER: OnceLock<Option<ClickHouseServer>> = OnceLock::new();
-    SERVER
-        .get_or_init(|| match find_clickhouse_binary() {
-            Some(binary) => Some(ClickHouseServer::start(binary)),
-            None => {
-                eprintln!(
-                    "integration tests are skipped: no 'clickhouse' binary in PATH \
-                     (set CLICKHOUSE_BINARY to override)"
-                );
-                None
-            }
-        })
-        .as_ref()
+    // A panicking initializer does not poison the OnceLock: it reverts to uninitialized and the
+    // next test would re-run the bootstrap against the leftover (still running) server, dying on
+    // its data/status lock. Attempt the bootstrap once and replay the original failure instead.
+    static SERVER: OnceLock<Result<Option<ClickHouseServer>, String>> = OnceLock::new();
+    match SERVER.get_or_init(|| match find_clickhouse_binary() {
+        Some(binary) => std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            ClickHouseServer::start(binary)
+        }))
+        .map(Some)
+        .map_err(|panic| {
+            panic
+                .downcast_ref::<String>()
+                .map(String::as_str)
+                .or_else(|| panic.downcast_ref::<&str>().copied())
+                .unwrap_or("unknown panic")
+                .to_string()
+        }),
+        None => {
+            eprintln!(
+                "integration tests are skipped: no 'clickhouse' binary in PATH \
+                 (set CLICKHOUSE_BINARY to override)"
+            );
+            Ok(None)
+        }
+    }) {
+        Ok(server) => server.as_ref(),
+        Err(reason) => panic!("shared server bootstrap failed earlier: {reason}"),
+    }
 }
 
 /// Like server(), but additionally skips the test if this server version does not have the table.

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -292,8 +292,11 @@ impl ClickHouseServer {
     }
 
     fn truncate_log_tables(&self) {
+        // Only MergeTree tables: since 26.8 the pattern also matches built-in system tables
+        // (system.user_query_log, engine SystemUserQueryLog) that do not support TRUNCATE
         let tables = self.query(
-            "SELECT name FROM system.tables WHERE database = 'system' AND name LIKE '%\\_log'",
+            "SELECT name FROM system.tables WHERE database = 'system' AND name LIKE '%\\_log' \
+             AND engine LIKE '%MergeTree'",
         );
         for table in tables.lines() {
             self.query(&format!("TRUNCATE TABLE system.{table}"));


### PR DESCRIPTION
Since 26.8 '%_log' also matches system.user_query_log (engine SystemUserQueryLog) which does not support TRUNCATE, panicking the shared-server bootstrap and cascading into "Another server instance is already running" for every later test.