### PR TITLE
Fix columns width for asynchronous inserts

### DIFF
--- a/src/tui/views/providers/asynchronous_inserts.rs
+++ b/src/tui/views/providers/asynchronous_inserts.rs
@@ -118,6 +118,7 @@ pub fn show_asynchronous_inserts(
         query: build_query(&context, &filters, &columns),
         columns,
         columns_to_compare: vec!["first_update"],
+        wide_columns: vec!["query"],
     };
     super::present_query_table(app, context, spec, show_insert_details, presentation);
 }

--- a/src/tui/views/providers/asynchronous_metric_log.rs
+++ b/src/tui/views/providers/asynchronous_metric_log.rs
@@ -125,6 +125,7 @@ fn show_asynchronous_metric_log(app: &mut App, context: ContextArc) {
         "dyn",
         columns,
         columns_to_compare,
+        vec!["name"],
         query,
     )
     .unwrap_or_else(|_| panic!("Cannot create {}", view_name));

--- a/src/tui/views/providers/background_schedule_pool.rs
+++ b/src/tui/views/providers/background_schedule_pool.rs
@@ -203,6 +203,7 @@ pub fn show_background_schedule_pool(
         query: build_query(&context, &filters, &columns),
         columns,
         columns_to_compare,
+        wide_columns: vec!["log_name"],
     };
     super::present_query_table(
         app,

--- a/src/tui/views/providers/background_schedule_pool_log.rs
+++ b/src/tui/views/providers/background_schedule_pool_log.rs
@@ -188,6 +188,7 @@ pub fn show_background_schedule_pool_log(
         query: build_query(&context, &filters),
         columns: COLUMNS.to_vec(),
         columns_to_compare: vec!["event_time", "log_name", "database", "table"],
+        wide_columns: vec!["exception"],
     };
     super::present_query_table(app, context, spec, show_task_logs, presentation);
 }

--- a/src/tui/views/providers/backups.rs
+++ b/src/tui/views/providers/backups.rs
@@ -74,6 +74,7 @@ impl ViewProvider for BackupsViewProvider {
                 sort_by: "total_size",
                 columns,
                 columns_to_compare: vec!["name"],
+                wide_columns: vec!["name"],
                 on_submit: Some(backups_logs_callback),
                 settings: HashMap::<&str, i32>::new(),
             },

--- a/src/tui/views/providers/dictionaries.rs
+++ b/src/tui/views/providers/dictionaries.rs
@@ -40,6 +40,7 @@ impl ViewProvider for DictionariesViewProvider {
                 sort_by: "memory",
                 columns,
                 columns_to_compare: vec!["name"],
+                wide_columns: vec!["name", "last_exception"],
                 on_submit: Some(super::query_result_show_row),
                 settings: HashMap::<&str, i32>::new(),
             },

--- a/src/tui/views/providers/error_log.rs
+++ b/src/tui/views/providers/error_log.rs
@@ -75,6 +75,7 @@ impl ViewProvider for ErrorLogViewProvider {
             "total",
             columns,
             columns_to_compare,
+            vec!["name"],
             query,
         )
         .unwrap_or_else(|_| panic!("Cannot get {}", view_name));

--- a/src/tui/views/providers/errors.rs
+++ b/src/tui/views/providers/errors.rs
@@ -128,6 +128,7 @@ impl ViewProvider for ErrorsViewProvider {
             "total",
             columns,
             columns_to_compare,
+            vec!["name"],
             query,
         )
         .unwrap_or_else(|_| panic!("Cannot get errors"));

--- a/src/tui/views/providers/logger_names.rs
+++ b/src/tui/views/providers/logger_names.rs
@@ -148,6 +148,7 @@ impl ViewProvider for LoggerNamesViewProvider {
             "count",
             columns.clone(),
             columns_to_compare,
+            vec!["logger_name"],
             query,
         )
         .unwrap_or_else(|_| panic!("Cannot get logger_names"));

--- a/src/tui/views/providers/merges.rs
+++ b/src/tui/views/providers/merges.rs
@@ -139,6 +139,7 @@ pub fn show_merges(
         query: build_query(&context, &filters, &columns),
         columns,
         columns_to_compare,
+        wide_columns: vec!["part"],
     };
     super::present_query_table(app, context, spec, merges_logs_callback, presentation);
 }

--- a/src/tui/views/providers/metric_log.rs
+++ b/src/tui/views/providers/metric_log.rs
@@ -136,6 +136,7 @@ fn show_metric_log(app: &mut App, context: ContextArc) {
         "dyn",
         columns,
         columns_to_compare,
+        vec!["name"],
         query,
     )
     .unwrap_or_else(|_| panic!("Cannot create {}", view_name));

--- a/src/tui/views/providers/mod.rs
+++ b/src/tui/views/providers/mod.rs
@@ -258,6 +258,8 @@ pub struct QueryTableSpec {
     pub sort_by: &'static str,
     pub columns: Vec<&'static str>,
     pub columns_to_compare: Vec<&'static str>,
+    /// Columns that expand to fill the remaining width, all others are capped.
+    pub wide_columns: Vec<&'static str>,
     pub query: String,
 }
 
@@ -283,6 +285,7 @@ pub fn present_query_table<F>(
         spec.sort_by,
         spec.columns,
         spec.columns_to_compare,
+        spec.wide_columns,
         spec.query,
     )
     .unwrap_or_else(|_| panic!("Cannot create {}", spec.view_name));
@@ -451,6 +454,8 @@ pub struct RenderFromClickHouseQueryArguments<F, T> {
     pub sort_by: &'static str,
     pub columns: Vec<&'static str>,
     pub columns_to_compare: Vec<&'static str>,
+    /// Columns that expand to fill the remaining width, all others are capped.
+    pub wide_columns: Vec<&'static str>,
     pub on_submit: Option<F>,
     pub settings: HashMap<&'static str, T>,
 }
@@ -534,6 +539,7 @@ pub fn render_from_clickhouse_query<F, T>(
         params.sort_by,
         params.columns.clone(),
         params.columns_to_compare,
+        params.wide_columns,
         query,
     )
     .unwrap_or_else(|_| panic!("Cannot get {}", table_alias));

--- a/src/tui/views/providers/mutations.rs
+++ b/src/tui/views/providers/mutations.rs
@@ -90,6 +90,7 @@ pub fn show_mutations(
         query: build_query(&context, &filters, &columns),
         columns,
         columns_to_compare,
+        wide_columns: vec!["command", "latest_fail_reason"],
     };
     super::present_query_table(
         app,

--- a/src/tui/views/providers/object_storage_queue.rs
+++ b/src/tui/views/providers/object_storage_queue.rs
@@ -24,6 +24,7 @@ fn show_queue(app: &mut App, context: ContextArc, table: &'static [&'static str]
             sort_by: "start_time",
             columns,
             columns_to_compare: vec!["file_name"],
+            wide_columns: vec!["file_name", "exception"],
             on_submit: Some(super::query_result_show_row),
             settings: HashMap::<&str, i32>::new(),
         },

--- a/src/tui/views/providers/part_log.rs
+++ b/src/tui/views/providers/part_log.rs
@@ -188,6 +188,7 @@ pub fn show_part_log(
         query: build_query(&context, &filters, &columns),
         columns,
         columns_to_compare: vec!["event_time", "event_type", "part_name"],
+        wide_columns: vec!["exception"],
     };
     super::present_query_table(app, context, spec, part_log_action_callback, presentation);
 }

--- a/src/tui/views/providers/query_patterns.rs
+++ b/src/tui/views/providers/query_patterns.rs
@@ -282,6 +282,7 @@ fn build_and_install(app: &mut App, context: ContextArc) {
         "total",
         columns,
         columns_to_compare,
+        vec!["normalized_query"],
         query,
     )
     .unwrap_or_else(|_| panic!("Cannot create {}", VIEW_NAME));

--- a/src/tui/views/providers/replicas.rs
+++ b/src/tui/views/providers/replicas.rs
@@ -81,6 +81,7 @@ impl ViewProvider for ReplicasViewProvider {
             "queue",
             columns.clone(),
             columns_to_compare,
+            vec!["database", "table"],
             query,
         )
         .unwrap_or_else(|_| panic!("Cannot get replicas"));

--- a/src/tui/views/providers/replicated_fetches.rs
+++ b/src/tui/views/providers/replicated_fetches.rs
@@ -37,6 +37,7 @@ impl ViewProvider for ReplicatedFetchesViewProvider {
                 sort_by: "elapsed",
                 columns,
                 columns_to_compare: vec!["database", "table", "part"],
+                wide_columns: vec!["part"],
                 on_submit: Some(super::query_result_show_row),
                 settings: HashMap::<&str, i32>::new(),
             },

--- a/src/tui/views/providers/replication_queue.rs
+++ b/src/tui/views/providers/replication_queue.rs
@@ -40,6 +40,7 @@ impl ViewProvider for ReplicationQueueViewProvider {
                 sort_by: "tries",
                 columns,
                 columns_to_compare: vec!["database", "table", "type"],
+                wide_columns: vec!["exception", "reason"],
                 on_submit: Some(super::query_result_show_row),
                 settings: HashMap::<&str, i32>::new(),
             },

--- a/src/tui/views/providers/table_parts.rs
+++ b/src/tui/views/providers/table_parts.rs
@@ -190,6 +190,7 @@ pub fn show_table_parts(
         query: build_query(&context, &filters, &columns),
         columns,
         columns_to_compare: vec!["name"],
+        wide_columns: vec!["name"],
     };
     super::present_query_table(
         app,

--- a/src/tui/views/providers/tables.rs
+++ b/src/tui/views/providers/tables.rs
@@ -106,6 +106,7 @@ impl ViewProvider for TablesViewProvider {
             "total_bytes",
             columns.clone(),
             columns_to_compare,
+            vec!["database", "table"],
             query,
         )
         .unwrap_or_else(|_| panic!("Cannot get tables"));

--- a/src/tui/views/queries_view.rs
+++ b/src/tui/views/queries_view.rs
@@ -1099,6 +1099,7 @@ impl QueriesView {
                                 sort_by,
                                 columns,
                                 vec!["name"],
+                                vec!["name"],
                                 query,
                             )
                             .unwrap_or_else(|_| panic!("Cannot get {}", table))
@@ -1168,6 +1169,7 @@ impl QueriesView {
                                 table,
                                 sort_by,
                                 columns,
+                                vec!["view_name"],
                                 vec!["view_name"],
                                 query,
                             )

--- a/src/tui/views/sql_query_view.rs
+++ b/src/tui/views/sql_query_view.rs
@@ -576,6 +576,7 @@ impl SQLQueryView {
         sort_by: &'static str,
         columns: Vec<&'static str>,
         columns_to_compare: Vec<&'static str>,
+        wide_columns: Vec<&'static str>,
         query: String,
     ) -> Result<OnEventView<Self>> {
         // Shared by the closures below; Arc<str> (not &'static str) so that
@@ -606,6 +607,13 @@ impl SQLQueryView {
                     .unwrap_or_else(|| panic!("Column '{}' not found in columns list", col_name))
             })
             .collect();
+        for col_name in &wide_columns {
+            assert!(
+                columns.contains(col_name),
+                "Wide column '{}' not found in columns list",
+                col_name
+            );
+        }
 
         let mut table = TableView::<Row, u8>::new();
         for (i, column) in columns.iter().enumerate() {
@@ -614,11 +622,12 @@ impl SQLQueryView {
             }
             let min_width = column.len();
 
-            // Use width_min for columns in columns_to_compare (they should expand)
-            if columns_to_compare.contains(&i) {
+            // Wide columns expand to fill the remaining width, all others are
+            // capped at a reasonable maximum.
+            if wide_columns.contains(column) {
                 table.add_column(i as u8, column.to_string(), |c| c.width_min(min_width));
             } else {
-                let max_width = 20; // Reasonable max for most columns
+                let max_width = 20;
                 table.add_column(i as u8, column.to_string(), |c| {
                     c.width_min_max(min_width, max_width)
                 });


### PR DESCRIPTION
Wide (uncapped) columns were tied to columns_to_compare, but the async inserts identity must stay "first_update" (tail-f-like view) while "query" is what should expand. Split them: SQLQueryView::new() takes explicit wide_columns, and each view lists only genuinely long columns (queries, exceptions, long names) instead of its identity columns.