### PR TITLE
Log viewer horizontal seek improvements

### DIFF
--- a/src/interpreter/options.rs
+++ b/src/interpreter/options.rs
@@ -412,6 +412,11 @@ pub struct ViewOptions {
     #[arg(long, action = ArgAction::SetTrue)]
     pub wrap: bool,
 
+    /// Pad log columns (host, thread_id, query_id, level, logger_name) to a
+    /// common width (makes seeking by columns exact)
+    #[arg(long, action = ArgAction::SetTrue)]
+    pub align_log_columns: bool,
+
     /// Open logs (query logs, table logs, ...) in a dialog instead of a split pane
     #[arg(long, action = ArgAction::SetTrue)]
     pub logs_in_dialog: bool,
@@ -561,6 +566,7 @@ struct ChDigViewConfig {
     start: Option<String>,
     end: Option<String>,
     wrap: Option<bool>,
+    align_log_columns: Option<bool>,
     no_strip_hostname_suffix: Option<bool>,
     no_color: Option<bool>,
     queries_limit: Option<u64>,
@@ -790,6 +796,11 @@ fn apply_chdig_config(options: &mut ChDigOptions, config: &ChDigConfig) {
         && let Some(wrap) = view.wrap
     {
         options.view.wrap = wrap;
+    }
+    if !options.view.align_log_columns
+        && let Some(align) = view.align_log_columns
+    {
+        options.view.align_log_columns = align;
     }
     if !options.view.no_strip_hostname_suffix
         && let Some(no_strip) = view.no_strip_hostname_suffix

--- a/src/view/log_view.rs
+++ b/src/view/log_view.rs
@@ -142,7 +142,20 @@ impl LogEntry {
         cluster: bool,
         identifier_maps: Option<&IdentifierMaps>,
     ) -> StyledString {
+        self.to_styled_string_and_column_offsets(cluster, identifier_maps)
+            .0
+    }
+
+    // Renders the line and also returns the display offsets where each
+    // seekable column starts: date, time, thread_id, query_id, level,
+    // logger_name (used for horizontal seeking by columns).
+    fn to_styled_string_and_column_offsets(
+        &self,
+        cluster: bool,
+        identifier_maps: Option<&IdentifierMaps>,
+    ) -> (StyledString, Vec<usize>) {
         let mut line = StyledString::new();
+        let mut column_offsets = Vec::with_capacity(6);
 
         if cluster {
             line.append_plain("[");
@@ -162,19 +175,24 @@ impl LogEntry {
         // Format timestamp with microseconds matching ClickHouse format: YYYY.MM.DD HH:MM:SS.microseconds
         let dt = self.event_time_microseconds;
         let microseconds = dt.timestamp_subsec_micros();
-        let timestamp = format!(
-            "{:04}.{:02}.{:02} {:02}:{:02}:{:02}.{:06}",
+        column_offsets.push(line.width());
+        line.append_plain(format!(
+            "{:04}.{:02}.{:02} ",
             dt.year(),
             dt.month(),
-            dt.day(),
+            dt.day()
+        ));
+        column_offsets.push(line.width());
+        line.append_plain(format!(
+            "{:02}:{:02}:{:02}.{:06} ",
             dt.hour(),
             dt.minute(),
             dt.second(),
             microseconds
-        );
-        line.append_plain(format!("{} ", timestamp));
+        ));
 
         // Thread ID with hash-based coloring: [ thread_id ]
+        column_offsets.push(line.width());
         line.append_plain("[ ");
         let thread_hash = int_hash_64(self.thread_id);
         let thread_color = hash_to_color(thread_hash);
@@ -183,6 +201,7 @@ impl LogEntry {
 
         // Query ID with hash-based coloring: {query_id}
         // ClickHouse writes query_id even if empty for log parser convenience
+        column_offsets.push(line.width());
         line.append_plain("{");
         let query_id_str = self.query_id.as_deref().unwrap_or("");
         if !query_id_str.is_empty() {
@@ -199,6 +218,7 @@ impl LogEntry {
         line.append_plain("} ");
 
         // Priority level with color: <level>
+        column_offsets.push(line.width());
         line.append_plain("<");
         let level_color = get_level_color(self.level.as_str());
         line.append_styled(self.level.as_str(), level_color);
@@ -211,6 +231,7 @@ impl LogEntry {
 
         // Logger name (source) with hash-based coloring: source:
         if let Some(logger_name) = &self.logger_name {
+            column_offsets.push(line.width());
             let logger_hash = string_hash(logger_name);
             let logger_color = hash_to_color(logger_hash);
             line.append_styled(logger_name, logger_color);
@@ -225,7 +246,7 @@ impl LogEntry {
 
         // Message
         line.append_plain(self.message.as_str());
-        return line;
+        return (line, column_offsets);
     }
 }
 
@@ -415,6 +436,66 @@ impl LogViewBase {
                 .copied()
                 .unwrap_or(0)
         }
+    }
+
+    // Horizontal seeking by columns: jump to the start of the next/previous
+    // column (date, time, thread_id, query_id, level, logger_name); past the
+    // last column seek by half of the viewport width.
+    //
+    // Field widths vary per line (empty query_id vs UUID, thread ids, ...),
+    // so the seek grid is the per-column maximum of the start offsets across
+    // the visible lines: each stop is past the given field of every line.
+    fn seek_columns(&mut self, forward: bool) {
+        let viewport = self.scroll_core.content_viewport();
+        let x = viewport.left();
+        let half = self.scroll_core.last_available_size().x / 2;
+
+        let identifier_maps = self.get_identifier_maps();
+        let mut offsets: Vec<usize> = Vec::new();
+        let mut prev_log_idx = usize::MAX;
+        for row in viewport.top()..=viewport.bottom() {
+            let Some((log_idx, _)) = self.display_row_to_log(row) else {
+                break;
+            };
+            if log_idx == prev_log_idx {
+                continue;
+            }
+            prev_log_idx = log_idx;
+
+            let line_offsets = self
+                .with_visible_log(log_idx, |log| {
+                    log.to_styled_string_and_column_offsets(self.cluster, identifier_maps.as_ref())
+                        .1
+                })
+                .unwrap_or_default();
+            if offsets.len() < line_offsets.len() {
+                offsets.resize(line_offsets.len(), 0);
+            }
+            for (offset, line_offset) in offsets.iter_mut().zip(line_offsets) {
+                *offset = usize::max(*offset, line_offset);
+            }
+        }
+
+        let target = if forward {
+            offsets
+                .iter()
+                .copied()
+                .find(|&offset| offset > x)
+                .unwrap_or(x + half)
+        } else {
+            let last = offsets.last().copied().unwrap_or(0);
+            if x > last {
+                usize::max(last, x.saturating_sub(half))
+            } else {
+                offsets
+                    .iter()
+                    .rev()
+                    .copied()
+                    .find(|&offset| offset < x)
+                    .unwrap_or(0)
+            }
+        };
+        self.scroll_core.set_offset((target, viewport.top()));
     }
 
     fn extract_identifiers(&mut self) {
@@ -1381,8 +1462,18 @@ impl LogView {
         let v = OnEventView::new(v)
             .on_pre_event_inner(Key::PageUp, scroll)
             .on_pre_event_inner(Key::PageDown, scroll)
-            .on_pre_event_inner(Key::Left, scroll)
-            .on_pre_event_inner(Key::Right, scroll)
+            .on_pre_event_inner(Key::Left, |v, _| {
+                let mut base = v.get_mut();
+                base.matched_row = None;
+                base.seek_columns(false);
+                Some(EventResult::consumed())
+            })
+            .on_pre_event_inner(Key::Right, |v, _| {
+                let mut base = v.get_mut();
+                base.matched_row = None;
+                base.seek_columns(true);
+                Some(EventResult::consumed())
+            })
             .on_pre_event_inner(Key::Up, scroll)
             .on_pre_event_inner(Key::Down, scroll)
             .on_pre_event_inner('j', move |v, _| scroll(v, &Event::Key(Key::Down)))

--- a/src/view/log_view.rs
+++ b/src/view/log_view.rs
@@ -132,33 +132,43 @@ struct IdentifierMaps {
     host_name_map: HashMap<String, String>,
 }
 
+// Maximum display width of each log column, so that every line can be padded
+// to a common grid (host is only rendered in cluster mode)
+#[derive(Default, Clone, Copy, PartialEq)]
+struct ColumnWidths {
+    host: usize,
+    thread: usize,
+    query_id: usize,
+    level: usize,
+    logger: usize,
+}
+
+// Pad the field that started at display offset `start` to `width` columns
+fn pad_column(line: &mut StyledString, start: usize, width: usize) {
+    let written = line.width() - start;
+    if written < width {
+        line.append_plain(" ".repeat(width - written));
+    }
+}
+
 impl LogEntry {
-    fn to_styled_string(&self, cluster: bool) -> StyledString {
-        self.to_styled_string_with_identifiers(cluster, None)
-    }
-
-    fn to_styled_string_with_identifiers(
-        &self,
-        cluster: bool,
-        identifier_maps: Option<&IdentifierMaps>,
-    ) -> StyledString {
-        self.to_styled_string_and_column_offsets(cluster, identifier_maps)
-            .0
-    }
-
     // Renders the line and also returns the display offsets where each
     // seekable column starts: date, time, thread_id, query_id, level,
     // logger_name (used for horizontal seeking by columns).
+    // With column_widths set, each field is padded to the column width so
+    // that all lines share the same grid.
     fn to_styled_string_and_column_offsets(
         &self,
         cluster: bool,
         identifier_maps: Option<&IdentifierMaps>,
+        column_widths: Option<&ColumnWidths>,
     ) -> (StyledString, Vec<usize>) {
         let mut line = StyledString::new();
         let mut column_offsets = Vec::with_capacity(6);
 
         if cluster {
             line.append_plain("[");
+            let start = line.width();
             let host_hash = string_hash(&self.host_name);
             let host_color = hash_to_color(host_hash);
             let display_name = self.display_host_name.as_ref().unwrap_or(&self.host_name);
@@ -168,6 +178,9 @@ impl LogEntry {
                 && let Some(id) = maps.host_name_map.get(&self.host_name)
             {
                 line.append_styled(format!("[{}]", id), Color::Rgb(255, 255, 0));
+            }
+            if let Some(widths) = column_widths {
+                pad_column(&mut line, start, widths.host);
             }
             line.append_plain("] ");
         }
@@ -196,13 +209,21 @@ impl LogEntry {
         line.append_plain("[ ");
         let thread_hash = int_hash_64(self.thread_id);
         let thread_color = hash_to_color(thread_hash);
-        line.append_styled(format!("{}", self.thread_id), thread_color);
+        let thread_str = format!("{}", self.thread_id);
+        // Numbers are right-aligned
+        if let Some(widths) = column_widths
+            && widths.thread > thread_str.len()
+        {
+            line.append_plain(" ".repeat(widths.thread - thread_str.len()));
+        }
+        line.append_styled(thread_str, thread_color);
         line.append_plain(" ] ");
 
         // Query ID with hash-based coloring: {query_id}
         // ClickHouse writes query_id even if empty for log parser convenience
         column_offsets.push(line.width());
         line.append_plain("{");
+        let start = line.width();
         let query_id_str = self.query_id.as_deref().unwrap_or("");
         if !query_id_str.is_empty() {
             let query_hash = string_hash(query_id_str);
@@ -215,11 +236,15 @@ impl LogEntry {
                 line.append_styled(format!("[{}]", id), Color::Rgb(255, 255, 0));
             }
         }
+        if let Some(widths) = column_widths {
+            pad_column(&mut line, start, widths.query_id);
+        }
         line.append_plain("} ");
 
         // Priority level with color: <level>
         column_offsets.push(line.width());
         line.append_plain("<");
+        let start = line.width();
         let level_color = get_level_color(self.level.as_str());
         line.append_styled(self.level.as_str(), level_color);
         if let Some(maps) = identifier_maps
@@ -227,11 +252,15 @@ impl LogEntry {
         {
             line.append_styled(format!("[{}]", id), Color::Rgb(255, 255, 0));
         }
+        if let Some(widths) = column_widths {
+            pad_column(&mut line, start, widths.level);
+        }
         line.append_plain("> ");
 
         // Logger name (source) with hash-based coloring: source:
         if let Some(logger_name) = &self.logger_name {
             column_offsets.push(line.width());
+            let start = line.width();
             let logger_hash = string_hash(logger_name);
             let logger_color = hash_to_color(logger_hash);
             line.append_styled(logger_name, logger_color);
@@ -242,6 +271,14 @@ impl LogEntry {
                 line.append_styled(format!("[{}]", id), Color::Rgb(255, 255, 0));
             }
             line.append_plain(": ");
+            if let Some(widths) = column_widths {
+                pad_column(&mut line, start, widths.logger + 2);
+            }
+        } else if let Some(widths) = column_widths
+            && widths.logger > 0
+        {
+            // Keep the message aligned with the lines that do have a logger
+            line.append_plain(" ".repeat(widths.logger + 2));
         }
 
         // Message
@@ -278,6 +315,13 @@ pub struct LogViewBase {
     wrap: bool,
     no_strip_hostname_suffix: bool,
     descending: bool,
+
+    // Pad columns to a common width (of the widest value seen so far)
+    align_columns: bool,
+    // Widths of the raw values, and the effective widths used for rendering
+    // (in filter mode the latter also accounts for the "[q1]" identifier tags)
+    raw_column_widths: ColumnWidths,
+    column_widths: ColumnWidths,
 
     // True until the first fetch finishes, to distinguish "Loading..." from "No logs"
     loading: bool,
@@ -323,6 +367,9 @@ impl Default for LogViewBase {
             wrap: false,
             no_strip_hostname_suffix: false,
             descending: false,
+            align_columns: false,
+            raw_column_widths: ColumnWidths::default(),
+            column_widths: ColumnWidths::default(),
             loading: true,
             filter_mode: false,
             filter_identifiers: HashMap::new(),
@@ -349,6 +396,53 @@ impl LogViewBase {
             self.filtered_log_indices
                 .get(visible_idx)
                 .and_then(|&idx| self.logs.with_entry(idx, f))
+        }
+    }
+
+    fn render_log(
+        &self,
+        log: &LogEntry,
+        identifier_maps: Option<&IdentifierMaps>,
+    ) -> (StyledString, Vec<usize>) {
+        log.to_styled_string_and_column_offsets(
+            self.cluster,
+            identifier_maps,
+            self.align_columns.then_some(&self.column_widths),
+        )
+    }
+
+    // Recompute the effective column widths; on change the row cache is
+    // invalidated (the cached widths/rows were rendered with the old padding)
+    fn refresh_column_widths(&mut self) {
+        if !self.align_columns {
+            return;
+        }
+
+        let mut widths = self.raw_column_widths;
+        if self.filter_mode {
+            // In filter mode every distinct value gets a "[q1]"-style tag
+            // appended, so reserve the widest tag per category on top of the
+            // raw width (a slight over-estimation for the widest value)
+            let mut tags = ColumnWidths::default();
+            for (id, filter_type) in &self.filter_identifiers {
+                let tag = id.width() + 2;
+                let max_tag = match filter_type {
+                    FilterType::QueryId(_) => &mut tags.query_id,
+                    FilterType::LoggerName(_) => &mut tags.logger,
+                    FilterType::Level(_) => &mut tags.level,
+                    FilterType::HostName(_) => &mut tags.host,
+                };
+                *max_tag = usize::max(*max_tag, tag);
+            }
+            widths.host += tags.host;
+            widths.query_id += tags.query_id;
+            widths.level += tags.level;
+            widths.logger += tags.logger;
+        }
+
+        if widths != self.column_widths {
+            self.column_widths = widths;
+            self.log_cumulative_rows.clear();
         }
     }
 
@@ -464,8 +558,7 @@ impl LogViewBase {
 
             let line_offsets = self
                 .with_visible_log(log_idx, |log| {
-                    log.to_styled_string_and_column_offsets(self.cluster, identifier_maps.as_ref())
-                        .1
+                    self.render_log(log, identifier_maps.as_ref()).1
                 })
                 .unwrap_or_default();
             if offsets.len() < line_offsets.len() {
@@ -555,18 +648,21 @@ impl LogViewBase {
     }
 
     fn rebuild_content_with_highlights(&mut self) {
+        self.refresh_column_widths();
         self.filtered_log_indices.clear();
         self.needs_relayout = true;
         self.compute_rows();
     }
 
     fn rebuild_content_normal(&mut self) {
+        self.refresh_column_widths();
         self.filtered_log_indices.clear();
         self.needs_relayout = true;
         self.compute_rows();
     }
 
     fn apply_filter(&mut self) {
+        self.refresh_column_widths();
         self.filtered_log_indices.clear();
 
         if let Some(ref filter) = self.active_filter {
@@ -633,11 +729,7 @@ impl LogViewBase {
         forward: bool,
     ) -> bool {
         let styled = self.with_visible_log(log_idx, |log| {
-            if let Some(maps) = identifier_maps {
-                log.to_styled_string_with_identifiers(self.cluster, Some(maps))
-            } else {
-                log.to_styled_string(self.cluster)
-            }
+            self.render_log(log, identifier_maps.as_ref()).0
         });
         if let Some(mut styled) = styled {
             styled.append("\n");
@@ -788,6 +880,26 @@ impl LogViewBase {
             }
         }
 
+        {
+            let widths = &mut self.raw_column_widths;
+            for log in &logs {
+                let host = log.display_host_name.as_ref().unwrap_or(&log.host_name);
+                widths.host = usize::max(widths.host, host.width());
+                widths.thread = usize::max(
+                    widths.thread,
+                    (log.thread_id.checked_ilog10().unwrap_or(0) + 1) as usize,
+                );
+                if let Some(ref query_id) = log.query_id {
+                    widths.query_id = usize::max(widths.query_id, query_id.width());
+                }
+                widths.level = usize::max(widths.level, log.level.width());
+                if let Some(ref logger_name) = log.logger_name {
+                    widths.logger = usize::max(widths.logger, logger_name.width());
+                }
+            }
+        }
+        self.refresh_column_widths();
+
         if new_batch {
             self.stream_insert_pos = 0;
         }
@@ -890,11 +1002,7 @@ impl LogViewBase {
         // every entry from the store, i.e. the whole backing file.
         for i in start_idx..visible_count {
             let counts = self.with_visible_log(i, |log| {
-                let mut styled = if let Some(ref maps) = identifier_maps {
-                    log.to_styled_string_with_identifiers(self.cluster, Some(maps))
-                } else {
-                    log.to_styled_string(self.cluster)
-                };
+                let mut styled = self.render_log(log, identifier_maps.as_ref()).0;
                 styled.append("\n");
 
                 let mut row_count = 0;
@@ -985,11 +1093,7 @@ impl LogViewBase {
             // Binary search to find which log this display row belongs to
             if let Some((log_idx, row_within_log)) = self.display_row_to_log(display_row)
                 && let Some(mut styled) = self.with_visible_log(log_idx, |log| {
-                    if let Some(ref maps) = identifier_maps {
-                        log.to_styled_string_with_identifiers(self.cluster, Some(maps))
-                    } else {
-                        log.to_styled_string(self.cluster)
-                    }
+                    self.render_log(log, identifier_maps.as_ref()).0
                 })
             {
                 styled.append("\n");
@@ -1068,7 +1172,7 @@ impl LogViewBase {
 
         for i in 0..visible_count {
             let result = self.with_visible_log(i, |log| -> Result<()> {
-                let mut styled = log.to_styled_string(self.cluster);
+                let mut styled = self.render_log(log, None).0;
                 styled.append("\n");
 
                 for row in LinesIterator::new(&styled, self.last_computed_width) {
@@ -1228,6 +1332,7 @@ impl LogView {
         wrap: bool,
         no_strip_hostname_suffix: bool,
         descending: bool,
+        align_columns: bool,
     ) -> Self {
         let mut v = LogViewBase {
             needs_relayout: true,
@@ -1235,6 +1340,7 @@ impl LogView {
             wrap,
             no_strip_hostname_suffix,
             descending,
+            align_columns,
             ..Default::default()
         };
         // In descending mode the newest log goes on top, so pin the viewport there and

--- a/src/view/log_view.rs
+++ b/src/view/log_view.rs
@@ -153,8 +153,9 @@ fn pad_column(line: &mut StyledString, start: usize, width: usize) {
 
 impl LogEntry {
     // Renders the line and also returns the display offsets where each
-    // seekable column starts: date, time, thread_id, query_id, level,
-    // logger_name (used for horizontal seeking by columns).
+    // seekable column starts, always 7 entries: date, time, thread_id,
+    // query_id, level, logger_name, message (used for horizontal seeking by
+    // columns, which relies on the positions being stable across lines).
     // With column_widths set, each field is padded to the column width so
     // that all lines share the same grid.
     fn to_styled_string_and_column_offsets(
@@ -164,7 +165,7 @@ impl LogEntry {
         column_widths: Option<&ColumnWidths>,
     ) -> (StyledString, Vec<usize>) {
         let mut line = StyledString::new();
-        let mut column_offsets = Vec::with_capacity(6);
+        let mut column_offsets = Vec::with_capacity(7);
 
         if cluster {
             line.append_plain("[");
@@ -274,14 +275,18 @@ impl LogEntry {
             if let Some(widths) = column_widths {
                 pad_column(&mut line, start, widths.logger + 2);
             }
-        } else if let Some(widths) = column_widths
-            && widths.logger > 0
-        {
-            // Keep the message aligned with the lines that do have a logger
-            line.append_plain(" ".repeat(widths.logger + 2));
+        } else {
+            column_offsets.push(line.width());
+            if let Some(widths) = column_widths
+                && widths.logger > 0
+            {
+                // Keep the message aligned with the lines that do have a logger
+                line.append_plain(" ".repeat(widths.logger + 2));
+            }
         }
 
         // Message
+        column_offsets.push(line.width());
         line.append_plain(self.message.as_str());
         return (line, column_offsets);
     }
@@ -297,6 +302,11 @@ enum FilterType {
 
 pub struct LogViewBase {
     max_width: usize,
+    // Largest message-column start: the horizontal scroll range is extended
+    // to max_message_offset + viewport width, so that seeking can bring any
+    // column to the left edge even when the lines (almost) fit the screen
+    // (the area right of a line's end is just blank)
+    max_message_offset: usize,
 
     content_size_with_wrap: Vec2,
     // Size without respecting wrap, since with wrap width is equal to the longest line
@@ -353,6 +363,7 @@ impl Default for LogViewBase {
     fn default() -> Self {
         Self {
             max_width: 0,
+            max_message_offset: 0,
             content_size_with_wrap: Vec2::zero(),
             screen_size_without_wrap: Vec2::zero(),
             needs_relayout: false,
@@ -988,6 +999,11 @@ impl LogViewBase {
         } else {
             0
         };
+        let mut max_message_offset = if can_do_incremental {
+            self.max_message_offset
+        } else {
+            0
+        };
         let mut cumulative = if can_do_incremental {
             *self.log_cumulative_rows.last().unwrap()
         } else {
@@ -1002,7 +1018,7 @@ impl LogViewBase {
         // every entry from the store, i.e. the whole backing file.
         for i in start_idx..visible_count {
             let counts = self.with_visible_log(i, |log| {
-                let mut styled = self.render_log(log, identifier_maps.as_ref()).0;
+                let (mut styled, offsets) = self.render_log(log, identifier_maps.as_ref());
                 styled.append("\n");
 
                 let mut row_count = 0;
@@ -1011,16 +1027,22 @@ impl LogViewBase {
                     row_max_width = usize::max(row_max_width, row.width);
                     row_count += 1;
                 }
-                (row_count, row_max_width)
+                (
+                    row_count,
+                    row_max_width,
+                    offsets.last().copied().unwrap_or(0),
+                )
             });
-            if let Some((row_count, row_max_width)) = counts {
+            if let Some((row_count, row_max_width, message_offset)) = counts {
                 max_width = usize::max(max_width, row_max_width);
+                max_message_offset = usize::max(max_message_offset, message_offset);
                 cumulative += row_count;
                 self.log_cumulative_rows.push(cumulative);
             }
         }
 
         self.max_width = max_width;
+        self.max_message_offset = max_message_offset;
         self.last_computed_width = width;
 
         log::trace!(
@@ -1079,6 +1101,14 @@ impl LogViewBase {
             total_rows
         };
         req.x = usize::max(req.x, self.max_width);
+        // Extend the scrollable width so that the message column can reach
+        // the left edge (see max_message_offset)
+        if !self.wrap && self.max_message_offset > 0 {
+            req.x = usize::max(
+                req.x,
+                self.max_message_offset + self.screen_size_without_wrap.x,
+            );
+        }
         return req;
     }
 

--- a/src/view/settings_view.rs
+++ b/src/view/settings_view.rs
@@ -43,6 +43,9 @@ fn apply_settings(siv: &mut Cursive, context: &ContextArc) {
     let wrap = siv
         .call_on_name("set_wrap", |v: &mut Checkbox| v.is_checked())
         .unwrap();
+    let align_log_columns = siv
+        .call_on_name("set_align_log_columns", |v: &mut Checkbox| v.is_checked())
+        .unwrap();
     let logs_in_dialog = siv
         .call_on_name("set_logs_in_dialog", |v: &mut Checkbox| v.is_checked())
         .unwrap();
@@ -215,6 +218,7 @@ fn apply_settings(siv: &mut Cursive, context: &ContextArc) {
         ctx.options.view.group_by = group_by;
         ctx.options.view.no_subqueries = no_subqueries;
         ctx.options.view.wrap = wrap;
+        ctx.options.view.align_log_columns = align_log_columns;
         ctx.options.view.logs_in_dialog = logs_in_dialog;
         ctx.options.view.no_strip_hostname_suffix = no_strip;
         ctx.options.view.no_color = no_color;
@@ -479,6 +483,11 @@ pub fn show_settings_dialog(siv: &mut Cursive) {
         opts.view.no_subqueries,
     );
     layout.checkbox("wrap", "set_wrap", opts.view.wrap);
+    layout.checkbox(
+        "align_log_columns",
+        "set_align_log_columns",
+        opts.view.align_log_columns,
+    );
     layout.checkbox(
         "logs_in_dialog",
         "set_logs_in_dialog",

--- a/src/view/text_log_view.rs
+++ b/src/view/text_log_view.rs
@@ -40,7 +40,7 @@ impl TextLogView {
         } = args;
         let last_event_time_microseconds = Arc::new(Mutex::new(start));
 
-        let (delay, is_cluster, wrap, no_strip_hostname_suffix, descending) = {
+        let (delay, is_cluster, wrap, no_strip_hostname_suffix, descending, align_columns) = {
             let ctx = context.lock().unwrap();
             // Only show hostname in logs when in cluster mode AND no host filter is active
             let show_hostname =
@@ -51,6 +51,7 @@ impl TextLogView {
                 ctx.options.view.wrap,
                 ctx.options.view.no_strip_hostname_suffix,
                 ctx.options.clickhouse.logs_order == crate::interpreter::options::LogsOrder::Desc,
+                ctx.options.view.align_log_columns,
             )
         };
 
@@ -126,7 +127,13 @@ impl TextLogView {
         }
 
         TextLogView {
-            inner_view: LogView::new(is_cluster, wrap, no_strip_hostname_suffix, descending),
+            inner_view: LogView::new(
+                is_cluster,
+                wrap,
+                no_strip_hostname_suffix,
+                descending,
+                align_columns,
+            ),
             last_event_time_microseconds,
             bg_runner,
         }


### PR DESCRIPTION
### Changes
- Seek by columns horizontally (date, time, thread_id, query_id, level, logger_name, 50% of the screen for message)
- Add ability to align columns to maximal width (for better scrolling experience) - OFF by default
- Allow to seek past the message (to avoid showing previous columns if they were seeked off)