### PR TITLE
Faster integration tests

### DIFF
--- a/src/common/relative_date_time.rs
+++ b/src/common/relative_date_time.rs
@@ -76,14 +76,14 @@ impl RelativeDateTime {
                 offset.num_nanoseconds()?
             )),
             (None, Some(offset)) => Some(format!(
-                "now() - INTERVAL {} NANOSECOND",
+                "now64(9) - INTERVAL {} NANOSECOND",
                 offset.num_nanoseconds()?
             )),
             (Some(date_time), None) => Some(format!(
                 "fromUnixTimestamp64Nano({})",
                 date_time.timestamp_nanos_opt()?
             )),
-            (None, None) => Some("now()".to_string()),
+            (None, None) => Some("now64(9)".to_string()),
         }
     }
 }

--- a/tests/tui.rs
+++ b/tests/tui.rs
@@ -131,12 +131,13 @@ impl Tui {
     }
 
     /// Wait until the predicate holds for a frame and return that frame.
+    /// The TUI loop emits a frame at least every 30ms on its own, so no
+    /// redraw has to be forced (a Refresh per frame would keep the loop
+    /// hot, spinning it at full speed for the whole wait).
     fn wait_for<F: Fn(&Screen) -> bool>(&self, what: &str, pred: F) -> Screen {
         let deadline = Instant::now() + Duration::from_secs(60);
         let mut last_screen = None;
         loop {
-            // Force a redraw, so that a new frame is always emitted
-            self.send(Event::Refresh);
             if let Ok(screen) = self.frames.recv_timeout(Duration::from_millis(200)) {
                 if pred(&screen) {
                     return screen;


### PR DESCRIPTION
Before

```
running 7 tests
test tests::integration ... ok
test tests::test_pane_click_focus ... ok
test tests::test_query_logs_view ... ok
test tests::test_settings_align_keeps_logs ... ok
test tests::test_table_logs_pane ... ok
test tests::test_panes ... ok
test tests::test_queries_view ... ok

test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 43.43s
```

And sometimes we even had tests that took > 60 seconds

```
test tests::test_settings_align_keeps_logs has been running for over 60 seconds
test tests::test_table_logs_pane has been running for over 60 seconds
```

Now:

```
running 7 tests
test tests::integration ... ok
test tests::test_panes ... ok
test tests::test_query_logs_view ... ok
test tests::test_queries_view ... ok
test tests::test_pane_click_focus ... ok
test tests::test_settings_align_keeps_logs ... ok
test tests::test_table_logs_pane ... ok

test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 13.01s
```