### PR TITLE
Implement auto-refresh of flamegraphs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -844,7 +844,7 @@ checksum = "26b73573e6edcd2af0cdf47bd6cb58f0b3839491263c314eaad1ccf24430e1de"
 [[package]]
 name = "flamelens"
 version = "0.4.0"
-source = "git+https://github.com/azat-rust/flamelens?branch=chdig#57c1e28065dd810cdbcd8e066e9e49df91f28228"
+source = "git+https://github.com/azat-rust/flamelens?branch=chdig#5751d22f5fc921395e29d17456782bcb3cb8cc9b"
 dependencies = [
  "anyhow",
  "cfg-if",

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ introspection, like `top` for Linux.
 ### Features
 
 - `top` like interface (or [`csysdig`](https://github.com/draios/sysdig) to be more precise)
-- [Flamegraphs](Documentation/FAQ.md#what-is-flamegraph) (CPU/Real/Memory/Live) in TUI (thanks to [flamelens](https://github.com/ys-l/flamelens))
+- [Flamegraphs](Documentation/FAQ.md#what-is-flamegraph) (CPU/Real/Memory/Live) in TUI (thanks to [flamelens](https://github.com/ys-l/flamelens)), auto-refreshed while the query is running (with changes since the previous refresh highlighted; `P` pauses, `D` toggles the diff coloring)
 - [Perfetto support](Documentation/FAQ.md#what-is-perfetto-export)
 - Share flamegraphs (using [pastila.nl](https://pastila.nl/) and [speedscope](https://www.speedscope.app/))
 - Share logs via [pastila.nl](https://pastila.nl/)

--- a/src/interpreter/flamegraph.rs
+++ b/src/interpreter/flamegraph.rs
@@ -38,6 +38,8 @@ fn run_flamelens(mut app: App) -> AppResult<()> {
 
     // Start the main loop.
     while app.running {
+        // Swaps in a pending live update, if any
+        app.tick();
         terminal.draw(|frame| {
             ui::render(&mut app, frame);
             if let Some(input_buffer) = &app.input_buffer
@@ -80,6 +82,12 @@ pub fn new_app(title: String, data: String) -> AppResult<App> {
 
     let flamegraph = FlameGraph::from_string(data, true);
     Ok(App::with_flamegraph(&title, flamegraph))
+}
+
+/// Unlike `new_app`, empty data is not an error: live updates will fill the
+/// graph in once samples arrive (e.g. after the first trace_log flush).
+pub fn new_live_app(title: String, data: String) -> App {
+    App::with_flamegraph(&title, FlameGraph::from_string(data, true))
 }
 
 /// A differential flamegraph: `after` rendered with per-frame coloring

--- a/src/interpreter/flamegraph.rs
+++ b/src/interpreter/flamegraph.rs
@@ -1,7 +1,8 @@
+use crate::interpreter::BackgroundRunner;
 use crate::interpreter::clickhouse::Columns;
 use crate::pastila;
 use anyhow::{Error, Result};
-use crossterm::event::{self, Event as CrosstermEvent, KeyEventKind};
+use crossterm::event::{self, Event as CrosstermEvent, KeyCode, KeyEventKind};
 use flamelens::app::{App, AppResult};
 use flamelens::flame::FlameGraph;
 use flamelens::handler::handle_key_events;
@@ -29,7 +30,7 @@ pub fn block_to_folded(block: &Columns) -> String {
         .join("\n")
 }
 
-fn run_flamelens(mut app: App) -> AppResult<()> {
+fn run_flamelens(mut app: App, mut refresh: Option<&mut BackgroundRunner>) -> AppResult<()> {
     let backend = CrosstermBackend::new(io::stderr());
     let mut terminal = Terminal::new(backend)?;
     let timeout = std::time::Duration::from_secs(1);
@@ -55,7 +56,17 @@ fn run_flamelens(mut app: App) -> AppResult<()> {
             match event::read().expect("unable to read event") {
                 CrosstermEvent::Key(e) => {
                     if e.kind == KeyEventKind::Press {
-                        handle_key_events(e, &mut app)?
+                        // In live mode r/R force a refresh instead of
+                        // flamelens's reset (Esc covers that); not while
+                        // typing into the search buffer.
+                        if matches!(e.code, KeyCode::Char('r' | 'R'))
+                            && app.input_buffer.is_none()
+                            && let Some(runner) = refresh.as_deref_mut()
+                        {
+                            runner.schedule();
+                        } else {
+                            handle_key_events(e, &mut app)?
+                        }
                     }
                 }
                 CrosstermEvent::Mouse(_e) => {}
@@ -105,8 +116,8 @@ pub fn new_diff_app(title: String, before: String, after: String) -> AppResult<A
 
 /// Fullscreen terminal takeover with flamelens's own event loop (the
 /// alternative is embedding it in a pane, see `tui::views::FlamelensView`).
-pub fn show(app: App) -> AppResult<()> {
-    run_flamelens(app)
+pub fn show(app: App, refresh: Option<&mut BackgroundRunner>) -> AppResult<()> {
+    run_flamelens(app, refresh)
 }
 
 pub async fn share(

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -19,6 +19,7 @@ pub use context::Context;
 pub use context::ContextArc;
 pub use worker::EventOwner;
 pub use worker::Worker;
+pub use worker::{FlamegraphSlot, FlamegraphSource};
 pub(crate) use worker::{
     fetch_and_populate_perfetto_trace, fetch_server_perfetto_sources,
     stream_queries_into_perfetto_trace,

--- a/src/interpreter/worker.rs
+++ b/src/interpreter/worker.rs
@@ -3,7 +3,7 @@ use crate::{
     interpreter::{
         ContextArc, Query,
         clickhouse::{
-            ClickHouse, TextLogArguments, TraceType, parse_metric_log_block,
+            ClickHouse, Columns, TextLogArguments, TraceType, parse_metric_log_block,
             parse_query_metric_log_block,
         },
         flamegraph,
@@ -62,6 +62,30 @@ impl std::fmt::Debug for OpaquePayload<Vec<Query>> {
     }
 }
 
+/// Feed of a live flamelens app (flamelens swaps the deposited graph in on
+/// tick()), written by the worker directly, not via UiSink: the fullscreen
+/// flamelens loop blocks the UI thread and never runs UiSink callbacks.
+pub type FlamegraphSlot = Arc<Mutex<Option<flamelens::app::ParsedFlameGraph>>>;
+
+impl std::fmt::Debug for OpaquePayload<FlamegraphSlot> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "<flamegraph slot>")
+    }
+}
+
+// How to (re-)fetch a flamegraph, for the periodic live updates
+#[derive(Debug, Clone)]
+pub enum FlamegraphSource {
+    TraceLog {
+        trace_type: TraceType,
+        query_ids: Option<Vec<String>>,
+        start: RelativeDateTime,
+        end: RelativeDateTime,
+    },
+    StackTrace(Option<Vec<String>>),
+    Jemalloc,
+}
+
 #[derive(Debug, Clone)]
 pub enum Event {
     // [filter, limit]
@@ -73,7 +97,7 @@ pub enum Event {
     // (view_name, args)
     TextLog(&'static str, TextLogArguments),
     // [bool (true - show in TUI, false - share via pastila), type, start, end]
-    ServerFlameGraph(bool, TraceType, DateTime<Local>, DateTime<Local>),
+    ServerFlameGraph(bool, TraceType, RelativeDateTime, RelativeDateTime),
     // [bool (true - show in TUI, false - share via pastila)]
     JemallocFlameGraph(bool),
     // (type, bool (true - show in TUI, false - open in browser), start time, end time, [query_ids])
@@ -95,6 +119,9 @@ pub enum Event {
     ),
     // [bool (true - show in TUI, false - open in browser), query_ids]
     LiveQueryFlameGraph(bool, Option<Vec<String>>),
+    // Periodic refresh of a live flamegraph: deposits the new graph into the
+    // flamelens app's slot instead of opening a new view
+    UpdateFlameGraph(FlamegraphSource, OpaquePayload<FlamegraphSlot>),
     Summary,
     // query_id
     KillQuery(String),
@@ -156,6 +183,7 @@ impl Event {
             Event::QueryFlameGraph(..) => "QueryFlameGraph".to_string(),
             Event::QueryFlameGraphDiff(..) => "QueryFlameGraphDiff".to_string(),
             Event::LiveQueryFlameGraph(..) => "LiveQueryFlameGraph".to_string(),
+            Event::UpdateFlameGraph(..) => "UpdateFlameGraph".to_string(),
             Event::Summary => "Summary".to_string(),
             Event::KillQuery(..) => "KillQuery".to_string(),
             Event::ExecuteQuery(..) => "ExecuteQuery".to_string(),
@@ -638,19 +666,56 @@ fn update_statusbar(cb_sink: &UiSink, message: &str) {
         .unwrap_or_default();
 }
 
+async fn fetch_flamegraph(
+    clickhouse: &ClickHouse,
+    source: &FlamegraphSource,
+    selected_host: Option<&String>,
+) -> Result<Columns> {
+    match source {
+        FlamegraphSource::TraceLog {
+            trace_type,
+            query_ids,
+            start,
+            end,
+        } => {
+            clickhouse
+                .get_flamegraph(
+                    trace_type.clone(),
+                    query_ids.as_deref(),
+                    Some(start.clone().into()),
+                    Some(end.clone().into()),
+                    selected_host,
+                )
+                .await
+        }
+        FlamegraphSource::StackTrace(query_ids) => {
+            clickhouse
+                .get_live_query_flamegraph(query_ids, selected_host)
+                .await
+        }
+        FlamegraphSource::Jemalloc => clickhouse.get_jemalloc_flamegraph(selected_host).await,
+    }
+}
+
 async fn render_or_share_flamegraph(
     tui: bool,
     cb_sink: UiSink,
     title: String,
     data: String,
     pastila: pastila::PastilaConfig,
+    live: Option<FlamegraphSource>,
 ) -> Result<()> {
     if tui {
         cb_sink
             .send(Box::new(move |app: &mut App| {
-                match flamegraph::new_app(title, data) {
-                    Ok(fl) => app.show_flamelens(fl),
-                    Err(err) => app.add_layer(Dialog::info(err.to_string())),
+                if let Some(source) = live {
+                    // Empty data is fine here: the updates will fill it in
+                    app.show_flamelens(flamegraph::new_live_app(title, data), Some(source));
+                } else {
+                    match flamegraph::new_app(title, data) {
+                        Ok(fl) => app.show_flamelens(fl, None),
+                        Err(err) => app.add_layer(Dialog::info(err.to_string())),
+                    }
                 }
             }))
             .map_err(|_| anyhow!("Cannot send message to UI"))?;
@@ -1194,56 +1259,63 @@ async fn process_event(context: ContextArc, event: Event, need_clear: &mut bool)
         }
         Event::ServerFlameGraph(tui, trace_type, start, end) => {
             let title = format!("ClickHouse Server {:?}", trace_type);
-            let flamegraph_block = clickhouse
-                .get_flamegraph(
-                    trace_type,
-                    None,
-                    Some(start),
-                    Some(end),
-                    selected_host.as_ref(),
-                )
-                .await?;
+            // An end anchored to "now" (i.e. no explicit --end) makes the
+            // window grow on every refresh
+            let live = tui && end.get_date_time().is_none();
+            let source = FlamegraphSource::TraceLog {
+                trace_type,
+                query_ids: None,
+                start,
+                end,
+            };
+            let flamegraph_block =
+                fetch_flamegraph(&clickhouse, &source, selected_host.as_ref()).await?;
             render_or_share_flamegraph(
                 tui,
                 cb_sink,
                 title,
                 flamegraph::block_to_folded(&flamegraph_block),
                 pastila.clone(),
+                live.then_some(source),
             )
             .await?;
             *need_clear = true;
         }
         Event::JemallocFlameGraph(tui) => {
-            let flamegraph_block = clickhouse
-                .get_jemalloc_flamegraph(selected_host.as_ref())
-                .await?;
+            let source = FlamegraphSource::Jemalloc;
+            let flamegraph_block =
+                fetch_flamegraph(&clickhouse, &source, selected_host.as_ref()).await?;
             render_or_share_flamegraph(
                 tui,
                 cb_sink,
                 "ClickHouse Server jemalloc".to_string(),
                 flamegraph::block_to_folded(&flamegraph_block),
                 pastila.clone(),
+                tui.then_some(source),
             )
             .await?;
             *need_clear = true;
         }
         Event::QueryFlameGraph(trace_type, tui, start, end, query_ids) => {
             let title = format!("ClickHouse Query {:?}", trace_type);
-            let flamegraph_block = clickhouse
-                .get_flamegraph(
-                    trace_type,
-                    Some(&query_ids),
-                    Some(start),
-                    end,
-                    selected_host.as_ref(),
-                )
-                .await?;
+            // A query that is still running has no end time; keep refreshing
+            // it (RelativeDateTime::from(None) resolves to now() every time)
+            let live = tui && end.is_none();
+            let source = FlamegraphSource::TraceLog {
+                trace_type,
+                query_ids: Some(query_ids),
+                start: RelativeDateTime::from(start),
+                end: RelativeDateTime::from(end),
+            };
+            let flamegraph_block =
+                fetch_flamegraph(&clickhouse, &source, selected_host.as_ref()).await?;
             render_or_share_flamegraph(
                 tui,
                 cb_sink,
                 title,
                 flamegraph::block_to_folded(&flamegraph_block),
                 pastila.clone(),
+                live.then_some(source),
             )
             .await?;
             *need_clear = true;
@@ -1271,7 +1343,7 @@ async fn process_event(context: ContextArc, event: Event, need_clear: &mut bool)
             cb_sink
                 .send(Box::new(
                     move |app: &mut App| match flamegraph::new_diff_app(title, before, after) {
-                        Ok(fl) => app.show_flamelens(fl),
+                        Ok(fl) => app.show_flamelens(fl, None),
                         Err(err) => app.add_layer(Dialog::info(err.to_string())),
                     },
                 ))
@@ -1284,18 +1356,33 @@ async fn process_event(context: ContextArc, event: Event, need_clear: &mut bool)
             } else {
                 "ClickHouse Server (live)"
             };
-            let flamegraph_block = clickhouse
-                .get_live_query_flamegraph(&query_ids, selected_host.as_ref())
-                .await?;
+            let source = FlamegraphSource::StackTrace(query_ids);
+            let flamegraph_block =
+                fetch_flamegraph(&clickhouse, &source, selected_host.as_ref()).await?;
             render_or_share_flamegraph(
                 tui,
                 cb_sink,
                 title.to_string(),
                 flamegraph::block_to_folded(&flamegraph_block),
                 pastila.clone(),
+                tui.then_some(source),
             )
             .await?;
             *need_clear = true;
+        }
+        Event::UpdateFlameGraph(source, slot) => {
+            let tic = Instant::now();
+            let flamegraph_block =
+                fetch_flamegraph(&clickhouse, &source, selected_host.as_ref()).await?;
+            let folded = flamegraph::block_to_folded(&flamegraph_block);
+            // An empty result (e.g. trace_log not flushed yet, or the
+            // stack_trace query finished) keeps the current graph on screen
+            if !folded.trim().is_empty() {
+                *slot.0.lock().unwrap() = Some(flamelens::app::ParsedFlameGraph {
+                    flamegraph: flamelens::flame::FlameGraph::from_string(folded, true),
+                    elapsed: tic.elapsed(),
+                });
+            }
         }
         Event::ExplainPlanIndexes(database, query) => {
             let plan = clickhouse

--- a/src/tui/navigation.rs
+++ b/src/tui/navigation.rs
@@ -1,6 +1,6 @@
 use crate::common::parse_datetime_or_date;
 use crate::interpreter::{
-    ContextArc, WorkerEvent,
+    BackgroundRunner, ContextArc, FlamegraphSource, WorkerEvent,
     clickhouse::TraceType,
     options::{ChDigViews, FlamelensPane},
 };
@@ -143,8 +143,9 @@ pub trait Navigation {
     fn show_server_flamegraph(&mut self, tui: bool, trace_type: Option<TraceType>);
     fn show_jemalloc_flamegraph(&mut self, tui: bool);
     /// Renders a flamegraph in the TUI: fullscreen flamelens takeover, or a
-    /// pane below/above the focused one (view.flamelens_pane).
-    fn show_flamelens(&mut self, fl: flamelens::app::App);
+    /// pane below/above the focused one (view.flamelens_pane). With `live`,
+    /// the flamegraph is refreshed every delay_interval until closed.
+    fn show_flamelens(&mut self, fl: flamelens::app::App, live: Option<FlamegraphSource>);
     fn show_server_perfetto(&mut self);
     fn show_connection_dialog(&mut self);
 
@@ -703,8 +704,8 @@ impl Navigation for App {
     fn show_server_flamegraph(&mut self, tui: bool, trace_type: Option<TraceType>) {
         let context = self.user_data::<ContextArc>().unwrap().clone();
         let mut context = context.lock().unwrap();
-        let start: DateTime<Local> = context.options.view.start.clone().into();
-        let end: DateTime<Local> = context.options.view.end.clone().into();
+        let start = context.options.view.start.clone();
+        let end = context.options.view.end.clone();
         if let Some(trace_type) = trace_type {
             context.worker.send(
                 true,
@@ -725,17 +726,54 @@ impl Navigation for App {
             .send(true, WorkerEvent::JemallocFlameGraph(tui));
     }
 
-    fn show_flamelens(&mut self, fl: flamelens::app::App) {
+    fn show_flamelens(&mut self, mut fl: flamelens::app::App, live: Option<FlamegraphSource>) {
         let context = self.user_data::<ContextArc>().unwrap().clone();
+        let live = live.map(|source| {
+            // Diff coloring is meaningful only for cumulative sources: a
+            // stack_trace snapshot would recolor almost every frame on each
+            // refresh.
+            let diff = !matches!(source, FlamegraphSource::StackTrace(_));
+            let slot = fl.enable_live(diff);
+            let (delay, cv, generation, owner) = {
+                let ctx = context.lock().unwrap();
+                (
+                    ctx.options.view.delay_interval,
+                    ctx.background_runner_cv.clone(),
+                    ctx.background_runner_generation.clone(),
+                    ctx.worker.event_owner(),
+                )
+            };
+            let mut bg_runner = BackgroundRunner::new(delay, cv, generation);
+            let cb_context = context.clone();
+            let cb_owner = owner.clone();
+            // start() forces an immediate first run, but the initial data was
+            // fetched just now - skip it
+            let first = std::sync::atomic::AtomicBool::new(true);
+            bg_runner.start(move |force| {
+                if first.swap(false, std::sync::atomic::Ordering::SeqCst) {
+                    return;
+                }
+                cb_context.lock().unwrap().worker.send_owned(
+                    &cb_owner,
+                    force,
+                    WorkerEvent::UpdateFlameGraph(source.clone(), slot.clone().into()),
+                );
+            });
+            (bg_runner, owner)
+        });
         let pane = context.lock().unwrap().options.view.flamelens_pane;
         if pane == FlamelensPane::Off {
+            // The updates keep flowing while the fullscreen loop blocks the
+            // UI thread: the worker feeds the slot directly, not via UiSink
             if let Err(err) = crate::interpreter::flamegraph::show(fl) {
                 self.add_layer(Dialog::info(err.to_string()));
             }
+            // `live` is dropped here: the runner joins, EventOwner cancels
+            // the in-flight update
             return;
         }
 
-        let view = FlamelensView::new(fl).with_name("flamelens");
+        let view = FlamelensView::new(fl, live).with_name("flamelens");
         if self.focus_name("flamelens") {
             // Replace the existing flamelens pane in place (present_view
             // replaces the focused pane).

--- a/src/tui/navigation.rs
+++ b/src/tui/navigation.rs
@@ -765,7 +765,9 @@ impl Navigation for App {
         if pane == FlamelensPane::Off {
             // The updates keep flowing while the fullscreen loop blocks the
             // UI thread: the worker feeds the slot directly, not via UiSink
-            if let Err(err) = crate::interpreter::flamegraph::show(fl) {
+            let mut live = live;
+            let refresh = live.as_mut().map(|(runner, _)| runner);
+            if let Err(err) = crate::interpreter::flamegraph::show(fl, refresh) {
                 self.add_layer(Dialog::info(err.to_string()));
             }
             // `live` is dropped here: the runner joins, EventOwner cancels

--- a/src/tui/views/flamelens_view.rs
+++ b/src/tui/views/flamelens_view.rs
@@ -1,7 +1,9 @@
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::layout::Rect;
 
-use crate::interpreter::{ContextArc, options::ChDigViews};
+use std::sync::Arc;
+
+use crate::interpreter::{BackgroundRunner, ContextArc, EventOwner, options::ChDigViews};
 use crate::tui::app::App;
 use crate::tui::component::{Canvas, Component};
 use crate::tui::event::{Event, EventResult, Key};
@@ -11,11 +13,15 @@ use crate::tui::navigation::Navigation;
 /// the fullscreen terminal takeover of `interpreter::flamegraph::show`.
 pub struct FlamelensView {
     fl: flamelens::app::App,
+    // Keeps the periodic live updates running; dropping it with the pane
+    // stops the runner thread and cancels the in-flight query (EventOwner).
+    #[allow(unused)]
+    live: Option<(BackgroundRunner, Arc<EventOwner>)>,
 }
 
 impl FlamelensView {
-    pub fn new(fl: flamelens::app::App) -> Self {
-        Self { fl }
+    pub fn new(fl: flamelens::app::App, live: Option<(BackgroundRunner, Arc<EventOwner>)>) -> Self {
+        Self { fl, live }
     }
 }
 
@@ -72,6 +78,8 @@ fn close_pane(app: &mut App) {
 
 impl Component for FlamelensView {
     fn draw(&mut self, canvas: &mut Canvas<'_>, area: Rect, focused: bool) {
+        // Swaps in a pending live update, if any
+        self.fl.tick();
         let cursor = flamelens::ui::render_in_area(&mut self.fl, area, canvas.buf);
         if focused && cursor.is_some() {
             canvas.cursor = cursor;

--- a/src/tui/views/flamelens_view.rs
+++ b/src/tui/views/flamelens_view.rs
@@ -87,6 +87,15 @@ impl Component for FlamelensView {
     }
 
     fn on_event(&mut self, event: &Event) -> EventResult {
+        // In live mode r/R force a refresh instead of flamelens's reset
+        // (Esc covers that); not while typing into the search buffer.
+        if matches!(event, Event::Char('r' | 'R'))
+            && self.fl.input_buffer.is_none()
+            && let Some((runner, _)) = self.live.as_mut()
+        {
+            runner.schedule();
+            return EventResult::consumed();
+        }
         // flamelens always consumes Esc (unzoom); with nothing to unwind let
         // it bubble up to the global "close pane" action.
         if *event == Event::Key(Key::Esc)


### PR DESCRIPTION
Refreshed every interval (default 30 seconds), and shows diff with previous (can be switched to plain flamegraph with `D`)

Fixes: https://github.com/azat/chdig/issues/101