### PR TITLE
Support duplicated views via named view instances (#292)

### DIFF
--- a/Documentation/FAQ.md
+++ b/Documentation/FAQ.md
@@ -49,6 +49,10 @@ has two sections for this:
   referred to by their CLI subcommand names (see `chdig --help`; both
   `last_queries` and `last-queries` are accepted):
   - `filter` - initial value of the view's `/` filter
+  - `query_kind` - restrict a queries view to these `query_kind` values
+    (`Select`, `Insert`, `Create`, `Drop`, `Alter`, ...), a single value or a
+    list; combined with `filter`. The live `queries` view needs ClickHouse
+    23.2+ for it (`system.processes.query_kind`)
   - `start`/`end` - time interval override for this view (such a view ignores
     the global `--start`/`--end` and `T`/`t`/`Alt+t` seeking)
   - `limit` - row limit override (`--limit`/`--queries-limit`, whichever
@@ -66,9 +70,37 @@ has two sections for this:
   `memory_allocated_without_check_flamegraph`, `events_flamegraph`,
   `live_flamegraph`, `jemalloc_flamegraph`).
 
+A `views:` entry with a `view:` field defines a **named instance** of that
+view type: the key becomes the instance name, and the layout may reference it
+like any view name. This is the way to show several differently configured
+copies of one view side by side (e.g. last SELECT / INSERT / DDL queries):
+
+```yaml
+views:
+  last_selects:
+    view: last_queries
+    query_kind: Select
+  last_inserts:
+    view: last_queries
+    query_kind: Insert
+
+layout:
+  panes: [last_selects, last_inserts]
+  focus: last_inserts
+```
+
+Each instance has its own `/`-filter state; the `(`/`)` queries-limit keys
+stay global (an instance's `limit:` overrides it), and the `F3` queries
+filter edits the builtin view's filter, not the focused instance's (use `/`
+in the pane instead). Instances are only instantiated via the layout - the
+`F2` menu opens the builtin views.
+
 See [chdig_views_layout.yaml](/tests/configs/chdig_views_layout.yaml) for a
 directly runnable example (queries, CPU flamegraph and server logs stacked in
-equal panes).
+equal panes), and
+[chdig_view_instances.yaml](/tests/configs/chdig_view_instances.yaml) for the
+named-instances one (last SELECT / INSERT / DDL queries plus CPU and jemalloc
+flamegraphs).
 
 ```yaml
 views:

--- a/src/interpreter/clickhouse.rs
+++ b/src/interpreter/clickhouse.rs
@@ -122,6 +122,32 @@ pub enum TraceType {
     MemoryAllocatedWithoutCheck,
 }
 
+/// Filters of the queries views (processes/slow_query_log/last_query_log).
+#[derive(Debug, Clone, Default)]
+pub struct QueriesFilter {
+    /// The '/'-prompt LIKE pattern (matched against query, user, query_id, ...).
+    pub like: String,
+    /// `query_kind IN (...)` restriction; empty = all kinds.
+    pub query_kind: Vec<String>,
+}
+
+impl QueriesFilter {
+    /// ` AND query_kind IN (...)` or empty.
+    fn query_kind_clause(&self) -> String {
+        if self.query_kind.is_empty() {
+            return String::new();
+        }
+        format!(
+            " AND query_kind IN ({})",
+            self.query_kind
+                .iter()
+                .map(|kind| format!("'{}'", kind.replace('\'', "''")))
+                .collect::<Vec<_>>()
+                .join(",")
+        )
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct TextLogArguments {
     pub query_ids: Option<Vec<String>>,
@@ -531,7 +557,7 @@ impl ClickHouse {
 
     pub async fn get_slow_query_log(
         &self,
-        filter: &String,
+        filter: &QueriesFilter,
         start: RelativeDateTime,
         end: RelativeDateTime,
         limit: u64,
@@ -539,14 +565,18 @@ impl ClickHouse {
     ) -> Result<Columns> {
         let dbtable = self.get_log_table_name("query_log");
         let host_filter = self.get_log_host_filter_clause(selected_host);
-        let filter_clause = if !filter.is_empty() {
+        let mut filter_clause = if !filter.like.is_empty() {
             format!(
                 "AND (client_hostname LIKE '{0}' OR log_comment LIKE '{0}' OR os_user LIKE '{0}' OR user LIKE '{0}' OR initial_user LIKE '{0}' OR client_name LIKE '{0}' OR query_id LIKE '{0}' OR query LIKE '{0}' OR current_database LIKE '{0}' OR toString(normalized_query_hash) LIKE '{0}')",
-                &filter
+                &filter.like
             )
         } else {
             "".to_string()
         };
+        // The condition sits in the initial_query_id selection, so it is the
+        // *initial* query's kind: the whole query group (subqueries included)
+        // is still pulled by the outer query.
+        filter_clause.push_str(&filter.query_kind_clause());
         let peak_threads_usage = if self
             .quirks
             .has(ClickHouseAvailableQuirks::QueryLogPeakThreadsUsage)
@@ -684,7 +714,7 @@ impl ClickHouse {
 
     pub async fn get_last_query_log(
         &self,
-        filter: &String,
+        filter: &QueriesFilter,
         start: RelativeDateTime,
         end: RelativeDateTime,
         limit: u64,
@@ -695,14 +725,16 @@ impl ClickHouse {
         // - distributed_group_by_no_merge=2 is broken for this query with WINDOW function
         let dbtable = self.get_log_table_name("query_log");
         let host_filter = self.get_log_host_filter_clause(selected_host);
-        let filter_clause = if !filter.is_empty() {
+        let mut filter_clause = if !filter.like.is_empty() {
             format!(
                 "AND (client_hostname LIKE '{0}' OR log_comment LIKE '{0}' OR os_user LIKE '{0}' OR user LIKE '{0}' OR initial_user LIKE '{0}' OR client_name LIKE '{0}' OR query_id LIKE '{0}' OR query LIKE '{0}' OR current_database LIKE '{0}' OR toString(normalized_query_hash) LIKE '{0}')",
-                &filter
+                &filter.like
             )
         } else {
             "".to_string()
         };
+        // The initial query's kind (see get_slow_query_log).
+        filter_clause.push_str(&filter.query_kind_clause());
         let peak_threads_usage = if self
             .quirks
             .has(ClickHouseAvailableQuirks::QueryLogPeakThreadsUsage)
@@ -836,12 +868,26 @@ impl ClickHouse {
 
     pub async fn get_processlist(
         &self,
-        filter: String,
+        filter: QueriesFilter,
         limit: u64,
         selected_host: Option<&String>,
     ) -> Result<Columns> {
         let dbtable = self.get_live_table_name("processes");
         let host_filter = self.get_host_filter_clause(selected_host);
+        // system.processes has query_kind only since 23.2
+        let query_kind_clause = if self
+            .quirks
+            .has(ClickHouseAvailableQuirks::ProcessesQueryKind)
+        {
+            filter.query_kind_clause()
+        } else {
+            if !filter.query_kind.is_empty() {
+                log::warn!(
+                    "query_kind filtering requires ClickHouse 23.2+ (system.processes), ignored"
+                );
+            }
+            String::new()
+        };
         return self
             .execute(
                 format!(
@@ -874,11 +920,13 @@ impl ClickHouse {
                     FROM {}
                     WHERE 1
                     {filter}
+                    {query_kind_clause}
                     {internal}
                     {host_filter}
                     LIMIT {limit}
                 "#,
                     dbtable,
+                    query_kind_clause = query_kind_clause,
                     q = if self.quirks.has(ClickHouseAvailableQuirks::ProcessesElapsed) {
                         10
                     } else {
@@ -892,8 +940,8 @@ impl ClickHouse {
                         "current_database"
                     },
                     internal = self.get_internal_filter_clause(),
-                    filter = if !filter.is_empty() {
-                        format!("AND (client_hostname LIKE '{0}' OR Settings['log_comment'] LIKE '{0}' OR os_user LIKE '{0}' OR user LIKE '{0}' OR initial_user LIKE '{0}' OR client_name LIKE '{0}' OR query_id LIKE '{0}' OR query LIKE '{0}' OR current_database LIKE '{0}' OR toString(normalizedQueryHash(query)) LIKE '{0}')", &filter)
+                    filter = if !filter.like.is_empty() {
+                        format!("AND (client_hostname LIKE '{0}' OR Settings['log_comment'] LIKE '{0}' OR os_user LIKE '{0}' OR user LIKE '{0}' OR initial_user LIKE '{0}' OR client_name LIKE '{0}' OR query_id LIKE '{0}' OR query LIKE '{0}' OR current_database LIKE '{0}' OR toString(normalizedQueryHash(query)) LIKE '{0}')", &filter.like)
                     } else {
                         "".to_string()
                     },

--- a/src/interpreter/clickhouse_quirks.rs
+++ b/src/interpreter/clickhouse_quirks.rs
@@ -11,10 +11,11 @@ pub enum ClickHouseAvailableQuirks {
     ProcessesPeakThreadsUsage = 32,
     SystemBackgroundSchedulePool = 64,
     AdditionalTableFiltersInSubquery = 128,
+    ProcessesQueryKind = 256,
 }
 
 // List of quirks (that requires workaround) or new features.
-const QUIRKS: [(&str, ClickHouseAvailableQuirks); 9] = [
+const QUIRKS: [(&str, ClickHouseAvailableQuirks); 10] = [
     // https://github.com/ClickHouse/ClickHouse/pull/46047
     //
     // NOTE: I use here 22.13 because I have such version in production, which is more or less the
@@ -47,6 +48,9 @@ const QUIRKS: [(&str, ClickHouseAvailableQuirks); 9] = [
         ">=25.12",
         ClickHouseAvailableQuirks::SystemBackgroundSchedulePool,
     ),
+    // query_kind is available in system.processes since 23.2
+    // https://github.com/ClickHouse/ClickHouse/pull/45872
+    (">=23.2", ClickHouseAvailableQuirks::ProcessesQueryKind),
     // ClickHouse before 26.3 did not applied additional_table_filters to tables read from within a
     // subquery, so on such versions the initial_query_id selection is run as its own top-level
     // query first, and its result is spliced into the main query as a literal IN (...) list instead
@@ -166,6 +170,10 @@ mod tests {
         assert!(quirks.has(ClickHouseAvailableQuirks::SystemReplicasUUID));
         assert!(quirks.has(ClickHouseAvailableQuirks::ProcessesPeakThreadsUsage));
         assert!(quirks.has(ClickHouseAvailableQuirks::TraceLogHasSymbols));
+        assert!(quirks.has(ClickHouseAvailableQuirks::ProcessesQueryKind));
+
+        let quirks = ClickHouseQuirks::new("23.1.1.1-stable".to_string());
+        assert!(!quirks.has(ClickHouseAvailableQuirks::ProcessesQueryKind));
     }
 
     #[test]

--- a/src/interpreter/context.rs
+++ b/src/interpreter/context.rs
@@ -148,6 +148,13 @@ impl Context {
         self.view_settings(view_name)?.limit
     }
 
+    /// Configured query_kind restriction of a queries view (empty = all).
+    pub fn view_query_kind(&self, view_name: &str) -> Vec<String> {
+        self.view_settings(view_name)
+            .map(|settings| settings.query_kind.clone())
+            .unwrap_or_default()
+    }
+
     /// Configured maximum log level for the view (`level <= '...'`).
     pub fn view_level(&self, view_name: &str) -> Option<crate::interpreter::options::LogLevel> {
         self.view_settings(view_name)?.level

--- a/src/interpreter/context.rs
+++ b/src/interpreter/context.rs
@@ -107,8 +107,18 @@ impl Context {
         &self,
         view_name: &str,
     ) -> Option<&crate::interpreter::options::ChDigViewSettings> {
+        // Direct hit: an instance name or a builtin whose widget name is the
+        // view name itself.
+        if let Some(instance) = self.options.views.get(view_name) {
+            return Some(&instance.settings);
+        }
+        // A builtin whose widget name differs from the view name (e.g.
+        // "processes" for the queries view).
         let view_type = self.view_registry.view_type_by_view_name(view_name)?;
-        self.options.views.get(&view_type)
+        self.options
+            .views
+            .get(view_type.config_name())
+            .map(|instance| &instance.settings)
     }
 
     /// Configured initial '/'-filter for the view whose main widget is

--- a/src/interpreter/context.rs
+++ b/src/interpreter/context.rs
@@ -267,7 +267,7 @@ impl Context {
                 let mut ctx = context.lock().unwrap();
                 ctx.set_current_view(provider.view_type());
             }
-            provider.show(app, context.clone());
+            provider.show(app, context.clone(), None);
         });
     }
 

--- a/src/interpreter/context.rs
+++ b/src/interpreter/context.rs
@@ -43,7 +43,7 @@ pub struct Context {
 
     /// Per-view '/'-filters of the queries views, keyed by view name; entries
     /// outlive the views so the filter survives switching views.
-    queries_filters: std::collections::HashMap<&'static str, Arc<Mutex<String>>>,
+    queries_filters: std::collections::HashMap<String, Arc<Mutex<String>>>,
     pub queries_limit: Arc<Mutex<u64>>,
     pub query_patterns_metric:
         &'static crate::tui::views::providers::query_patterns_metrics::Metric,
@@ -162,13 +162,14 @@ impl Context {
 
     /// The '/'-filter of a queries view, created on first use (seeded from the
     /// config).
-    pub fn queries_filter(&mut self, view_name: &'static str) -> Arc<Mutex<String>> {
+    pub fn queries_filter(&mut self, view_name: &str) -> Arc<Mutex<String>> {
         if let Some(filter) = self.queries_filters.get(view_name) {
             return filter.clone();
         }
         let seed = self.view_filter_seed(view_name).unwrap_or_default();
         let filter = Arc::new(Mutex::new(seed));
-        self.queries_filters.insert(view_name, filter.clone());
+        self.queries_filters
+            .insert(view_name.to_string(), filter.clone());
         filter
     }
 
@@ -263,7 +264,7 @@ impl Context {
     pub fn add_view_action<F, E, V>(
         &mut self,
         view: &mut crate::tui::OnEventView<V>,
-        owner: &'static str,
+        owner: Arc<str>,
         text: &'static str,
         event: E,
         cb: F,
@@ -271,7 +272,6 @@ impl Context {
         F: Fn(&mut dyn crate::tui::Component) -> Result<Option<crate::tui::EventResult>>
             + Send
             + Sync
-            + Copy
             + 'static,
         E: Into<crate::tui::Event>,
         V: crate::tui::Component,
@@ -297,14 +297,13 @@ impl Context {
     pub fn add_view_action_without_shortcut<F, V>(
         &mut self,
         view: &mut crate::tui::OnEventView<V>,
-        owner: &'static str,
+        owner: Arc<str>,
         text: &'static str,
         cb: F,
     ) where
         F: Fn(&mut dyn crate::tui::Component) -> Result<Option<crate::tui::EventResult>>
             + Send
             + Sync
-            + Copy
             + 'static,
         V: crate::tui::Component,
     {

--- a/src/interpreter/options.rs
+++ b/src/interpreter/options.rs
@@ -1081,6 +1081,12 @@ pub struct ChDigViewSettings {
     view: Option<ChDigViews>,
     /// Initial value of the view's filter (same as the '/' prompt).
     pub filter: Option<String>,
+    /// Restrict a queries view to these query_kind values (Select, Insert,
+    /// Create, Drop, Alter, ...; the system.query_log/system.processes
+    /// query_kind column). A single value or a list; combined with `filter`.
+    /// The live queries view needs 23.2+ for it.
+    #[serde(deserialize_with = "string_or_seq")]
+    pub query_kind: Vec<String>,
     /// Time interval override for the view's own query (the global
     /// --start/--end, T/t seeking and Alt+t do not affect such a view).
     pub start: Option<RelativeDateTime>,
@@ -1100,6 +1106,42 @@ pub struct ChDigViewSettings {
 pub struct ViewInstance {
     pub view_type: ChDigViews,
     pub settings: ChDigViewSettings,
+}
+
+/// Accepts both `key: value` and `key: [a, b]`.
+fn string_or_seq<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    struct StringOrSeq;
+
+    impl<'de> serde::de::Visitor<'de> for StringOrSeq {
+        type Value = Vec<String>;
+
+        fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.write_str("a string or a list of strings")
+        }
+
+        fn visit_str<E>(self, value: &str) -> Result<Vec<String>, E>
+        where
+            E: serde::de::Error,
+        {
+            Ok(vec![value.to_string()])
+        }
+
+        fn visit_seq<A>(self, mut seq: A) -> Result<Vec<String>, A::Error>
+        where
+            A: serde::de::SeqAccess<'de>,
+        {
+            let mut values = Vec::new();
+            while let Some(value) = seq.next_element::<String>()? {
+                values.push(value);
+            }
+            Ok(values)
+        }
+    }
+
+    deserializer.deserialize_any(StringOrSeq)
 }
 
 fn is_valid_instance_name(s: &str) -> bool {
@@ -2390,6 +2432,20 @@ views:
         assert_eq!(instance.settings.filter.as_deref(), Some("SELECT%"));
         // A redundant 'view:' matching the builtin key is allowed
         assert_eq!(config.views["queries"].view_type, ChDigViews::Queries);
+
+        // query_kind: a single value or a list
+        let config: ChDigConfig = serde_yaml::from_str(
+            "views:\n  last_inserts:\n    view: last_queries\n    query_kind: Insert\n  last_ddls:\n    view: last_queries\n    query_kind: [Create, Drop, Alter]\n",
+        )
+        .unwrap();
+        assert_eq!(
+            config.views["last_inserts"].settings.query_kind,
+            vec!["Insert"]
+        );
+        assert_eq!(
+            config.views["last_ddls"].settings.query_kind,
+            vec!["Create", "Drop", "Alter"]
+        );
 
         let views_error = |yaml: &str| {
             serde_yaml::from_str::<ChDigConfig>(yaml)

--- a/src/interpreter/options.rs
+++ b/src/interpreter/options.rs
@@ -292,6 +292,7 @@ pub const RESERVED_VIEW_NAMES: &[&str] = &[
     "query_log",
     "logger_logs",
     "background_schedule_pool_logs",
+    "filtered_logs",
 ];
 
 /// Accepts both snake_case and the CLI kebab-case.

--- a/src/interpreter/options.rs
+++ b/src/interpreter/options.rs
@@ -241,7 +241,58 @@ impl ChDigViews {
             .map(|(name, _)| *name)
             .unwrap()
     }
+
+    /// Base types that named `views:` instances may use (their widget names,
+    /// worker events and settings lookups are instance-aware).
+    pub fn supports_instances(self) -> bool {
+        use ChDigViews::*;
+        matches!(
+            self,
+            Queries
+                | LastQueries
+                | SlowQueries
+                | ServerLogs
+                | CpuFlamegraph
+                | RealFlamegraph
+                | MemoryFlamegraph
+                | MemorySampleFlamegraph
+                | JemallocSampleFlamegraph
+                | MemoryAllocatedWithoutCheckFlamegraph
+                | EventsFlamegraph
+                | LiveFlamegraph
+                | JemallocFlamegraph
+        )
+    }
 }
+
+/// Widget names already taken by the TUI that are not view config names; an
+/// instance named like one would receive foreign updates. The provider part
+/// is kept in sync by test_reserved_view_names.
+pub const RESERVED_VIEW_NAMES: &[&str] = &[
+    // providers whose widget name differs from the view config name
+    "processes",
+    "slow_query_log",
+    "last_query_log",
+    "logger_names",
+    "s3queue_metadata_cache",
+    "azure_queue_metadata_cache",
+    // fixed TUI widget names
+    "flamelens",
+    "panes",
+    "main",
+    "left_menu",
+    "summary",
+    "status",
+    "version",
+    "connection",
+    "debug_status",
+    "is_paused",
+    "help",
+    "actions_select",
+    "query_log",
+    "logger_logs",
+    "background_schedule_pool_logs",
+];
 
 /// Accepts both snake_case and the CLI kebab-case.
 impl FromStr for ChDigViews {
@@ -379,9 +430,10 @@ pub struct ChDigOptions {
     pub service: ServiceOptions,
     #[clap(skip)]
     pub perfetto: ChDigPerfettoConfig,
-    /// Per-view settings, populated from the YAML config (`views:` section).
+    /// Per-view settings and named view instances, populated from the YAML
+    /// config (`views:` section), keyed by view/instance name.
     #[clap(skip)]
-    pub views: HashMap<ChDigViews, ChDigViewSettings>,
+    pub views: HashMap<String, ViewInstance>,
     /// Startup pane layout, populated from the YAML config (`layout:` section).
     #[clap(skip)]
     pub layout: Option<LayoutConfig>,
@@ -707,16 +759,17 @@ pub enum LayoutDirection {
     Vertical,
 }
 
-/// One pane of the startup layout: a bare view name or a nested node.
+/// One pane of the startup layout: a bare view/instance name or a nested
+/// node. Names are resolved in `LayoutConfig::resolve` (the `views:` section
+/// with the instance names may be parsed after the layout).
 #[derive(Debug, Clone)]
 pub enum LayoutPane {
-    View(ChDigViews),
+    View(String),
     Node(Box<LayoutNode>),
 }
 
 /// Hand-written instead of #[serde(untagged)]: untagged swallows the variant
-/// errors, turning a misspelled view name into "data did not match any
-/// variant" instead of the "unknown view ..." one.
+/// errors, losing the field errors of a malformed pane definition.
 impl<'de> Deserialize<'de> for LayoutPane {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -735,10 +788,7 @@ impl<'de> Deserialize<'de> for LayoutPane {
             where
                 E: serde::de::Error,
             {
-                value
-                    .parse()
-                    .map(LayoutPane::View)
-                    .map_err(serde::de::Error::custom)
+                Ok(LayoutPane::View(value.to_string()))
             }
 
             fn visit_map<A>(self, map: A) -> Result<LayoutPane, A::Error>
@@ -758,7 +808,7 @@ impl<'de> Deserialize<'de> for LayoutPane {
 #[derive(Deserialize, Debug, Clone, Default)]
 #[serde(default, deny_unknown_fields)]
 pub struct LayoutNode {
-    pub view: Option<ChDigViews>,
+    pub view: Option<String>,
     pub direction: LayoutDirection,
     /// Fraction of the parent split given to this pane (within (0, 1));
     /// panes without it share the remainder equally.
@@ -775,14 +825,30 @@ pub struct LayoutConfig {
     pub direction: LayoutDirection,
     pub panes: Vec<LayoutPane>,
     #[serde(default)]
-    pub focus: Option<ChDigViews>,
+    pub focus: Option<String>,
 }
 
-/// Validated `LayoutConfig`: every fraction explicit (children's sum to 1),
-/// single-pane splits collapsed.
+/// A leaf of the resolved layout: the base view type plus the instance name
+/// for named instances (None = the provider's default widget name).
+#[derive(Debug, Clone, PartialEq)]
+pub struct ResolvedView {
+    pub view_type: ChDigViews,
+    pub instance: Option<String>,
+}
+
+impl ResolvedView {
+    pub fn name(&self) -> &str {
+        self.instance
+            .as_deref()
+            .unwrap_or_else(|| self.view_type.config_name())
+    }
+}
+
+/// Validated `LayoutConfig`: every name resolved, every fraction explicit
+/// (children's sum to 1), single-pane splits collapsed.
 #[derive(Debug, Clone, PartialEq)]
 pub enum ResolvedLayout {
-    View(ChDigViews),
+    View(ResolvedView),
     Split {
         direction: LayoutDirection,
         children: Vec<(f32, ResolvedLayout)>,
@@ -790,9 +856,9 @@ pub enum ResolvedLayout {
 }
 
 impl ResolvedLayout {
-    pub fn views(&self, out: &mut Vec<ChDigViews>) {
+    pub fn views<'a>(&'a self, out: &mut Vec<&'a ResolvedView>) {
         match self {
-            ResolvedLayout::View(view) => out.push(*view),
+            ResolvedLayout::View(view) => out.push(view),
             ResolvedLayout::Split { children, .. } => {
                 for (_, child) in children {
                     child.views(out);
@@ -802,31 +868,56 @@ impl ResolvedLayout {
     }
 }
 
+/// A layout reference: a builtin view name (always the builtin, even when a
+/// same-named `views:` entry holds its settings) or a `views:` instance name.
+fn resolve_view_ref(name: &str, views: &HashMap<String, ViewInstance>) -> Result<ResolvedView> {
+    let name = name.replace('-', "_");
+    if let Ok(view_type) = name.parse::<ChDigViews>() {
+        return Ok(ResolvedView {
+            view_type,
+            instance: None,
+        });
+    }
+    if let Some(instance) = views.get(&name) {
+        return Ok(ResolvedView {
+            view_type: instance.view_type,
+            instance: Some(name),
+        });
+    }
+    Err(anyhow!("layout: unknown view or instance '{}'", name))
+}
+
 impl LayoutConfig {
     /// Validates the layout and returns it in resolved form along with the
     /// view to focus (defaults to the first one).
-    pub fn resolve(&self) -> Result<(ResolvedLayout, ChDigViews)> {
-        let root = resolve_layout_split(self.direction, &self.panes)?;
+    pub fn resolve(
+        &self,
+        views: &HashMap<String, ViewInstance>,
+    ) -> Result<(ResolvedLayout, ResolvedView)> {
+        let root = resolve_layout_split(self.direction, &self.panes, views)?;
 
-        let mut views = Vec::new();
-        root.views(&mut views);
-        for (i, view) in views.iter().enumerate() {
-            if *view == ChDigViews::Client {
+        let mut leaves = Vec::new();
+        root.views(&mut leaves);
+        for (i, view) in leaves.iter().enumerate() {
+            if view.view_type == ChDigViews::Client {
                 return Err(anyhow!("layout: the client view cannot be used"));
             }
-            if views[..i].contains(view) {
+            if leaves[..i].contains(view) {
                 return Err(anyhow!(
                     "layout: view '{}' is used more than once",
-                    view.config_name()
+                    view.name()
                 ));
             }
         }
 
-        let focus = self.focus.unwrap_or(views[0]);
-        if !views.contains(&focus) {
+        let focus = match &self.focus {
+            Some(name) => resolve_view_ref(name, views)?,
+            None => leaves[0].clone(),
+        };
+        if !leaves.contains(&&focus) {
             return Err(anyhow!(
                 "layout: focus view '{}' is not in the layout",
-                focus.config_name()
+                focus.name()
             ));
         }
         Ok((root, focus))
@@ -836,6 +927,7 @@ impl LayoutConfig {
 fn resolve_layout_split(
     direction: LayoutDirection,
     panes: &[LayoutPane],
+    views: &HashMap<String, ViewInstance>,
 ) -> Result<ResolvedLayout> {
     if panes.is_empty() {
         return Err(anyhow!("layout: 'panes' cannot be empty"));
@@ -844,11 +936,11 @@ fn resolve_layout_split(
     let mut children = Vec::with_capacity(panes.len());
     for pane in panes {
         let (ratio, resolved) = match pane {
-            LayoutPane::View(view) => (None, ResolvedLayout::View(*view)),
+            LayoutPane::View(name) => (None, ResolvedLayout::View(resolve_view_ref(name, views)?)),
             LayoutPane::Node(node) => {
-                let resolved = match (node.view, node.panes.is_empty()) {
-                    (Some(view), true) => ResolvedLayout::View(view),
-                    (None, false) => resolve_layout_split(node.direction, &node.panes)?,
+                let resolved = match (&node.view, node.panes.is_empty()) {
+                    (Some(name), true) => ResolvedLayout::View(resolve_view_ref(name, views)?),
+                    (None, false) => resolve_layout_split(node.direction, &node.panes, views)?,
                     (Some(_), false) => {
                         return Err(anyhow!(
                             "layout: a pane cannot have both 'view' and 'panes'"
@@ -984,6 +1076,9 @@ impl<'de> Deserialize<'de> for LogLevel {
 #[derive(Deserialize, Debug, Clone, Default)]
 #[serde(default, deny_unknown_fields)]
 pub struct ChDigViewSettings {
+    /// Base view type when the entry defines a named instance (the key is
+    /// then a new instance name); consumed while parsing the `views:` map.
+    view: Option<ChDigViews>,
     /// Initial value of the view's filter (same as the '/' prompt).
     pub filter: Option<String>,
     /// Time interval override for the view's own query (the global
@@ -997,6 +1092,90 @@ pub struct ChDigViewSettings {
     pub level: Option<LogLevel>,
 }
 
+/// A `views:` entry: settings for a builtin view (the key is the view name)
+/// or a named instance of one (the key is the instance name, `view:` names
+/// the base type). Instances make it possible to place several differently
+/// configured copies of one view in the layout.
+#[derive(Debug, Clone)]
+pub struct ViewInstance {
+    pub view_type: ChDigViews,
+    pub settings: ChDigViewSettings,
+}
+
+fn is_valid_instance_name(s: &str) -> bool {
+    let mut chars = s.chars();
+    chars
+        .next()
+        .is_some_and(|c| c.is_ascii_alphabetic() || c == '_')
+        && chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+fn deserialize_views<'de, D>(deserializer: D) -> Result<HashMap<String, ViewInstance>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de::Error;
+
+    let raw = HashMap::<String, ChDigViewSettings>::deserialize(deserializer)?;
+    let mut views = HashMap::with_capacity(raw.len());
+    for (key, mut settings) in raw {
+        let name = key.replace('-', "_");
+        let base = settings.view.take();
+        let view_type = match (name.parse::<ChDigViews>(), base) {
+            (Ok(view_type), None) => view_type,
+            (Ok(view_type), Some(base)) if base == view_type => view_type,
+            (Ok(view_type), Some(base)) => {
+                return Err(D::Error::custom(format!(
+                    "views: '{}' is a builtin view name, it cannot be an instance of '{}'",
+                    view_type.config_name(),
+                    base.config_name(),
+                )));
+            }
+            (Err(err), None) => {
+                return Err(D::Error::custom(format!(
+                    "views: {} (to define a named instance of a view, add 'view: <name>')",
+                    err
+                )));
+            }
+            (Err(_), Some(base)) => {
+                if !base.supports_instances() {
+                    return Err(D::Error::custom(format!(
+                        "views: '{}' does not support named instances (supported: {})",
+                        base.config_name(),
+                        ChDigViews::NAMES
+                            .iter()
+                            .filter(|(_, view)| view.supports_instances())
+                            .map(|(name, _)| *name)
+                            .collect::<Vec<_>>()
+                            .join(", "),
+                    )));
+                }
+                if !is_valid_instance_name(&name) {
+                    return Err(D::Error::custom(format!(
+                        "views: invalid instance name '{}' (expected [A-Za-z_][A-Za-z0-9_]*)",
+                        name
+                    )));
+                }
+                if RESERVED_VIEW_NAMES.contains(&name.as_str()) {
+                    return Err(D::Error::custom(format!(
+                        "views: instance name '{}' is reserved",
+                        name
+                    )));
+                }
+                base
+            }
+        };
+        views.insert(
+            name,
+            ViewInstance {
+                view_type,
+                settings,
+            },
+        );
+    }
+    Ok(views)
+}
+
 #[derive(Deserialize, Default)]
 #[serde(default)]
 struct ChDigConfig {
@@ -1004,7 +1183,8 @@ struct ChDigConfig {
     view: ChDigViewConfig,
     service: ChDigServiceConfig,
     perfetto: ChDigPerfettoConfig,
-    views: HashMap<ChDigViews, ChDigViewSettings>,
+    #[serde(deserialize_with = "deserialize_views")]
+    views: HashMap<String, ViewInstance>,
     layout: Option<LayoutConfig>,
 }
 
@@ -1719,7 +1899,7 @@ fn adjust_defaults(options: &mut ChDigOptions, matches: &ArgMatches) -> Result<(
 
     // Reject a broken layout at startup, not when the TUI applies it.
     if let Some(layout) = &options.layout {
-        layout.resolve()?;
+        layout.resolve(&options.views)?;
     }
 
     let config = if let Some(user_config) = &options.clickhouse.config {
@@ -2163,40 +2343,94 @@ views:
         let config: ChDigConfig = serde_yaml::from_str(VIEWS_YAML).unwrap();
 
         assert_eq!(config.views.len(), 3);
+        assert_eq!(config.views["queries"].view_type, ChDigViews::Queries);
         assert_eq!(
-            config.views[&ChDigViews::Queries].filter.as_deref(),
+            config.views["queries"].settings.filter.as_deref(),
             Some("user_1")
         );
+        // '-' in the key is normalized to '_'
+        let last_queries = &config.views["last_queries"];
+        assert_eq!(last_queries.view_type, ChDigViews::LastQueries);
+        assert_eq!(last_queries.settings.filter.as_deref(), Some("user_2"));
         assert_eq!(
-            config.views[&ChDigViews::LastQueries].filter.as_deref(),
-            Some("user_2")
-        );
-        let last_queries = &config.views[&ChDigViews::LastQueries];
-        assert_eq!(
-            last_queries.start.as_ref().unwrap().to_editable_string(),
+            last_queries
+                .settings
+                .start
+                .as_ref()
+                .unwrap()
+                .to_editable_string(),
             "4h"
         );
         assert_eq!(
-            last_queries.end.as_ref().unwrap().to_editable_string(),
+            last_queries
+                .settings
+                .end
+                .as_ref()
+                .unwrap()
+                .to_editable_string(),
             "30m"
         );
-        assert_eq!(config.views[&ChDigViews::ServerLogs].filter, None);
-        assert!(config.views[&ChDigViews::ServerLogs].start.is_none());
-        assert_eq!(config.views[&ChDigViews::ServerLogs].limit, Some(100));
-        assert_eq!(
-            config.views[&ChDigViews::ServerLogs].level,
-            Some(LogLevel::Error)
-        );
+        let server_logs = &config.views["server_logs"].settings;
+        assert_eq!(server_logs.filter, None);
+        assert!(server_logs.start.is_none());
+        assert_eq!(server_logs.limit, Some(100));
+        assert_eq!(server_logs.level, Some(LogLevel::Error));
         assert_eq!("Error", LogLevel::Error.as_str());
-        assert_eq!(config.views[&ChDigViews::LastQueries].limit, None);
+        assert_eq!(last_queries.settings.limit, None);
+    }
+
+    #[test]
+    fn test_chdig_config_view_instances() {
+        let config: ChDigConfig = serde_yaml::from_str(
+            "views:\n  last_selects:\n    view: last_queries\n    filter: \"SELECT%\"\n  queries:\n    view: queries\n    filter: x\n",
+        )
+        .unwrap();
+        let instance = &config.views["last_selects"];
+        assert_eq!(instance.view_type, ChDigViews::LastQueries);
+        assert_eq!(instance.settings.filter.as_deref(), Some("SELECT%"));
+        // A redundant 'view:' matching the builtin key is allowed
+        assert_eq!(config.views["queries"].view_type, ChDigViews::Queries);
+
+        let views_error = |yaml: &str| {
+            serde_yaml::from_str::<ChDigConfig>(yaml)
+                .err()
+                .unwrap()
+                .to_string()
+        };
+        assert!(
+            views_error("views:\n  queries:\n    view: last_queries\n")
+                .contains("builtin view name")
+        );
+        assert!(
+            views_error("views:\n  my_merges:\n    view: merges\n")
+                .contains("does not support named instances")
+        );
+        assert!(views_error("views:\n  processes:\n    view: last_queries\n").contains("reserved"));
+        assert!(
+            views_error("views:\n  1st:\n    view: last_queries\n")
+                .contains("invalid instance name")
+        );
+    }
+
+    fn resolved_view(view_type: ChDigViews) -> ResolvedLayout {
+        ResolvedLayout::View(ResolvedView {
+            view_type,
+            instance: None,
+        })
     }
 
     #[test]
     fn test_chdig_config_layout() {
         let config = read_chdig_config("tests/configs/chdig_views_layout.yaml").unwrap();
-        let (resolved, focus) = config.layout.as_ref().unwrap().resolve().unwrap();
+        let (resolved, focus) = config
+            .layout
+            .as_ref()
+            .unwrap()
+            .resolve(&config.views)
+            .unwrap();
 
-        assert_eq!(focus, ChDigViews::Queries);
+        assert_eq!(focus.view_type, ChDigViews::Queries);
+        assert_eq!(focus.instance, None);
         // Unspecified fractions are computed as (1 - given)/n: the expected
         // values must be the same f32 expressions, not literals.
         assert_eq!(
@@ -2204,14 +2438,14 @@ views:
             ResolvedLayout::Split {
                 direction: LayoutDirection::Horizontal,
                 children: vec![
-                    (0.6, ResolvedLayout::View(ChDigViews::Queries)),
+                    (0.6, resolved_view(ChDigViews::Queries)),
                     (
                         1.0 - 0.6,
                         ResolvedLayout::Split {
                             direction: LayoutDirection::Vertical,
                             children: vec![
-                                (1.0 - 0.4, ResolvedLayout::View(ChDigViews::CpuFlamegraph)),
-                                (0.4, ResolvedLayout::View(ChDigViews::ServerLogs)),
+                                (1.0 - 0.4, resolved_view(ChDigViews::CpuFlamegraph)),
+                                (0.4, resolved_view(ChDigViews::ServerLogs)),
                             ],
                         }
                     ),
@@ -2227,22 +2461,27 @@ views:
             "layout:\n  panes:\n  - queries\n  - direction: vertical\n    ratio: 0.4\n    panes: [last_queries, server_logs]\n",
         )
         .unwrap();
-        let (resolved, focus) = config.layout.as_ref().unwrap().resolve().unwrap();
+        let (resolved, focus) = config
+            .layout
+            .as_ref()
+            .unwrap()
+            .resolve(&config.views)
+            .unwrap();
 
-        assert_eq!(focus, ChDigViews::Queries);
+        assert_eq!(focus.view_type, ChDigViews::Queries);
         assert_eq!(
             resolved,
             ResolvedLayout::Split {
                 direction: LayoutDirection::Horizontal,
                 children: vec![
-                    (0.6, ResolvedLayout::View(ChDigViews::Queries)),
+                    (0.6, resolved_view(ChDigViews::Queries)),
                     (
                         0.4,
                         ResolvedLayout::Split {
                             direction: LayoutDirection::Vertical,
                             children: vec![
-                                (0.5, ResolvedLayout::View(ChDigViews::LastQueries)),
-                                (0.5, ResolvedLayout::View(ChDigViews::ServerLogs)),
+                                (0.5, resolved_view(ChDigViews::LastQueries)),
+                                (0.5, resolved_view(ChDigViews::ServerLogs)),
                             ],
                         }
                     ),
@@ -2251,19 +2490,74 @@ views:
         );
     }
 
+    #[test]
+    fn test_chdig_config_layout_instances() {
+        let config: ChDigConfig = serde_yaml::from_str(
+            "views:\n  last_selects:\n    view: last_queries\n  last_inserts:\n    view: last_queries\nlayout:\n  panes:\n  - last_selects\n  - view: last_inserts\n    ratio: 0.3\n  - last_queries\n  focus: last_inserts\n",
+        )
+        .unwrap();
+        let (resolved, focus) = config
+            .layout
+            .as_ref()
+            .unwrap()
+            .resolve(&config.views)
+            .unwrap();
+
+        // The same base type may appear several times via instances (and once
+        // more as the bare builtin).
+        let instance = |name: &str| {
+            ResolvedLayout::View(ResolvedView {
+                view_type: ChDigViews::LastQueries,
+                instance: Some(name.to_string()),
+            })
+        };
+        assert_eq!(
+            resolved,
+            ResolvedLayout::Split {
+                direction: LayoutDirection::Horizontal,
+                children: vec![
+                    ((1.0 - 0.3) / 2.0, instance("last_selects")),
+                    (0.3, instance("last_inserts")),
+                    ((1.0 - 0.3) / 2.0, resolved_view(ChDigViews::LastQueries)),
+                ],
+            }
+        );
+        assert_eq!(focus.instance.as_deref(), Some("last_inserts"));
+        assert_eq!(focus.name(), "last_inserts");
+    }
+
     fn layout_error(yaml: &str) -> String {
         let config: ChDigConfig = serde_yaml::from_str(yaml).unwrap();
-        config.layout.unwrap().resolve().err().unwrap().to_string()
+        config
+            .layout
+            .unwrap()
+            .resolve(&config.views)
+            .err()
+            .unwrap()
+            .to_string()
     }
 
     #[test]
     fn test_chdig_config_layout_invalid() {
         assert!(layout_error("layout:\n  panes: [queries, queries]\n").contains("more than once"));
         assert!(layout_error("layout:\n  panes: [client]\n").contains("client"));
+        assert!(layout_error("layout:\n  panes: [no_such_view]\n").contains("unknown view"));
         assert!(
             layout_error("layout:\n  panes: [queries]\n  focus: merges\n")
                 .contains("not in the layout")
         );
+        assert!(
+            layout_error(
+                "views:\n  last_selects:\n    view: last_queries\nlayout:\n  panes: [last_selects, last_selects]\n"
+            )
+            .contains("'last_selects' is used more than once")
+        );
+        // An instance defined but not referenced in the layout is fine
+        let config: ChDigConfig = serde_yaml::from_str(
+            "views:\n  last_selects:\n    view: last_queries\nlayout:\n  panes: [queries]\n",
+        )
+        .unwrap();
+        assert!(config.layout.unwrap().resolve(&config.views).is_ok());
         assert!(
             layout_error(
                 "layout:\n  panes:\n    - view: queries\n      ratio: 1.5\n    - merges\n"
@@ -2280,8 +2574,8 @@ views:
         // focus defaults to the first view
         let config: ChDigConfig =
             serde_yaml::from_str("layout:\n  panes: [merges, queries]\n").unwrap();
-        let (_, focus) = config.layout.unwrap().resolve().unwrap();
-        assert_eq!(focus, ChDigViews::Merges);
+        let (_, focus) = config.layout.unwrap().resolve(&config.views).unwrap();
+        assert_eq!(focus.view_type, ChDigViews::Merges);
     }
 
     #[test]
@@ -2338,7 +2632,7 @@ views:
 
         assert_eq!(options.views.len(), 3);
         assert_eq!(
-            options.views[&ChDigViews::Queries].filter.as_deref(),
+            options.views["queries"].settings.filter.as_deref(),
             Some("user_1")
         );
     }

--- a/src/interpreter/options.rs
+++ b/src/interpreter/options.rs
@@ -2582,6 +2582,20 @@ views:
         assert_eq!(focus.name(), "last_inserts");
     }
 
+    /// The shipped example config must keep parsing and resolving.
+    #[test]
+    fn test_chdig_config_view_instances_example() {
+        let config = read_chdig_config("tests/configs/chdig_view_instances.yaml").unwrap();
+        let (_, focus) = config
+            .layout
+            .as_ref()
+            .unwrap()
+            .resolve(&config.views)
+            .unwrap();
+        assert_eq!(focus.instance.as_deref(), Some("last_selects"));
+        assert_eq!(config.views["last_ddls"].settings.query_kind.len(), 4);
+    }
+
     fn layout_error(yaml: &str) -> String {
         let config: ChDigConfig = serde_yaml::from_str(yaml).unwrap();
         config

--- a/src/interpreter/worker.rs
+++ b/src/interpreter/worker.rs
@@ -198,12 +198,27 @@ impl Event {
             Event::SlowQueryLog(view_name, ..) => format!("SlowQueryLog({})", view_name),
             Event::LastQueryLog(view_name, ..) => format!("LastQueryLog({})", view_name),
             Event::TextLog(view_name, ..) => format!("TextLog({})", view_name),
-            Event::ServerFlameGraph(..) => "ServerFlameGraph".to_string(),
-            Event::JemallocFlameGraph(..) => "JemallocFlameGraph".to_string(),
+            // Per-target-pane keys for the same reason (a layout can hold
+            // several flamegraph panes); None = the ad-hoc "flamelens" slot
+            // (and the share path).
+            Event::ServerFlameGraph(.., target) => format!(
+                "ServerFlameGraph({})",
+                target.as_deref().unwrap_or("flamelens")
+            ),
+            Event::JemallocFlameGraph(_, target) => format!(
+                "JemallocFlameGraph({})",
+                target.as_deref().unwrap_or("flamelens")
+            ),
             Event::QueryFlameGraph(..) => "QueryFlameGraph".to_string(),
             Event::QueryFlameGraphDiff(..) => "QueryFlameGraphDiff".to_string(),
-            Event::LiveQueryFlameGraph(..) => "LiveQueryFlameGraph".to_string(),
-            Event::UpdateFlameGraph(..) => "UpdateFlameGraph".to_string(),
+            Event::LiveQueryFlameGraph(.., target) => format!(
+                "LiveQueryFlameGraph({})",
+                target.as_deref().unwrap_or("flamelens")
+            ),
+            // The slot is unnamed; its Arc identity tells the panes apart.
+            Event::UpdateFlameGraph(_, slot) => {
+                format!("UpdateFlameGraph({:p})", Arc::as_ptr(&slot.0))
+            }
             Event::Summary => "Summary".to_string(),
             Event::KillQuery(..) => "KillQuery".to_string(),
             Event::ExecuteQuery(..) => "ExecuteQuery".to_string(),

--- a/src/interpreter/worker.rs
+++ b/src/interpreter/worker.rs
@@ -3,8 +3,8 @@ use crate::{
     interpreter::{
         ContextArc, Query,
         clickhouse::{
-            ClickHouse, Columns, TextLogArguments, TraceType, parse_metric_log_block,
-            parse_query_metric_log_block,
+            ClickHouse, Columns, QueriesFilter, TextLogArguments, TraceType,
+            parse_metric_log_block, parse_query_metric_log_block,
         },
         flamegraph,
         perfetto::PerfettoTraceBuilder,
@@ -89,11 +89,23 @@ pub enum FlamegraphSource {
 #[derive(Debug, Clone)]
 pub enum Event {
     // [view_name, filter, limit]
-    ProcessList(Arc<str>, String, u64),
+    ProcessList(Arc<str>, QueriesFilter, u64),
     // [view_name, filter, start, end, limit]
-    SlowQueryLog(Arc<str>, String, RelativeDateTime, RelativeDateTime, u64),
+    SlowQueryLog(
+        Arc<str>,
+        QueriesFilter,
+        RelativeDateTime,
+        RelativeDateTime,
+        u64,
+    ),
     // [view_name, filter, start, end, limit]
-    LastQueryLog(Arc<str>, String, RelativeDateTime, RelativeDateTime, u64),
+    LastQueryLog(
+        Arc<str>,
+        QueriesFilter,
+        RelativeDateTime,
+        RelativeDateTime,
+        u64,
+    ),
     // (view_name, args)
     TextLog(Arc<str>, TextLogArguments),
     // [bool (true - show in TUI, false - share via pastila), type, start, end,

--- a/src/interpreter/worker.rs
+++ b/src/interpreter/worker.rs
@@ -88,14 +88,14 @@ pub enum FlamegraphSource {
 
 #[derive(Debug, Clone)]
 pub enum Event {
-    // [filter, limit]
-    ProcessList(String, u64),
-    // [filter, start, end, limit]
-    SlowQueryLog(String, RelativeDateTime, RelativeDateTime, u64),
-    // [filter, start, end, limit]
-    LastQueryLog(String, RelativeDateTime, RelativeDateTime, u64),
+    // [view_name, filter, limit]
+    ProcessList(Arc<str>, String, u64),
+    // [view_name, filter, start, end, limit]
+    SlowQueryLog(Arc<str>, String, RelativeDateTime, RelativeDateTime, u64),
+    // [view_name, filter, start, end, limit]
+    LastQueryLog(Arc<str>, String, RelativeDateTime, RelativeDateTime, u64),
     // (view_name, args)
-    TextLog(&'static str, TextLogArguments),
+    TextLog(Arc<str>, TextLogArguments),
     // [bool (true - show in TUI, false - share via pastila), type, start, end,
     // target pane slot (a view named like this shows the result; None - the
     // ad-hoc "flamelens" slot)]
@@ -104,10 +104,10 @@ pub enum Event {
         TraceType,
         RelativeDateTime,
         RelativeDateTime,
-        Option<&'static str>,
+        Option<Arc<str>>,
     ),
     // [bool (true - show in TUI, false - share via pastila), target pane slot]
-    JemallocFlameGraph(bool, Option<&'static str>),
+    JemallocFlameGraph(bool, Option<Arc<str>>),
     // (type, bool (true - show in TUI, false - open in browser), start time, end time, [query_ids])
     QueryFlameGraph(
         TraceType,
@@ -126,7 +126,7 @@ pub enum Event {
         Vec<String>,
     ),
     // [bool (true - show in TUI, false - open in browser), query_ids, target pane slot]
-    LiveQueryFlameGraph(bool, Option<Vec<String>>, Option<&'static str>),
+    LiveQueryFlameGraph(bool, Option<Vec<String>>, Option<Arc<str>>),
     // Periodic refresh of a live flamegraph: deposits the new graph into the
     // flamelens app's slot instead of opening a new view
     UpdateFlameGraph(FlamegraphSource, OpaquePayload<FlamegraphSlot>),
@@ -180,11 +180,11 @@ pub enum Event {
 impl Event {
     fn enum_key(&self) -> String {
         match self {
-            Event::ProcessList(..) => "ProcessList".to_string(),
-            Event::SlowQueryLog(..) => "SlowQueryLog".to_string(),
-            Event::LastQueryLog(..) => "LastQueryLog".to_string(),
-            // Per-view key: log views in several panes update concurrently,
+            // Per-view keys: views in several panes update concurrently,
             // one shared capacity-1 channel would drop their updates.
+            Event::ProcessList(view_name, ..) => format!("ProcessList({})", view_name),
+            Event::SlowQueryLog(view_name, ..) => format!("SlowQueryLog({})", view_name),
+            Event::LastQueryLog(view_name, ..) => format!("LastQueryLog({})", view_name),
             Event::TextLog(view_name, ..) => format!("TextLog({})", view_name),
             Event::ServerFlameGraph(..) => "ServerFlameGraph".to_string(),
             Event::JemallocFlameGraph(..) => "JemallocFlameGraph".to_string(),
@@ -712,7 +712,7 @@ async fn render_or_share_flamegraph(
     data: String,
     pastila: pastila::PastilaConfig,
     live: Option<FlamegraphSource>,
-    target: Option<&'static str>,
+    target: Option<Arc<str>>,
 ) -> Result<()> {
     if tui {
         cb_sink
@@ -1183,14 +1183,14 @@ async fn process_event(context: ContextArc, event: Event, need_clear: &mut bool)
     let selected_host = context.lock().unwrap().selected_host.clone();
 
     match event {
-        Event::ProcessList(filter, limit) => {
+        Event::ProcessList(view_name, filter, limit) => {
             let block = clickhouse
                 .get_processlist(filter, limit, selected_host.as_ref())
                 .await?;
             cb_sink
                 .send(Box::new(move |app: &mut App| {
                     app.call_on_name_or_render_error(
-                        "processes",
+                        &view_name,
                         move |view: &mut OnEventView<QueriesView>| {
                             return view.get_inner_mut().update(block);
                         },
@@ -1198,14 +1198,14 @@ async fn process_event(context: ContextArc, event: Event, need_clear: &mut bool)
                 }))
                 .map_err(|_| anyhow!("Cannot send message to UI"))?;
         }
-        Event::SlowQueryLog(filter, start, end, limit) => {
+        Event::SlowQueryLog(view_name, filter, start, end, limit) => {
             let block = clickhouse
                 .get_slow_query_log(&filter, start, end, limit, selected_host.as_ref())
                 .await?;
             cb_sink
                 .send(Box::new(move |app: &mut App| {
                     app.call_on_name_or_render_error(
-                        "slow_query_log",
+                        &view_name,
                         move |view: &mut OnEventView<QueriesView>| {
                             return view.get_inner_mut().update(block);
                         },
@@ -1213,14 +1213,14 @@ async fn process_event(context: ContextArc, event: Event, need_clear: &mut bool)
                 }))
                 .map_err(|_| anyhow!("Cannot send message to UI"))?;
         }
-        Event::LastQueryLog(filter, start, end, limit) => {
+        Event::LastQueryLog(view_name, filter, start, end, limit) => {
             let block = clickhouse
                 .get_last_query_log(&filter, start, end, limit, selected_host.as_ref())
                 .await?;
             cb_sink
                 .send(Box::new(move |app: &mut App| {
                     app.call_on_name_or_render_error(
-                        "last_query_log",
+                        &view_name,
                         move |view: &mut OnEventView<QueriesView>| {
                             return view.get_inner_mut().update(block);
                         },
@@ -1234,8 +1234,9 @@ async fn process_event(context: ContextArc, event: Event, need_clear: &mut bool)
                 .get_query_logs(&args, async |block| {
                     let is_new_batch = std::mem::take(&mut new_batch);
                     let (ack_tx, ack_rx) = oneshot::channel::<bool>();
+                    let view_name = view_name.clone();
                     let sent = cb_sink.send(Box::new(move |app: &mut App| {
-                        let ret = app.call_on_name(view_name, move |view: &mut TextLogView| {
+                        let ret = app.call_on_name(&view_name, move |view: &mut TextLogView| {
                             view.update(block, is_new_batch)
                         });
                         let ok = match ret {
@@ -1259,7 +1260,7 @@ async fn process_event(context: ContextArc, event: Event, need_clear: &mut bool)
             // (the error will be reported separately)
             cb_sink
                 .send(Box::new(move |app: &mut App| {
-                    app.call_on_name(view_name, |view: &mut TextLogView| {
+                    app.call_on_name(&view_name, |view: &mut TextLogView| {
                         view.finish_loading();
                     });
                 }))

--- a/src/tui/actions.rs
+++ b/src/tui/actions.rs
@@ -59,7 +59,7 @@ pub struct GlobalAction {
 pub struct ViewAction {
     /// Name of the view the action belongs to (actions of several live views
     /// can coexist, each view drops only its own).
-    pub owner: &'static str,
+    pub owner: Arc<str>,
     /// The callback lives only in the owning view's OnEventView handler;
     /// menus trigger it by replaying `description.event`.
     pub description: ActionDescription,

--- a/src/tui/navigation.rs
+++ b/src/tui/navigation.rs
@@ -259,7 +259,7 @@ impl Navigation for App {
             ctx.current_view = Some(previous_view);
             ctx.view_registry.get_by_view_type(previous_view)
         };
-        provider.show(self, context);
+        provider.show(self, context, None);
     }
 
     fn toggle_pause_updates(&mut self, reason: Option<&str>) {
@@ -417,7 +417,7 @@ impl Navigation for App {
                     ctx.set_current_view(start_view);
                     ctx.view_registry.get_by_view_type(start_view)
                 };
-                provider.show(self, context.clone());
+                provider.show(self, context.clone(), None);
             }
             None => self.apply_layout(context.clone()),
         }
@@ -450,7 +450,7 @@ impl Navigation for App {
                 .unwrap()
                 .view_registry
                 .get_by_view_type(view.view_type);
-            provider.show(self, context.clone());
+            provider.show(self, context.clone(), view.instance.as_deref());
         }
 
         context.lock().unwrap().set_current_view(focus.view_type);
@@ -1064,7 +1064,7 @@ impl Navigation for App {
                                     mux.set_focus(focused);
                                 });
                                 app.drop_main_view();
-                                provider.show(app, context_arc.clone());
+                                provider.show(app, context_arc.clone(), None);
 
                                 context_arc.lock().unwrap().trigger_view_refresh();
                             },

--- a/src/tui/navigation.rs
+++ b/src/tui/navigation.rs
@@ -16,6 +16,7 @@ use anyhow::Result;
 use chrono::{DateTime, Local};
 use ratatui::layout::{Rect, Size};
 use std::collections::HashSet;
+use std::sync::Arc;
 
 /// Placeholder content of a freshly split pane. It must be focusable so that
 /// the view selected in the views menu replaces this pane (present_view
@@ -61,11 +62,11 @@ fn focused_pane_contains(app: &mut App, name: &str) -> bool {
 /// Owners of view actions that live in the focused pane. Actions of views in
 /// other panes are hidden until those panes are focused (their key bindings
 /// only fire there anyway, since events follow the focus path).
-fn focused_action_owners(app: &mut App) -> HashSet<&'static str> {
+fn focused_action_owners(app: &mut App) -> HashSet<Arc<str>> {
     let context = app.user_data::<ContextArc>().unwrap().clone();
-    let owners: HashSet<&'static str> = {
+    let owners: HashSet<Arc<str>> = {
         let ctx = context.lock().unwrap();
-        ctx.view_actions.iter().map(|a| a.owner).collect()
+        ctx.view_actions.iter().map(|a| a.owner.clone()).collect()
     };
     owners
         .into_iter()
@@ -195,7 +196,7 @@ pub trait Navigation {
         &mut self,
         fl: flamelens::app::App,
         live: Option<FlamegraphSource>,
-        target: Option<&'static str>,
+        target: Option<Arc<str>>,
     );
     fn show_server_perfetto(&mut self);
     fn show_connection_dialog(&mut self);
@@ -207,12 +208,7 @@ pub trait Navigation {
     fn present_view<V: Component + 'static>(&mut self, focus: &str, view: V);
     /// Shows a log view in a new pane to the right (default) or in a dialog
     /// (--logs-in-dialog). `view` must contain a view named `view_name`.
-    fn present_logs<V: Component + 'static>(
-        &mut self,
-        view_name: &'static str,
-        title: &str,
-        view: V,
-    );
+    fn present_logs<V: Component + 'static>(&mut self, view_name: &str, title: &str, view: V);
 
     fn set_statusbar_version(&mut self, main_content: impl Into<StyledString>);
     fn set_statusbar_content(&mut self, content: impl Into<StyledString>);
@@ -560,7 +556,7 @@ impl Navigation for App {
             for shortcut in context
                 .view_actions
                 .iter()
-                .filter(|a| owners.contains(a.owner))
+                .filter(|a| owners.contains(&a.owner))
             {
                 text.append(shortcut.description.preview_styled());
             }
@@ -682,7 +678,7 @@ impl Navigation for App {
                                 .iter()
                                 .find(|x| {
                                     x.description.text == selected_action
-                                        && owners.contains(x.owner)
+                                        && owners.contains(&x.owner)
                                 })
                                 .map(|x| x.description.event.clone())
                         };
@@ -705,7 +701,7 @@ impl Navigation for App {
                     for action in context
                         .view_actions
                         .iter()
-                        .filter(|a| owners.contains(a.owner))
+                        .filter(|a| owners.contains(&a.owner))
                     {
                         select.add_item_str(action.description.text);
                         has_any = true;
@@ -741,7 +737,7 @@ impl Navigation for App {
                     context
                         .view_actions
                         .iter()
-                        .filter(|x| owners.contains(x.owner))
+                        .filter(|x| owners.contains(&x.owner))
                         .map(|x| &x.description),
                 )
                 .chain(context.views_menu_actions.iter().map(|x| &x.description))
@@ -775,7 +771,7 @@ impl Navigation for App {
                     .unwrap()
                     .view_actions
                     .iter()
-                    .find(|x| x.description.text == action_text && owners.contains(x.owner))
+                    .find(|x| x.description.text == action_text && owners.contains(&x.owner))
                     .map(|x| x.description.event.clone());
                 if let Some(event) = event {
                     app.on_event(event);
@@ -829,7 +825,7 @@ impl Navigation for App {
         &mut self,
         mut fl: flamelens::app::App,
         live: Option<FlamegraphSource>,
-        target: Option<&'static str>,
+        target: Option<Arc<str>>,
     ) {
         let context = self.user_data::<ContextArc>().unwrap().clone();
         let live = live.map(|source| {
@@ -870,7 +866,7 @@ impl Navigation for App {
         // flamegraphs (F and friends) share the "flamelens" one. An existing
         // pane holding the slot outranks flamelens_pane: the result is
         // rendered into it in place.
-        let slot = target.unwrap_or("flamelens");
+        let slot: &str = target.as_deref().unwrap_or("flamelens");
         let has_flamelens_pane = self.focus_name(slot);
         if pane == FlamelensPane::Off && !has_flamelens_pane {
             // The updates keep flowing while the fullscreen loop blocks the
@@ -1113,12 +1109,7 @@ impl Navigation for App {
         self.focus_name(focus);
     }
 
-    fn present_logs<V: Component + 'static>(
-        &mut self,
-        view_name: &'static str,
-        title: &str,
-        view: V,
-    ) {
+    fn present_logs<V: Component + 'static>(&mut self, view_name: &str, title: &str, view: V) {
         let in_dialog = {
             let context = self.user_data::<ContextArc>().unwrap().clone();
             let ctx = context.lock().unwrap();

--- a/src/tui/navigation.rs
+++ b/src/tui/navigation.rs
@@ -2,7 +2,7 @@ use crate::common::parse_datetime_or_date;
 use crate::interpreter::{
     BackgroundRunner, ContextArc, FlamegraphSource, WorkerEvent,
     clickhouse::TraceType,
-    options::{ChDigViews, FlamelensPane, LayoutDirection, ResolvedLayout},
+    options::{ChDigViews, FlamelensPane, LayoutDirection, ResolvedLayout, ResolvedView},
 };
 use crate::tui::{
     self, App, Component, Dialog, DummyView, EditView, Event, EventResult, Key, LinearLayout,
@@ -90,10 +90,10 @@ fn toggle_debug_metrics(app: &mut App) {
 /// Converts a resolved layout subtree into a Mux layout of PaneStub leaves
 /// (an n-way split folds into nested binary splits), collecting the views in
 /// placement order.
-fn stub_layout(resolved: &ResolvedLayout, views: &mut Vec<ChDigViews>) -> mux::Layout {
+fn stub_layout(resolved: &ResolvedLayout, views: &mut Vec<ResolvedView>) -> mux::Layout {
     match resolved {
         ResolvedLayout::View(view) => {
-            views.push(*view);
+            views.push(view.clone());
             mux::Layout::leaf(PaneStub::new())
         }
         ResolvedLayout::Split {
@@ -106,7 +106,7 @@ fn stub_layout(resolved: &ResolvedLayout, views: &mut Vec<ChDigViews>) -> mux::L
 fn fold_split(
     direction: LayoutDirection,
     children: &[(f32, ResolvedLayout)],
-    views: &mut Vec<ChDigViews>,
+    views: &mut Vec<ResolvedView>,
 ) -> mux::Layout {
     if children.len() == 1 {
         return stub_layout(&children[0].1, views);
@@ -427,7 +427,12 @@ impl Navigation for App {
         // Validated in adjust_defaults(), hence the unwraps.
         let (resolved, focus) = {
             let ctx = context.lock().unwrap();
-            ctx.options.layout.as_ref().unwrap().resolve().unwrap()
+            ctx.options
+                .layout
+                .as_ref()
+                .unwrap()
+                .resolve(&ctx.options.views)
+                .unwrap()
         };
 
         let mut views = Vec::new();
@@ -444,19 +449,23 @@ impl Navigation for App {
                 .lock()
                 .unwrap()
                 .view_registry
-                .get_by_view_type(*view);
+                .get_by_view_type(view.view_type);
             provider.show(self, context.clone());
         }
 
-        context.lock().unwrap().set_current_view(focus);
-        let focus_name = {
-            let ctx = context.lock().unwrap();
-            ctx.view_registry
-                .get_by_view_type(focus)
-                .view_name()
-                .unwrap()
+        context.lock().unwrap().set_current_view(focus.view_type);
+        let focus_name = match &focus.instance {
+            Some(name) => name.clone(),
+            None => {
+                let ctx = context.lock().unwrap();
+                ctx.view_registry
+                    .get_by_view_type(focus.view_type)
+                    .view_name()
+                    .unwrap()
+                    .to_string()
+            }
         };
-        self.focus_name(focus_name);
+        self.focus_name(&focus_name);
     }
 
     /// Ignore rustfmt max_width, otherwise callback actions looks ugly

--- a/src/tui/provider.rs
+++ b/src/tui/provider.rs
@@ -18,7 +18,11 @@ pub trait ViewProvider: Send + Sync {
 
     fn view_type(&self) -> ChDigViews;
 
-    fn show(&self, app: &mut App, context: ContextArc);
+    /// Shows the view in the focused pane. `instance` is the name of a named
+    /// view instance (`views:` config section) to show instead of the default
+    /// singleton: the widget is named after it, so several instances of one
+    /// view type can coexist. None everywhere but the layout instantiation.
+    fn show(&self, app: &mut App, context: ContextArc, instance: Option<&str>);
 }
 
 pub struct ViewRegistry {

--- a/src/tui/views/flamelens_view.rs
+++ b/src/tui/views/flamelens_view.rs
@@ -73,7 +73,7 @@ fn close_pane(app: &mut App) {
         ctx.view_registry.get_by_view_type(current_view)
     };
     app.drop_main_view();
-    provider.show(app, context);
+    provider.show(app, context, None);
 }
 
 impl Component for FlamelensView {

--- a/src/tui/views/providers/asynchronous_inserts.rs
+++ b/src/tui/views/providers/asynchronous_inserts.rs
@@ -16,7 +16,7 @@ impl ViewProvider for AsynchronousInsertsViewProvider {
         ChDigViews::AsynchronousInserts
     }
 
-    fn show(&self, app: &mut App, context: ContextArc) {
+    fn show(&self, app: &mut App, context: ContextArc, _instance: Option<&str>) {
         show_asynchronous_inserts(app, context, None, None, Presentation::FullScreen);
     }
 }

--- a/src/tui/views/providers/asynchronous_metric_log.rs
+++ b/src/tui/views/providers/asynchronous_metric_log.rs
@@ -19,7 +19,7 @@ impl ViewProvider for AsynchronousMetricLogViewProvider {
         ChDigViews::AsynchronousMetricLog
     }
 
-    fn show(&self, app: &mut App, context: ContextArc) {
+    fn show(&self, app: &mut App, context: ContextArc, _instance: Option<&str>) {
         show_asynchronous_metric_log(app, context);
     }
 }

--- a/src/tui/views/providers/background_schedule_pool.rs
+++ b/src/tui/views/providers/background_schedule_pool.rs
@@ -19,7 +19,7 @@ impl ViewProvider for BackgroundSchedulePoolViewProvider {
         ChDigViews::BackgroundSchedulePool
     }
 
-    fn show(&self, app: &mut App, context: ContextArc) {
+    fn show(&self, app: &mut App, context: ContextArc, _instance: Option<&str>) {
         show_background_schedule_pool(app, context, None, None, Presentation::FullScreen);
     }
 }

--- a/src/tui/views/providers/background_schedule_pool_log.rs
+++ b/src/tui/views/providers/background_schedule_pool_log.rs
@@ -19,7 +19,7 @@ impl ViewProvider for BackgroundSchedulePoolLogViewProvider {
         ChDigViews::BackgroundSchedulePoolLog
     }
 
-    fn show(&self, app: &mut App, context: ContextArc) {
+    fn show(&self, app: &mut App, context: ContextArc, _instance: Option<&str>) {
         show_background_schedule_pool_log(app, context, None, None, None, Presentation::FullScreen);
     }
 }

--- a/src/tui/views/providers/backups.rs
+++ b/src/tui/views/providers/backups.rs
@@ -19,7 +19,7 @@ impl ViewProvider for BackupsViewProvider {
         ChDigViews::Backups
     }
 
-    fn show(&self, app: &mut App, context: ContextArc) {
+    fn show(&self, app: &mut App, context: ContextArc, _instance: Option<&str>) {
         let columns = vec![
             "name",
             "status",

--- a/src/tui/views/providers/client.rs
+++ b/src/tui/views/providers/client.rs
@@ -63,7 +63,7 @@ impl ViewProvider for ClientViewProvider {
         ChDigViews::Client
     }
 
-    fn show(&self, app: &mut App, context: ContextArc) {
+    fn show(&self, app: &mut App, context: ContextArc, _instance: Option<&str>) {
         let options = context.lock().unwrap().options.clickhouse.clone();
 
         let mut cmd = Command::new("clickhouse");

--- a/src/tui/views/providers/dictionaries.rs
+++ b/src/tui/views/providers/dictionaries.rs
@@ -15,7 +15,7 @@ impl ViewProvider for DictionariesViewProvider {
         ChDigViews::Dictionaries
     }
 
-    fn show(&self, app: &mut App, context: ContextArc) {
+    fn show(&self, app: &mut App, context: ContextArc, _instance: Option<&str>) {
         let columns = vec![
             "name",
             "status",

--- a/src/tui/views/providers/error_log.rs
+++ b/src/tui/views/providers/error_log.rs
@@ -16,7 +16,7 @@ impl ViewProvider for ErrorLogViewProvider {
         ChDigViews::ErrorLog
     }
 
-    fn show(&self, app: &mut App, context: ContextArc) {
+    fn show(&self, app: &mut App, context: ContextArc, _instance: Option<&str>) {
         let view_name = "error_log";
 
         if app.focus_name(view_name) {

--- a/src/tui/views/providers/errors.rs
+++ b/src/tui/views/providers/errors.rs
@@ -85,7 +85,7 @@ impl ViewProvider for ErrorsViewProvider {
         ChDigViews::Errors
     }
 
-    fn show(&self, app: &mut App, context: ContextArc) {
+    fn show(&self, app: &mut App, context: ContextArc, _instance: Option<&str>) {
         if app.focus_name("errors") {
             return;
         }

--- a/src/tui/views/providers/flamegraph.rs
+++ b/src/tui/views/providers/flamegraph.rs
@@ -118,10 +118,16 @@ impl ViewProvider for &'static FlamegraphViewProvider {
         let event = match &self.source {
             Source::Trace(trace_type) => {
                 let (start, end) = ctx.view_interval(slot);
-                WorkerEvent::ServerFlameGraph(true, trace_type.clone(), start, end, Some(slot))
+                WorkerEvent::ServerFlameGraph(
+                    true,
+                    trace_type.clone(),
+                    start,
+                    end,
+                    Some(slot.into()),
+                )
             }
-            Source::Live => WorkerEvent::LiveQueryFlameGraph(true, None, Some(slot)),
-            Source::Jemalloc => WorkerEvent::JemallocFlameGraph(true, Some(slot)),
+            Source::Live => WorkerEvent::LiveQueryFlameGraph(true, None, Some(slot.into())),
+            Source::Jemalloc => WorkerEvent::JemallocFlameGraph(true, Some(slot.into())),
         };
         ctx.worker.send(true, event);
     }

--- a/src/tui/views/providers/flamegraph.rs
+++ b/src/tui/views/providers/flamegraph.rs
@@ -106,8 +106,8 @@ impl ViewProvider for &'static FlamegraphViewProvider {
         self.view
     }
 
-    fn show(&self, app: &mut App, context: ContextArc) {
-        let slot = self.view.config_name();
+    fn show(&self, app: &mut App, context: ContextArc, instance: Option<&str>) {
+        let slot = instance.unwrap_or_else(|| self.view.config_name());
         if app.focus_name(slot) {
             return;
         }

--- a/src/tui/views/providers/logger_names.rs
+++ b/src/tui/views/providers/logger_names.rs
@@ -24,7 +24,7 @@ impl ViewProvider for LoggerNamesViewProvider {
         ChDigViews::Loggers
     }
 
-    fn show(&self, app: &mut App, context: ContextArc) {
+    fn show(&self, app: &mut App, context: ContextArc, _instance: Option<&str>) {
         if app.focus_name("logger_names") {
             return;
         }

--- a/src/tui/views/providers/merges.rs
+++ b/src/tui/views/providers/merges.rs
@@ -19,7 +19,7 @@ impl ViewProvider for MergesViewProvider {
         ChDigViews::Merges
     }
 
-    fn show(&self, app: &mut App, context: ContextArc) {
+    fn show(&self, app: &mut App, context: ContextArc, _instance: Option<&str>) {
         show_merges(app, context, None, None, Presentation::FullScreen);
     }
 }

--- a/src/tui/views/providers/metric_log.rs
+++ b/src/tui/views/providers/metric_log.rs
@@ -19,7 +19,7 @@ impl ViewProvider for MetricLogViewProvider {
         ChDigViews::MetricLog
     }
 
-    fn show(&self, app: &mut App, context: ContextArc) {
+    fn show(&self, app: &mut App, context: ContextArc, _instance: Option<&str>) {
         show_metric_log(app, context);
     }
 }

--- a/src/tui/views/providers/mod.rs
+++ b/src/tui/views/providers/mod.rs
@@ -31,47 +31,49 @@ use crate::tui::{App, Dialog, Nameable, NamedView, Navigation, Resizable, SizeCo
 use chrono::{DateTime, Local};
 use std::collections::HashMap;
 
-/// Registers every view provider in the views menu (F2).
-pub fn register(context: &mut crate::interpreter::Context) {
+/// Every view provider, in views-menu order.
+pub fn all() -> Vec<std::sync::Arc<dyn crate::tui::ViewProvider>> {
     use std::sync::Arc;
 
-    context.register_provider(Arc::new(queries::ProcessesViewProvider));
-    context.register_provider(Arc::new(queries::SlowQueryLogViewProvider));
-    context.register_provider(Arc::new(queries::LastQueryLogViewProvider));
-    context.register_provider(Arc::new(query_patterns::QueryPatternsViewProvider));
-    context.register_provider(Arc::new(merges::MergesViewProvider));
-    context.register_provider(Arc::new(object_storage_queue::S3QueueViewProvider));
-    context.register_provider(Arc::new(object_storage_queue::AzureQueueViewProvider));
-    context.register_provider(Arc::new(mutations::MutationsViewProvider));
-    context.register_provider(Arc::new(replicated_fetches::ReplicatedFetchesViewProvider));
-    context.register_provider(Arc::new(replication_queue::ReplicationQueueViewProvider));
-    context.register_provider(Arc::new(replicas::ReplicasViewProvider));
-    context.register_provider(Arc::new(tables::TablesViewProvider));
-    context.register_provider(Arc::new(
-        background_schedule_pool::BackgroundSchedulePoolViewProvider,
-    ));
-    context.register_provider(Arc::new(
-        background_schedule_pool_log::BackgroundSchedulePoolLogViewProvider,
-    ));
-    context.register_provider(Arc::new(table_parts::TablePartsViewProvider));
-    context.register_provider(Arc::new(
-        asynchronous_inserts::AsynchronousInsertsViewProvider,
-    ));
-    context.register_provider(Arc::new(part_log::PartLogViewProvider));
-    context.register_provider(Arc::new(metric_log::MetricLogViewProvider));
-    context.register_provider(Arc::new(
-        asynchronous_metric_log::AsynchronousMetricLogViewProvider,
-    ));
-    context.register_provider(Arc::new(backups::BackupsViewProvider));
-    context.register_provider(Arc::new(dictionaries::DictionariesViewProvider));
-    context.register_provider(Arc::new(server_logs::ServerLogsViewProvider));
-    context.register_provider(Arc::new(logger_names::LoggerNamesViewProvider));
-    context.register_provider(Arc::new(errors::ErrorsViewProvider));
-    context.register_provider(Arc::new(error_log::ErrorLogViewProvider));
+    let mut providers: Vec<Arc<dyn crate::tui::ViewProvider>> = vec![
+        Arc::new(queries::ProcessesViewProvider),
+        Arc::new(queries::SlowQueryLogViewProvider),
+        Arc::new(queries::LastQueryLogViewProvider),
+        Arc::new(query_patterns::QueryPatternsViewProvider),
+        Arc::new(merges::MergesViewProvider),
+        Arc::new(object_storage_queue::S3QueueViewProvider),
+        Arc::new(object_storage_queue::AzureQueueViewProvider),
+        Arc::new(mutations::MutationsViewProvider),
+        Arc::new(replicated_fetches::ReplicatedFetchesViewProvider),
+        Arc::new(replication_queue::ReplicationQueueViewProvider),
+        Arc::new(replicas::ReplicasViewProvider),
+        Arc::new(tables::TablesViewProvider),
+        Arc::new(background_schedule_pool::BackgroundSchedulePoolViewProvider),
+        Arc::new(background_schedule_pool_log::BackgroundSchedulePoolLogViewProvider),
+        Arc::new(table_parts::TablePartsViewProvider),
+        Arc::new(asynchronous_inserts::AsynchronousInsertsViewProvider),
+        Arc::new(part_log::PartLogViewProvider),
+        Arc::new(metric_log::MetricLogViewProvider),
+        Arc::new(asynchronous_metric_log::AsynchronousMetricLogViewProvider),
+        Arc::new(backups::BackupsViewProvider),
+        Arc::new(dictionaries::DictionariesViewProvider),
+        Arc::new(server_logs::ServerLogsViewProvider),
+        Arc::new(logger_names::LoggerNamesViewProvider),
+        Arc::new(errors::ErrorsViewProvider),
+        Arc::new(error_log::ErrorLogViewProvider),
+    ];
     for provider in flamegraph::PROVIDERS {
-        context.register_provider(Arc::new(provider));
+        providers.push(Arc::new(provider));
     }
-    context.register_provider(Arc::new(client::ClientViewProvider));
+    providers.push(Arc::new(client::ClientViewProvider));
+    providers
+}
+
+/// Registers every view provider in the views menu (F2).
+pub fn register(context: &mut crate::interpreter::Context) {
+    for provider in all() {
+        context.register_provider(provider);
+    }
 }
 
 /// How a provider table is shown: as the main (full-screen) view or as a
@@ -634,6 +636,28 @@ pub fn query_result_show_row(app: &mut App, columns: Vec<&'static str>, row: Que
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Every widget name that differs from the view's config name must be in
+    /// RESERVED_VIEW_NAMES, otherwise a view instance could take it and
+    /// receive that view's worker updates.
+    #[test]
+    fn test_reserved_view_names() {
+        use crate::interpreter::options::RESERVED_VIEW_NAMES;
+
+        for provider in all() {
+            let Some(view_name) = provider.view_name() else {
+                continue;
+            };
+            if view_name != provider.view_type().config_name() {
+                assert!(
+                    RESERVED_VIEW_NAMES.contains(&view_name),
+                    "widget name '{}' (view '{}') is missing in RESERVED_VIEW_NAMES",
+                    view_name,
+                    provider.view_type().config_name(),
+                );
+            }
+        }
+    }
 
     #[test]
     fn test_backquote_if_needed_valid_identifiers() {

--- a/src/tui/views/providers/mutations.rs
+++ b/src/tui/views/providers/mutations.rs
@@ -15,7 +15,7 @@ impl ViewProvider for MutationsViewProvider {
         ChDigViews::Mutations
     }
 
-    fn show(&self, app: &mut App, context: ContextArc) {
+    fn show(&self, app: &mut App, context: ContextArc, _instance: Option<&str>) {
         show_mutations(app, context, None, None, Presentation::FullScreen);
     }
 }

--- a/src/tui/views/providers/object_storage_queue.rs
+++ b/src/tui/views/providers/object_storage_queue.rs
@@ -46,7 +46,7 @@ impl ViewProvider for S3QueueViewProvider {
         ChDigViews::S3Queue
     }
 
-    fn show(&self, app: &mut App, context: ContextArc) {
+    fn show(&self, app: &mut App, context: ContextArc, _instance: Option<&str>) {
         show_queue(app, context, &["s3queue_metadata_cache", "s3queue"]);
     }
 }
@@ -66,7 +66,7 @@ impl ViewProvider for AzureQueueViewProvider {
         ChDigViews::AzureQueue
     }
 
-    fn show(&self, app: &mut App, context: ContextArc) {
+    fn show(&self, app: &mut App, context: ContextArc, _instance: Option<&str>) {
         show_queue(app, context, &["azure_queue_metadata_cache", "azure_queue"]);
     }
 }

--- a/src/tui/views/providers/part_log.rs
+++ b/src/tui/views/providers/part_log.rs
@@ -20,7 +20,7 @@ impl ViewProvider for PartLogViewProvider {
         ChDigViews::PartLog
     }
 
-    fn show(&self, app: &mut App, context: ContextArc) {
+    fn show(&self, app: &mut App, context: ContextArc, _instance: Option<&str>) {
         show_part_log(app, context, None, None, None, Presentation::FullScreen);
     }
 }

--- a/src/tui/views/providers/queries.rs
+++ b/src/tui/views/providers/queries.rs
@@ -21,23 +21,35 @@ impl ViewProvider for ProcessesViewProvider {
         ChDigViews::Queries
     }
 
-    fn show(&self, app: &mut App, context: ContextArc) {
-        if app.focus_name("processes") {
-            return;
-        }
-
-        app.present_view(
-            "processes",
-            QueriesView::new(
-                context.clone(),
-                ProcessesType::ProcessList,
-                "processes",
-                "Queries",
-            )
-            .with_name("processes")
-            .full_screen(),
+    fn show(&self, app: &mut App, context: ContextArc, instance: Option<&str>) {
+        show_queries_view(
+            app,
+            context,
+            ProcessesType::ProcessList,
+            instance.unwrap_or("processes"),
+            instance.unwrap_or("Queries"),
         );
     }
+}
+
+/// The instance name doubles as the pane title, to tell the panes apart.
+fn show_queries_view(
+    app: &mut App,
+    context: ContextArc,
+    processes_type: ProcessesType,
+    name: &str,
+    title: &str,
+) {
+    if app.focus_name(name) {
+        return;
+    }
+
+    app.present_view(
+        name,
+        QueriesView::new(context, processes_type, name, title)
+            .with_name(name)
+            .full_screen(),
+    );
 }
 
 pub struct SlowQueryLogViewProvider;
@@ -55,21 +67,13 @@ impl ViewProvider for SlowQueryLogViewProvider {
         ChDigViews::SlowQueries
     }
 
-    fn show(&self, app: &mut App, context: ContextArc) {
-        if app.focus_name("slow_query_log") {
-            return;
-        }
-
-        app.present_view(
-            "slow_query_log",
-            QueriesView::new(
-                context.clone(),
-                ProcessesType::SlowQueryLog,
-                "slow_query_log",
-                "Slow queries",
-            )
-            .with_name("slow_query_log")
-            .full_screen(),
+    fn show(&self, app: &mut App, context: ContextArc, instance: Option<&str>) {
+        show_queries_view(
+            app,
+            context,
+            ProcessesType::SlowQueryLog,
+            instance.unwrap_or("slow_query_log"),
+            instance.unwrap_or("Slow queries"),
         );
     }
 }
@@ -89,21 +93,13 @@ impl ViewProvider for LastQueryLogViewProvider {
         ChDigViews::LastQueries
     }
 
-    fn show(&self, app: &mut App, context: ContextArc) {
-        if app.focus_name("last_query_log") {
-            return;
-        }
-
-        app.present_view(
-            "last_query_log",
-            QueriesView::new(
-                context.clone(),
-                ProcessesType::LastQueryLog,
-                "last_query_log",
-                "Last queries",
-            )
-            .with_name("last_query_log")
-            .full_screen(),
+    fn show(&self, app: &mut App, context: ContextArc, instance: Option<&str>) {
+        show_queries_view(
+            app,
+            context,
+            ProcessesType::LastQueryLog,
+            instance.unwrap_or("last_query_log"),
+            instance.unwrap_or("Last queries"),
         );
     }
 }

--- a/src/tui/views/providers/query_patterns.rs
+++ b/src/tui/views/providers/query_patterns.rs
@@ -27,7 +27,7 @@ impl ViewProvider for QueryPatternsViewProvider {
         ChDigViews::QueryPatterns
     }
 
-    fn show(&self, app: &mut App, context: ContextArc) {
+    fn show(&self, app: &mut App, context: ContextArc, _instance: Option<&str>) {
         show_query_patterns(app, context);
     }
 }
@@ -180,7 +180,7 @@ fn open_last_queries_for_hash(app: &mut App, columns: Vec<&'static str>, row: Qu
         ctx.set_current_view(ChDigViews::LastQueries);
         ctx.view_registry.get_by_view_type(ChDigViews::LastQueries)
     };
-    provider.show(app, context.clone());
+    provider.show(app, context.clone(), None);
     context.lock().unwrap().trigger_view_refresh();
 }
 

--- a/src/tui/views/providers/replicas.rs
+++ b/src/tui/views/providers/replicas.rs
@@ -17,7 +17,7 @@ impl ViewProvider for ReplicasViewProvider {
         ChDigViews::Replicas
     }
 
-    fn show(&self, app: &mut App, context: ContextArc) {
+    fn show(&self, app: &mut App, context: ContextArc, _instance: Option<&str>) {
         if app.focus_name("replicas") {
             return;
         }

--- a/src/tui/views/providers/replicated_fetches.rs
+++ b/src/tui/views/providers/replicated_fetches.rs
@@ -15,7 +15,7 @@ impl ViewProvider for ReplicatedFetchesViewProvider {
         ChDigViews::ReplicatedFetches
     }
 
-    fn show(&self, app: &mut App, context: ContextArc) {
+    fn show(&self, app: &mut App, context: ContextArc, _instance: Option<&str>) {
         let columns = vec![
             "database",
             "table",

--- a/src/tui/views/providers/replication_queue.rs
+++ b/src/tui/views/providers/replication_queue.rs
@@ -15,7 +15,7 @@ impl ViewProvider for ReplicationQueueViewProvider {
         ChDigViews::ReplicationQueue
     }
 
-    fn show(&self, app: &mut App, context: ContextArc) {
+    fn show(&self, app: &mut App, context: ContextArc, _instance: Option<&str>) {
         let columns = vec![
             "database",
             "table",

--- a/src/tui/views/providers/server_logs.rs
+++ b/src/tui/views/providers/server_logs.rs
@@ -18,8 +18,9 @@ impl ViewProvider for ServerLogsViewProvider {
         ChDigViews::ServerLogs
     }
 
-    fn show(&self, app: &mut App, context: ContextArc) {
-        if app.focus_name("server_logs") {
+    fn show(&self, app: &mut App, context: ContextArc, instance: Option<&str>) {
+        let name = instance.unwrap_or("server_logs");
+        if app.focus_name(name) {
             return;
         }
 
@@ -27,22 +28,21 @@ impl ViewProvider for ServerLogsViewProvider {
             let ctx = context.lock().unwrap();
             (
                 ctx.selected_host.clone(),
-                ctx.view_filter_seed("server_logs"),
-                ctx.view_interval("server_logs"),
-                ctx.view_limit_override("server_logs"),
-                ctx.view_level("server_logs")
-                    .map(|level| level.as_str().to_string()),
+                ctx.view_filter_seed(name),
+                ctx.view_interval(name),
+                ctx.view_limit_override(name),
+                ctx.view_level(name).map(|level| level.as_str().to_string()),
             )
         };
 
         app.present_view(
-            "server_logs",
+            name,
             LinearLayout::vertical()
-                .child(TextView::new("Server logs:").center())
+                .child(TextView::new(format!("{}:", instance.unwrap_or("Server logs"))).center())
                 .child(DummyView.fixed_height(1))
                 .child(
                     TextLogView::new(
-                        "server_logs",
+                        name,
                         context,
                         crate::interpreter::TextLogArguments {
                             query_ids: None,
@@ -55,7 +55,7 @@ impl ViewProvider for ServerLogsViewProvider {
                             limit,
                         },
                     )
-                    .with_name("server_logs")
+                    .with_name(name)
                     .full_screen(),
                 ),
         );

--- a/src/tui/views/providers/table_parts.rs
+++ b/src/tui/views/providers/table_parts.rs
@@ -20,7 +20,7 @@ impl ViewProvider for TablePartsViewProvider {
         ChDigViews::TableParts
     }
 
-    fn show(&self, app: &mut App, context: ContextArc) {
+    fn show(&self, app: &mut App, context: ContextArc, _instance: Option<&str>) {
         show_table_parts(app, context, None, None, Presentation::FullScreen);
     }
 }

--- a/src/tui/views/providers/tables.rs
+++ b/src/tui/views/providers/tables.rs
@@ -20,7 +20,7 @@ impl ViewProvider for TablesViewProvider {
         ChDigViews::Tables
     }
 
-    fn show(&self, app: &mut App, context: ContextArc) {
+    fn show(&self, app: &mut App, context: ContextArc, _instance: Option<&str>) {
         if app.focus_name("tables") {
             return;
         }

--- a/src/tui/views/queries_view.rs
+++ b/src/tui/views/queries_view.rs
@@ -363,7 +363,7 @@ pub struct QueriesView {
     limit: Arc<Mutex<u64>>,
     // Keep clipboard alive so X11 clipboard manager can persist the data
     clipboard: Option<arboard::Clipboard>,
-    view_name: &'static str,
+    view_name: Arc<str>,
 
     #[allow(unused)]
     bg_runner: BackgroundRunner,
@@ -1191,32 +1191,34 @@ impl QueriesView {
     pub fn new(
         context: ContextArc,
         processes_type: Type,
-        view_name: &'static str,
+        view_name: &str,
         title: &str,
     ) -> OnEventView<Self> {
+        let view_name: Arc<str> = Arc::from(view_name);
+
         // Macro to simplify adding view actions
         macro_rules! add_action {
             // With shortcut and method arguments
             ($ctx:expr, $view:expr, $desc:expr, $shortcut:expr, $method:ident($($args:expr),*)) => {
-                $ctx.add_view_action($view, view_name, $desc, $shortcut, |v| {
+                $ctx.add_view_action($view, view_name.clone(), $desc, $shortcut, |v| {
                     v.downcast_mut::<QueriesView>().unwrap().$method($($args),*)
                 })
             };
             // Without shortcut but with method arguments
             ($ctx:expr, $view:expr, $desc:expr, $method:ident($($args:expr),*)) => {
-                $ctx.add_view_action_without_shortcut($view, view_name, $desc, |v| {
+                $ctx.add_view_action_without_shortcut($view, view_name.clone(), $desc, |v| {
                     v.downcast_mut::<QueriesView>().unwrap().$method($($args),*)
                 })
             };
             // With shortcut (char or Event), no arguments
             ($ctx:expr, $view:expr, $desc:expr, $shortcut:expr, $method:ident) => {
-                $ctx.add_view_action($view, view_name, $desc, $shortcut, |v| {
+                $ctx.add_view_action($view, view_name.clone(), $desc, $shortcut, |v| {
                     v.downcast_mut::<QueriesView>().unwrap().$method()
                 })
             };
             // Without shortcut, no arguments
             ($ctx:expr, $view:expr, $desc:expr, $method:ident) => {
-                $ctx.add_view_action_without_shortcut($view, view_name, $desc, |v| {
+                $ctx.add_view_action_without_shortcut($view, view_name.clone(), $desc, |v| {
                     v.downcast_mut::<QueriesView>().unwrap().$method()
                 })
             };
@@ -1225,7 +1227,7 @@ impl QueriesView {
         let delay = context.lock().unwrap().options.view.delay_interval;
 
         let is_system_processes = matches!(processes_type, Type::ProcessList);
-        let filter = context.lock().unwrap().queries_filter(view_name);
+        let filter = context.lock().unwrap().queries_filter(&view_name);
         let limit = context.lock().unwrap().queries_limit.clone();
 
         let event_owner = context.lock().unwrap().worker.event_owner();
@@ -1233,7 +1235,9 @@ impl QueriesView {
         let update_callback_filter = filter.clone();
         let update_callback_limit = limit.clone();
         let update_callback_process_type = processes_type.clone();
+        let update_callback_view_name = view_name.clone();
         let update_callback = move |force: bool| {
+            let view_name = &update_callback_view_name;
             let mut context = update_callback_context.lock().unwrap();
             let filter = update_callback_filter.lock().unwrap().clone();
             let limit = context.view_limit(view_name, *update_callback_limit.lock().unwrap());
@@ -1244,17 +1248,17 @@ impl QueriesView {
                 Type::ProcessList => context.worker.send_owned(
                     &event_owner,
                     force,
-                    WorkerEvent::ProcessList(filter, limit),
+                    WorkerEvent::ProcessList(view_name.clone(), filter, limit),
                 ),
                 Type::SlowQueryLog => context.worker.send_owned(
                     &event_owner,
                     force,
-                    WorkerEvent::SlowQueryLog(filter, start_time, end_time, limit),
+                    WorkerEvent::SlowQueryLog(view_name.clone(), filter, start_time, end_time, limit),
                 ),
                 Type::LastQueryLog => context.worker.send_owned(
                     &event_owner,
                     force,
-                    WorkerEvent::LastQueryLog(filter, start_time, end_time, limit),
+                    WorkerEvent::LastQueryLog(view_name.clone(), filter, start_time, end_time, limit),
                 ),
             }
         };
@@ -1297,6 +1301,7 @@ impl QueriesView {
                 .query_columns
                 .retain(|c| c != label);
         });
+        let submit_view_name = view_name.clone();
         table.set_on_submit(move |app, _row, _index| {
             let context = app.user_data::<ContextArc>().unwrap().clone();
             let query_actions = context
@@ -1304,11 +1309,12 @@ impl QueriesView {
                 .unwrap()
                 .view_actions
                 .iter()
-                .filter(|x| x.owner == view_name)
+                .filter(|x| x.owner == submit_view_name)
                 .map(|x| &x.description)
                 .cloned()
                 .collect();
 
+            let view_name = submit_view_name.clone();
             crate::tui::fuzzy_actions(app, query_actions, move |app, action_text| {
                 log::trace!("Triggering {:?} (from query row submit)", action_text);
 
@@ -1378,7 +1384,7 @@ impl QueriesView {
             filter,
             limit,
             clipboard: None,
-            view_name,
+            view_name: view_name.clone(),
             bg_runner,
         };
 
@@ -1411,10 +1417,13 @@ impl QueriesView {
         add_action!(context, &mut event_view, "EXPLAIN SYNTAX", 's', action_explain_syntax);
         add_action!(context, &mut event_view, "EXPLAIN PLAN", 'e', action_explain_plan);
         add_action!(context, &mut event_view, "EXPLAIN PIPELINE", 'E', action_explain_pipeline);
-        context.add_view_action(&mut event_view, view_name, "Filter", '/', move |_v| {
+        let filter_view_name = view_name.clone();
+        context.add_view_action(&mut event_view, view_name.clone(), "Filter", '/', move |_v| {
+            let view_name = filter_view_name.clone();
             return Ok(Some(EventResult::with_cb(move |app: &mut App| {
+                let view_name = view_name.clone();
                 let filter_cb = move |app: &mut App, text: &str| {
-                    app.call_on_name(view_name, |v: &mut OnEventView<QueriesView>| {
+                    app.call_on_name(&view_name, |v: &mut OnEventView<QueriesView>| {
                         let v = v.get_inner_mut();
                         log::info!("Set filter to '{}'", text);
                         *v.filter.lock().unwrap() = text.to_string();

--- a/src/tui/views/queries_view.rs
+++ b/src/tui/views/queries_view.rs
@@ -15,7 +15,7 @@ use std::sync::{Arc, Mutex};
 use crate::common::RelativeDateTime;
 use crate::interpreter::{
     BackgroundRunner, ContextArc, Query, TextLogArguments, WorkerEvent,
-    clickhouse::{Columns, TraceType},
+    clickhouse::{Columns, QueriesFilter, TraceType},
     options::ViewOptions,
 };
 use crate::tui::app::App;
@@ -1239,7 +1239,10 @@ impl QueriesView {
         let update_callback = move |force: bool| {
             let view_name = &update_callback_view_name;
             let mut context = update_callback_context.lock().unwrap();
-            let filter = update_callback_filter.lock().unwrap().clone();
+            let filter = QueriesFilter {
+                like: update_callback_filter.lock().unwrap().clone(),
+                query_kind: context.view_query_kind(view_name),
+            };
             let limit = context.view_limit(view_name, *update_callback_limit.lock().unwrap());
 
             let (start_time, end_time) = context.view_interval(view_name);

--- a/src/tui/views/settings_view.rs
+++ b/src/tui/views/settings_view.rs
@@ -284,7 +284,7 @@ fn apply_settings(app: &mut App, context: &ContextArc) {
     };
     log::info!("Reopen {:?} view after settings change", current_view);
     app.drop_main_view();
-    provider.show(app, context.clone());
+    provider.show(app, context.clone(), None);
     context.lock().unwrap().trigger_view_refresh();
 }
 

--- a/src/tui/views/text_log_view.rs
+++ b/src/tui/views/text_log_view.rs
@@ -32,7 +32,8 @@ pub struct TextLogView {
 const FLUSH_INTERVAL_MILLISECONDS: i64 = 7500;
 
 impl TextLogView {
-    pub fn new(view_name: &'static str, context: ContextArc, args: TextLogArguments) -> Self {
+    pub fn new(view_name: &str, context: ContextArc, args: TextLogArguments) -> Self {
+        let view_name: Arc<str> = Arc::from(view_name);
         let flush_interval_milliseconds =
             Duration::try_milliseconds(FLUSH_INTERVAL_MILLISECONDS).unwrap();
         let TextLogArguments {
@@ -113,7 +114,7 @@ impl TextLogView {
                     &update_callback_event_owner,
                     effective_force,
                     WorkerEvent::TextLog(
-                        view_name,
+                        view_name.clone(),
                         TextLogArguments {
                             query_ids: query_ids.clone(),
                             logger_names: logger_names.clone(),

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -320,6 +320,28 @@ impl ClickHouseServer {
         self.insert_query_log_into("system.query_log", query_id, user, duration_ms, query);
     }
 
+    pub fn insert_query_log_kind(&self, query_id: &str, query: &str, query_kind: &str) {
+        self.query(&format!(
+            r#"
+            INSERT INTO system.query_log
+                (hostname, type, event_date, event_time, event_time_microseconds,
+                 query_start_time, query_start_time_microseconds, query_duration_ms,
+                 memory_usage, current_database, query, normalized_query_hash,
+                 query_id, initial_query_id, is_initial_query, user, initial_user,
+                 peak_threads_usage, exception_code, client_name, query_kind)
+            VALUES
+                (hostName(), 'QueryFinish',
+                 toDate(now() - INTERVAL 1 MINUTE),
+                 now() - INTERVAL 1 MINUTE,
+                 now64(6) - INTERVAL 1 MINUTE,
+                 now() - INTERVAL 1 MINUTE, now64(6) - INTERVAL 1 MINUTE, 100,
+                 1048576, 'default', '{query}', normalizedQueryHash('{query}'),
+                 '{query_id}', '{query_id}', 1, 'it_user_kind', 'it_user_kind',
+                 2, 0, '', '{query_kind}')
+            "#
+        ));
+    }
+
     /// Same, but into an arbitrary query_log-structured table (e.g. a rotated query_log_0 for
     /// --history tests).
     pub fn insert_query_log_into(

--- a/tests/configs/chdig_view_instances.yaml
+++ b/tests/configs/chdig_view_instances.yaml
@@ -1,0 +1,28 @@
+---
+# Named view instances (issue #292): several panes of one view type, each
+# with its own settings.
+#
+#   chdig --chdig-config tests/configs/chdig_view_instances.yaml
+#
+# A 'views:' entry with a 'view:' field defines a named instance of that view
+# type; the key is the instance name, referenceable from the layout.
+views:
+  last_selects:
+    view: last_queries
+    query_kind: Select
+  last_inserts:
+    view: last_queries
+    query_kind: Insert
+  last_ddls:
+    view: last_queries
+    query_kind: [Create, Drop, Alter, Rename]
+
+layout:
+  direction: horizontal
+  panes:
+  - direction: vertical
+    ratio: 0.6
+    panes: [last_selects, last_inserts, last_ddls]
+  - direction: vertical
+    panes: [cpu_flamegraph, jemalloc_flamegraph]
+  focus: last_selects

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2,7 +2,8 @@ mod common;
 
 use chdig::common::RelativeDateTime;
 use chdig::interpreter::clickhouse::{
-    TraceType, column_as_string, parse_metric_log_block, parse_query_metric_log_block,
+    QueriesFilter, TraceType, column_as_string, parse_metric_log_block,
+    parse_query_metric_log_block,
 };
 use chdig::interpreter::options::ClickHouseOptions;
 use chdig::interpreter::perfetto::PerfettoTraceBuilder;
@@ -17,6 +18,13 @@ use std::collections::HashMap;
 // process-per-test runners (cargo-nextest) separate #[tokio::test]s would each bootstrap their
 // own server. Each scenario still inserts rows with its own unique prefix and filters by it,
 // since the data stays on the shared server.
+
+fn like(pattern: &str) -> QueriesFilter {
+    QueriesFilter {
+        like: pattern.to_string(),
+        ..Default::default()
+    }
+}
 
 fn window() -> (RelativeDateTime, RelativeDateTime) {
     (
@@ -81,7 +89,7 @@ async fn test_last_query_log() {
     let chdig = server.chdig().await;
     let (start, end) = window();
     let block = chdig
-        .get_last_query_log(&"it-last-%".to_string(), start, end, 100, None)
+        .get_last_query_log(&like("it-last-%"), start, end, 100, None)
         .await
         .unwrap();
 
@@ -131,7 +139,7 @@ async fn test_last_query_log_normalized_query() {
     let chdig = server.chdig().await;
     let (start, end) = window();
     let block = chdig
-        .get_last_query_log(&"it-norm-%".to_string(), start, end, 100, None)
+        .get_last_query_log(&like("it-norm-%"), start, end, 100, None)
         .await
         .unwrap();
 
@@ -145,6 +153,53 @@ async fn test_last_query_log_normalized_query() {
         normalized.contains('?') && !normalized.contains("42"),
         "literals are not normalized: {normalized}"
     );
+}
+
+async fn test_last_query_log_query_kind() {
+    let Some(server) = common::server() else {
+        return;
+    };
+    server.insert_query_log_kind("it-kind-1", "SELECT 1 FROM it_kind", "Select");
+    server.insert_query_log_kind("it-kind-2", "INSERT INTO it_kind VALUES", "Insert");
+    server.insert_query_log_kind("it-kind-3", "DROP TABLE it_kind", "Drop");
+
+    let chdig = server.chdig().await;
+    let (start, end) = window();
+
+    let kinds = |kinds: &[&str]| QueriesFilter {
+        like: "it-kind-%".to_string(),
+        query_kind: kinds.iter().map(|kind| kind.to_string()).collect(),
+    };
+
+    let block = chdig
+        .get_last_query_log(&kinds(&["Select"]), start.clone(), end.clone(), 100, None)
+        .await
+        .unwrap();
+    assert_eq!(block.row_count(), 1);
+    assert_eq!(
+        block.get::<String, _>(0, "query_id").unwrap(),
+        "it-kind-1".to_string()
+    );
+
+    // A list composes as IN
+    let block = chdig
+        .get_last_query_log(
+            &kinds(&["Insert", "Drop"]),
+            start.clone(),
+            end.clone(),
+            100,
+            None,
+        )
+        .await
+        .unwrap();
+    assert_eq!(block.row_count(), 2);
+
+    // Empty = all kinds
+    let block = chdig
+        .get_last_query_log(&kinds(&[]), start, end, 100, None)
+        .await
+        .unwrap();
+    assert_eq!(block.row_count(), 3);
 }
 
 // The "Query patterns" view builds one fat query that computes all ~30 metrics
@@ -218,7 +273,7 @@ async fn test_slow_query_log() {
     let chdig = server.chdig().await;
     let (start, end) = window();
     let block = chdig
-        .get_slow_query_log(&"it-slow-%".to_string(), start, end, 100, None)
+        .get_slow_query_log(&like("it-slow-%"), start, end, 100, None)
         .await
         .unwrap();
 
@@ -250,7 +305,7 @@ async fn test_query_log_additional_table_filters_quirk_variations() {
 
         let (start, end) = window();
         let last = chdig
-            .get_last_query_log(&"it-quirk-%".to_string(), start, end, 100, None)
+            .get_last_query_log(&like("it-quirk-%"), start, end, 100, None)
             .await
             .unwrap();
         let mut last_ids: Vec<String> = (0..last.row_count())
@@ -265,7 +320,7 @@ async fn test_query_log_additional_table_filters_quirk_variations() {
 
         let (start, end) = window();
         let slow = chdig
-            .get_slow_query_log(&"it-quirk-%".to_string(), start, end, 100, None)
+            .get_slow_query_log(&like("it-quirk-%"), start, end, 100, None)
             .await
             .unwrap();
         assert_eq!(
@@ -288,7 +343,7 @@ async fn test_query_log_out_of_window() {
     let start = RelativeDateTime::new(Some(TimeDelta::minutes(10)));
     let end = RelativeDateTime::new(Some(TimeDelta::minutes(5)));
     let block = chdig
-        .get_last_query_log(&"it-window-%".to_string(), start, end, 100, None)
+        .get_last_query_log(&like("it-window-%"), start, end, 100, None)
         .await
         .unwrap();
     assert_eq!(block.row_count(), 0);
@@ -322,7 +377,7 @@ async fn test_processlist_and_kill_query() {
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(60);
     loop {
         let block = chdig
-            .get_processlist("it-proc-%".to_string(), 100, None)
+            .get_processlist(like("it-proc-%"), 100, None)
             .await
             .unwrap();
         if block.row_count() == 1 {
@@ -343,7 +398,7 @@ async fn test_processlist_and_kill_query() {
     let status = child.wait().unwrap();
     assert!(!status.success());
     let block = chdig
-        .get_processlist("it-proc-%".to_string(), 100, None)
+        .get_processlist(like("it-proc-%"), 100, None)
         .await
         .unwrap();
     assert_eq!(block.row_count(), 0);
@@ -1319,7 +1374,7 @@ async fn test_history() {
     let chdig = server.chdig().await;
     let (start, end) = window();
     let block = chdig
-        .get_last_query_log(&"it-hist-%".to_string(), start, end, 100, None)
+        .get_last_query_log(&like("it-hist-%"), start, end, 100, None)
         .await
         .unwrap();
     assert_eq!(block.row_count(), 1);
@@ -1333,7 +1388,7 @@ async fn test_history() {
     .unwrap();
     let (start, end) = window();
     let block = chdig
-        .get_last_query_log(&"it-hist-%".to_string(), start, end, 100, None)
+        .get_last_query_log(&like("it-hist-%"), start, end, 100, None)
         .await
         .unwrap();
     let mut query_ids: Vec<String> = (0..block.row_count())
@@ -1359,7 +1414,7 @@ async fn test_cluster() {
     // Both "replicas" are the same server, so clusterAllReplicas() must return the row twice
     let (start, end) = window();
     let block = chdig
-        .get_last_query_log(&"it-clu-%".to_string(), start, end, 100, None)
+        .get_last_query_log(&like("it-clu-%"), start, end, 100, None)
         .await
         .unwrap();
     assert_eq!(block.row_count(), 2);
@@ -1402,7 +1457,7 @@ async fn test_history_with_cluster() {
     // clusterAllReplicas() over merge(): both rotated tables, each row from both "replicas"
     let (start, end) = window();
     let block = chdig
-        .get_last_query_log(&"it-histclu-%".to_string(), start, end, 100, None)
+        .get_last_query_log(&like("it-histclu-%"), start, end, 100, None)
         .await
         .unwrap();
     let mut query_ids: Vec<String> = (0..block.row_count())
@@ -1444,7 +1499,7 @@ async fn test_custom_database() {
     .unwrap();
     let (start, end) = window();
     let block = chdig
-        .get_last_query_log(&"it-db-%".to_string(), start, end, 100, None)
+        .get_last_query_log(&like("it-db-%"), start, end, 100, None)
         .await
         .unwrap();
     assert_eq!(block.row_count(), 1);
@@ -1483,7 +1538,7 @@ async fn test_database_from_url() {
     let chdig = ClickHouse::new(options.clickhouse).await.unwrap();
     let (start, end) = window();
     let block = chdig
-        .get_last_query_log(&"it-urldb-%".to_string(), start, end, 100, None)
+        .get_last_query_log(&like("it-urldb-%"), start, end, 100, None)
         .await
         .unwrap();
     assert_eq!(block.row_count(), 1);
@@ -1495,6 +1550,7 @@ common::integration_tests!(
     test_summary,
     test_last_query_log,
     test_last_query_log_normalized_query,
+    test_last_query_log_query_kind,
     test_query_patterns,
     test_slow_query_log,
     test_query_log_additional_table_filters_quirk_variations,


### PR DESCRIPTION
A `views:` entry with a `view:` field defines a named instance of a view type, referenceable from the layout — so the same view can be opened in several panes with different settings. Also adds a `query_kind` per-view setting.

```yaml
views:
  last_selects:
    view: last_queries
    query_kind: Select
  last_inserts:
    view: last_queries
    query_kind: Insert
layout:
  panes: [last_selects, last_inserts, cpu_flamegraph]
```

Fixes: #292 